### PR TITLE
Start message format test suite

### DIFF
--- a/test/format/en_US.xml
+++ b/test/format/en_US.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE formattest SYSTEM "../formattest.xsd">
+<formattest locale="en-US">
+    <test>
+        <params>
+            <param name="relationship" type="String"><value>brother</value></param>
+        </params>
+        <source>I didn't find <var name="relationship" inflect="indefinite"/> in your contacts. What is your <var name="relationship" inflect="genitive"/> name?</source>
+        <print>I didn't find a brother in your contacts. What is your brotherʼs name?</print>
+    </test>
+    <test>
+        <params>
+            <param name="relationship" type="String"><value>aunt</value></param>
+        </params>
+        <source>I didn't find <var name="relationship" inflect="indefinite"/> in your contacts. What is your <var name="relationship" inflect="genitive"/> name?</source>
+        <print>I didn't find an aunt in your contacts. What is your auntʼs name?</print>
+    </test>
+    <test>
+        <params>
+            <param name="object" type="String"><value>light</value></param>
+        </params>
+        <source>The <var name="object"/> <switch value="object" feature="number">
+            <case is="plural">are</case>
+            <default>is</default>
+        </switch> on</source>
+        <print>The light is on</print>
+    </test>
+    <test>
+        <params>
+            <param name="object" type="String"><value>lights</value></param>
+        </params>
+        <source>The <var name="object"/> <switch value="object" feature="number">
+            <case is="plural">are</case>
+            <default>is</default>
+        </switch> on</source>
+        <print>The lights are on</print>
+    </test>
+    <test>
+        <params>
+            <param name="object" type="String"><value>lights on the front porch</value></param>
+        </params>
+        <source>The <var name="object"/> <switch value="object" feature="number">
+            <case is="plural">are</case>
+            <default>is</default>
+        </switch> on</source>
+        <print>The lights on the front porch are on</print>
+    </test>
+    <test>
+        <params>
+            <param name="object" type="String"><value>light on the front porch</value></param>
+        </params>
+        <source>The <var name="object"/> <switch value="object" feature="number">
+            <case is="plural">are</case>
+            <default>is</default>
+        </switch> on</source>
+        <print>The light on the front porch is on</print>
+    </test>
+    <test>
+        <params>
+            <param name="number" type="Number"><value>1</value></param>
+            <param name="unit" type="String"><value>day</value></param>
+        </params>
+        <source>Your meeting is in <quantity value="number" unit="unit"/> from now</source>
+        <print>Your meeting is in 1 day from now</print>
+    </test>
+    <test>
+        <params>
+            <param name="number" type="Number"><value>2</value></param>
+            <param name="unit" type="String"><value>day</value></param>
+        </params>
+        <source>Your meeting is in <quantity value="number" unit="unit"/> from now</source>
+        <print>Your meeting is in 2 days from now</print>
+    </test>
+    <test>
+        <params>
+            <param name="number" type="Number"><value>3</value></param>
+            <param name="unit" type="String"><value>church</value></param>
+        </params>
+        <source><quantity value="number" unit="unit"/> were found nearby</source>
+        <print>3 churches were found nearby</print>
+    </test>
+    <test>
+        <params>
+            <param name="oridinalNum" type="Number"><value>4</value></param>
+        </params>
+        <source>Your <number name="oridinalNum" style="asWords" variant="ordinal"/> meeting has been canceled</source>
+        <print>Your fourth meeting has been canceled</print>
+    </test>
+</formattest>

