### PR TITLE
Add case selection specification

### DIFF
--- a/spec/case-selection.md
+++ b/spec/case-selection.md
@@ -1,0 +1,68 @@
+## Variant Case Selection
+
+> This is a fragment of the full MessageFormat 2 specification,
+> intended for later merge into a complete spec document.
+
+### Prerequisites
+
+The following assumptions are made about the **data model** and **function registry**,
+as prerequisites for the following algorithm:
+
+1. The data model supports a message type that allows for selecting
+   one variant **case** of a message based on the value of one or more **selectors**.
+
+2. The value of a selector may be determined by a literal value,
+   a function defined in the function registry,
+   a dynamic variable provided at runtime,
+   the formatted value of another message,
+   or some subset of these.
+   The process for determining the value of any of the above is defined elsewhere.
+
+3. For each selector, a default or **fallback** value is defined.
+   This may be a fixed value such as `"other"`,
+   or a string or integer value defined separately for each selector.
+
+4. In the data model, the selectors are defined by an ordered list.
+
+5. In the data model, the variant cases are defined by an ordered list of entries.
+   In addition to the case's actual message **value**,
+   each entry contains the **key** for the case as an ordered list of string and integer values.
+   These key values are aligned with the selectors.
+   The length of any key list is not greater than the length of the selector list.
+
+6. If the function registry contains a `plural` selector function,
+   that function may be called with one number argument,
+   and be expected to return a list of string and integer values.
+   The returned values correspond to the numerical value of the argument as well as
+   the identifier of the cardinal plural category of the argument.
+
+7. The cases are sorted, such that numerical keys are before string keys and
+   default or fallback key values are after all other key values.
+   If a fallback key has a number value, it is sorted after all non-fallback keys.
+
+### Algorithm
+
+1. The value `s` of each selector is determined:
+
+   1. The initial value `v` of the selector is resolved (see prereq. 2)
+   2. If `v` is a string value or a list of string and integer values, `s = v` is set.
+   3. Else if `v` is a number and a `plural` function is defined, `s = plural(v)` is set.
+   4. Else if `v` is a number, `s = v` is set.
+   5. Else, `v` is forcibly stringified: `s = String(v)`.
+
+   At this point, we have a list `S` of selector values,
+   each of which is a string, number, or a list of a string and integer values.
+
+2. For each case (in order), its key `K` is compared to the selector values.
+   Each string or integer `k` in `K` is compared to its corresponding selector value `s`
+   as well that selector's fallback value `d`:
+
+   1. If `s` is a string or number and `k == s`, the match succeeds.
+   2. Else if `s` if a list of string and integer values and `k` is in `s`, the match succeeds.
+   3. Else if `k == d`, the match succeds.
+   4. Else, the match fails.
+
+   If the match succeeds for all `k` in `K`,
+   the case is selected and its value is selected as the value of the whole message.
+
+3. If no case matches the selector value, an empty string is selected as the message value.


### PR DESCRIPTION
Closes #93
Closes #99
Closes #104
Closes #105
Closes #106

I'm not sure what the plan is on us actually producing spec text, so I figured I'd propose a start to it by adding the `spec/` directory as a place to collect various parts of the specification as we agree on them. As with all our other work, it should be obvious that nothing is final until everything is final, and the contents of this directory may also change as our thinking changes and we take new aspects into consideration.

This PR adds a specification for the handling of case selection. This is an essential part of our [Deliverable 4](https://github.com/unicode-org/message-format-wg/blob/master/guidelines/goals.md#deliverables), "A specification for resolving translations at runtime, including interpolated data types and runtime errors."

A TypeScript implementation of the algorithm is [provided here](https://github.com/messageformat/messageformat/blob/2c97189bf2dad54d3cc0fe0d2c13a2f418b9aaa4/packages/messageformat/src/format-message.ts#L104). Its functioning has been verified against some pretty complex [MF1 & Fluent test cases](https://github.com/messageformat/messageformat/blob/2c97189bf2dad54d3cc0fe0d2c13a2f418b9aaa4/packages/messageformat/src/mf2-features.test.ts#L197).

The relatively high number of issues closed is due to our general silence on actually discussing this topic, at least so far. Previous to this, I'm only aware of #101 as a previously proposed algorithm (which this supersedes). While issue #99 is not directly about selector logic, the proposed algorithm relies on an answer "yes" to its question of allowing function references in the data model; this is supported by both proposed data models.

### Discussion

This selector structure provides a superset of the functionality provided by the `select`, `plural`, and `selectordinal` selectors of MessageFormat 1, the Fluent selector, as well as all other selector methods currently in use.

The algorithm is highly reliant on the case order being correct (see prereq. 7). This is intentional, as it allows for the runtime logic to be relatively simple, and for case selection precedence to be easily deduced.

For a selector function such as `plural`, the order of the keys that it returns is not significant.

It is intentional that a key list may be shorter than its selector list. Such a key list may be considered to have the default value set for each of the not-defined selectors.

The only requirement this algorithm places on the function registry is that it may provide something like a "selector function" matching the above-defined signature. How the registry might be organised or structured and whether this differs somehow from a "formatter function" is explicitly left undefined here.

To use a plural category selector on a numerical value with non-default options and arguments, an explicit function reference may be used. This allows e.g. for ordinal and range plurals to be supported.

This algorithm special-cases numerical values to use a pre-defined default function. It would be possible to extend this logic to also cover e.g. number ranges and gender selectors, but those could easily be implemented using explicit selector functions.

An implementation could define a warning to be emitted if the algorithm reaches step 3. That situation should not be considered as an error, but it could (and possibly should?) be noted at least during development and linting, as it may indicate a missing variant case.

### Open Questions

This algorithm does not define what a "number" is. It should be self-evident that a primitive `number` type would match this definition, but it is conceivable to also consider an object
```ts
{ type: "number", value: number, precision: number }
```
as a "number", and treat it accordingly (with an extension of the matching logic in steps 2.1-2.3).

The benefit of this would be an ability to express a value such as `1.0` as distinct from `1`, which would allow for its correct handling for plural category selection.