### PR TITLE
Add delegates and update acronyms

### DIFF
--- a/delegates.md
+++ b/delegates.md
@@ -23,21 +23,29 @@ Please include your primary affiliation (e.g., the company you represent or wher
 ### Current
 
 - Addison Phillips - Amazon.com (APS)
+- Dan Chiba - Oracle (DCA)
 - Eemeli Aro - OpenJSF & Vincit (EAO)
 - Elango Cheran - Google (ECH)
+- George Rhoten - Apple (GWR)
+- Jan Mühlemann  - Locize (JMU)
+- Janne Tynkkynen - PayPal (JMT)
+- Jeff Genovy - Microsoft (JMG)
 - John Watson - Facebook (JRW)
 - Long Ho - Dropbox (LHO)
+- Mick Monaghan - Guidewire - (MMN)
 - Mihai Nita - Google (MIH)
 - Mike McKenna - PayPal (MGM)
+- Nick Felker - Google (NFR)
 - Nicolas Bouvrette - Expedia (NIC)
-- Rafael Xavier - PayPal (RX)
+- Pu Chen - Netflix (PUC)
+- Rafael Xavier - PayPal (RXR)
 - Richard Gibson - OpenJSF & Oracle (RGN)
 - Robert Chu - Amazon.com (RCU)
 - Romulo Cintra - CaixaBank (RCA)
 - Shane Carr - Google (SFC)
 - Staś Małolepszy - Mozilla (SMY)
 - Steven R. Loomis - IBM (SRL)
-- Zibi Braniecki - Mozilla (ZB)
+- Zibi Braniecki - Mozilla (ZBI)
 
 ### Former
 


### PR DESCRIPTION
I'm adding new delegates from yesterday's meeting.  I am also changing all delegates to have 3-letter acronyms, since we are operating separately from TC39.  This means that I added a letter to @zbraniecki and @rxaviers.  Let me know if it look OK.  (This only affects MF-WG, not ECMA-402)