--- a/test/format/es_MX.xml
+++ b/test/format/es_MX.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE formattest SYSTEM "../formattest.xsd">
+<formattest locale="es-MX">
+    <test>
+        <params>
+            <param name="words" type="String[]"><value>gato</value><value>gata</value><value>gatos</value><value>gatas</value></param>
+        </params>
+        <source>¿Te gustan los videos sobre <list name="words" type="conjunction" inflect="definite"/>?</source>
+        <print>¿Te gustan los videos sobre el gato, la gata, los gatos y las gatas?</print>
+    </test>
+    <test>
+        <params>
+            <param name="words" type="String[]"><value>gatos</value></param>
+        </params>
+        <source>¿Te gustan los videos sobre <list name="words" type="conjunction" inflect="definite"/>?</source>
+        <print>¿Te gustan los videos sobre los gatos?</print>
+    </test>
+    <test>
+        <params>
+            <param name="words" type="String[]"><value>gatos</value><value>idiomas</value></param>
+        </params>
+        <source>¿Te gustan los videos sobre <list name="words" type="conjunction"/>?</source>
+        <print>¿Te gustan los videos sobre gatos e idiomas?</print>
+    </test>
+    <test>
+        <params>
+            <param name="words" type="String[]"><value>idiomas</value><value>gatos</value></param>
+        </params>
+        <source>¿Te gustan los videos sobre <list name="words" type="conjunction"/>?</source>
+        <print>¿Te gustan los videos sobre idiomas y gatos?</print>
+    </test>
+    <test>
+        <params>
+            <param name="number" type="Number"><value>1</value></param>
+            <param name="unit" type="String"><value>niño</value></param>
+        </params>
+        <source>Hay <quantity value="number" unit="unit"/> en el video</source>
+        <print>Hay 1 niño en el video</print>
+        <speak>Hay un niño en el video</speak>
+    </test>
+    <test>
+        <params>
+            <param name="number" type="Number"><value>1</value></param>
+            <param name="unit" type="String"><value>niña</value></param>
+        </params>
+        <source>Hay <quantity value="number" unit="unit"/> en el video</source>
+        <print>Hay 1 niña en el video</print>
+        <speak>Hay una niña en el video</speak>
+    </test>
+    <test>
+        <params>
+            <param name="number" type="Number"><value>3</value></param>
+            <param name="unit" type="String"><value>niño</value></param>
+        </params>
+        <source>Hay <quantity value="number" unit="unit"/> en el video</source>
+        <print>Hay 3 niños en el video</print>
+        <speak>Hay tres niños en el video</speak>
+    </test>
+</formattest>

--- a/test/formattest.xsd
+++ b/test/formattest.xsd
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+    <xs:element name="formattest">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="test"/>
+            </xs:sequence>
+            <xs:attribute name="locale" use="required" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="test">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="params"/>
+                <xs:element ref="source"/>
+                <xs:element ref="print"/>
+                <xs:element ref="speak"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="params">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="param"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="param">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="value"/>
+            </xs:sequence>
+            <xs:attribute name="name" use="required" type="xs:NCName"/>
+            <xs:attribute name="type" use="required" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="value" type="xs:string"/>
+    <xs:complexType name="message" mixed="true">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="number"/>
+            <xs:element ref="list"/>
+            <xs:element ref="quantity"/>
+            <xs:element ref="switch"/>
+            <xs:element ref="var"/>
+        </xs:choice>
+    </xs:complexType>
+    <xs:element name="source" type="message"/>
+    <xs:element name="list">
+        <xs:complexType>
+            <xs:attribute name="inflect" type="xs:NCName"/>
+            <xs:attribute name="name" use="required" type="xs:NCName"/>
+            <xs:attribute name="type" use="required" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="number">
+        <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:NCName"/>
+            <xs:attribute name="style" use="required" type="xs:NCName"/>
+            <xs:attribute name="variant" use="required" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quantity">
+        <xs:complexType>
+            <xs:attribute name="unit" use="required" type="xs:NCName"/>
+            <xs:attribute name="value" use="required" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="switch">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="case"/>
+                <xs:element ref="default"/>
+            </xs:sequence>
+            <xs:attribute name="feature" use="required" type="xs:NCName"/>
+            <xs:attribute name="value" use="required" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="case">
+        <xs:complexType>
+            <xs:simpleContent>
+                <xs:extension base="message">
+                    <xs:attribute name="is" use="required" type="xs:NCName"/>
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="default" type="message"/>
+    <xs:element name="var">
+        <xs:complexType>
+            <xs:attribute name="inflect" type="xs:NCName"/>
+            <xs:attribute name="name" use="required" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="print" type="xs:string"/>
+    <xs:element name="speak" type="xs:string"/>
+</xs:schema>


### PR DESCRIPTION
These changes are a part of issue #109. This is just a start. I wanted to get feedback before I add more. I can confirm that my implementation passes these tests.

It's worth noting that this XML syntax could potentially be extended to include the XHTML namespace or the SSML namespace. For example, the speak namespace could be omitted from the print line, and the print namespace could be omitted from the speak line. Using XML should also lend itself well to XLIFF for translation purposes.

Some options that remain to be implemented for testing include:

- The full range of CLDR plural rules for quantity.
- The various text transformations (e.g. titlecasing and quoting).
- Semantic concepts to be retrieved from a semantic feature model.
- Dependency handling (e.g. 1 noun affecting the inflection of another noun).
- Handling other variants of numbers, like the number digits after the decimal point.