### PR TITLE
(third) Implement formatToParts

### DIFF
--- a/experiments/stasm/third/README.md
+++ b/experiments/stasm/third/README.md
@@ -73,6 +73,7 @@ Run each example individually:
     npm run example phrases
     npm run example list
     npm run example number
+    npm run example opaque
 
 ## References
 

--- a/experiments/stasm/third/example/example_glossary.ts
+++ b/experiments/stasm/third/example/example_glossary.ts
@@ -1,6 +1,6 @@
 import {Argument, Message, Parameter} from "../impl/model.js";
 import {REGISTRY} from "../impl/registry.js";
-import {formatMessage, FormattingContext, StringValue} from "../impl/runtime.js";
+import {formatMessage, FormattingContext, formatToParts, StringValue} from "../impl/runtime.js";
 import {get_term} from "./glossary.js";
 
 REGISTRY["NOUN"] = function get_noun(
@@ -139,6 +139,15 @@ console.log("==== English ====");
 			item: new StringValue("t-shirt"),
 			color: new StringValue("red"),
 		})
+	);
+
+	console.log(
+		Array.of(
+			...formatToParts(message, {
+				item: new StringValue("t-shirt"),
+				color: new StringValue("red"),
+			})
+		)
 	);
 }
 

--- a/experiments/stasm/third/example/example_list.ts
+++ b/experiments/stasm/third/example/example_list.ts
@@ -22,22 +22,20 @@ class Person {
 
 // TODO(stasm): This is generic enough that it could be in impl/runtime.ts.
 class ListValue<T> extends RuntimeValue<Array<T>> {
-	private opts: Record<string, string>; // ListFormatOptions
+	private opts: Intl.ListFormatOptions;
 
-	constructor(value: Array<T>, opts: Record<string, string> = {}) {
+	constructor(value: Array<T>, opts: Intl.ListFormatOptions = {}) {
 		super(value);
 		this.opts = opts;
 	}
 
 	formatToString(ctx: FormattingContext): string {
 		// TODO(stasm): Cache ListFormat.
-		// @ts-ignore
 		let lf = new Intl.ListFormat(ctx.locale, this.opts);
 		return lf.format(this.value);
 	}
 
 	*formatToParts(ctx: FormattingContext): IterableIterator<FormattedPart> {
-		// @ts-ignore
 		let lf = new Intl.ListFormat(ctx.locale, this.opts);
 		yield* lf.formatToParts(this.value);
 	}

--- a/experiments/stasm/third/example/example_list.ts
+++ b/experiments/stasm/third/example/example_list.ts
@@ -2,6 +2,7 @@ import {Argument, Message, Parameter} from "../impl/model.js";
 import {REGISTRY} from "../impl/registry.js";
 import {
 	formatMessage,
+	FormattedPart,
 	FormattingContext,
 	PluralValue,
 	RuntimeValue,
@@ -20,7 +21,12 @@ class Person {
 
 class PeopleValue extends RuntimeValue<Array<Person>> {
 	format(ctx: FormattingContext): string {
-		throw new RangeError("Must be formatted via PEOPLE_LIST.");
+		// TODO(stasm): Implement this.
+		throw new Error("Not implemented yet.");
+	}
+	*formatToParts(ctx: FormattingContext): IterableIterator<FormattedPart> {
+		// TODO(stasm): Implement this.
+		throw new Error("Not implemented yet.");
 	}
 }
 

--- a/experiments/stasm/third/example/example_list.ts
+++ b/experiments/stasm/third/example/example_list.ts
@@ -29,7 +29,7 @@ class ListValue<T> extends RuntimeValue<Array<T>> {
 		this.opts = opts;
 	}
 
-	format(ctx: FormattingContext): string {
+	formatToString(ctx: FormattingContext): string {
 		// TODO(stasm): Cache ListFormat.
 		// @ts-ignore
 		let lf = new Intl.ListFormat(ctx.locale, this.opts);

--- a/experiments/stasm/third/example/example_list.ts
+++ b/experiments/stasm/third/example/example_list.ts
@@ -20,7 +20,7 @@ class Person {
 	}
 }
 
-// TODO(stasm): Move this to impl/runtime.ts?
+// TODO(stasm): This is generic enough that it could be in impl/runtime.ts.
 class ListValue<T> extends RuntimeValue<Array<T>> {
 	private opts: Record<string, string>; // ListFormatOptions
 

--- a/experiments/stasm/third/example/example_number.ts
+++ b/experiments/stasm/third/example/example_number.ts
@@ -1,5 +1,5 @@
 import {Message} from "../impl/model.js";
-import {formatMessage, NumberValue} from "../impl/runtime.js";
+import {formatMessage, formatToParts, NumberValue} from "../impl/runtime.js";
 
 console.log("==== English ====");
 
@@ -77,5 +77,12 @@ console.log("==== French ====");
 		formatMessage(message, {
 			payloadSize: new NumberValue(1.23),
 		})
+	);
+	console.log(
+		Array.of(
+			...formatToParts(message, {
+				payloadSize: new NumberValue(1.23),
+			})
+		)
 	);
 }

--- a/experiments/stasm/third/example/example_opaque.ts
+++ b/experiments/stasm/third/example/example_opaque.ts
@@ -1,0 +1,53 @@
+import {Message} from "../impl/model.js";
+import {FormattingContext, formatToParts, OpaquePart, RuntimeValue} from "../impl/runtime.js";
+
+// We want to pass it into the translation and get it back out unformatted, in
+// the correct position in the sentence, via formatToParts.
+class SomeUnstringifiableClass {}
+
+// TODO(stasm): This is generic enough that it could be in impl/runtime.ts.
+class WrappedValue extends RuntimeValue<SomeUnstringifiableClass> {
+	formatToString(ctx: FormattingContext): string {
+		throw new Error("Method not implemented.");
+	}
+	*formatToParts(ctx: FormattingContext): IterableIterator<OpaquePart> {
+		yield {type: "opaque", value: this.value};
+	}
+}
+
+console.log("==== English ====");
+
+{
+	// "Ready? Then {$submitButton}!"
+	let message: Message = {
+		lang: "en",
+		id: "submit",
+		phrases: {},
+		selectors: [
+			{
+				expr: null,
+				default: {type: "StringLiteral", value: "default"},
+			},
+		],
+		variants: [
+			{
+				keys: [{type: "StringLiteral", value: "default"}],
+				value: [
+					{type: "StringLiteral", value: "Ready? Then  "},
+					{
+						type: "VariableReference",
+						name: "submitButton",
+					},
+					{type: "StringLiteral", value: "!"},
+				],
+			},
+		],
+	};
+	console.log(
+		Array.of(
+			...formatToParts(message, {
+				submitButton: new WrappedValue(new SomeUnstringifiableClass()),
+			})
+		)
+	);
+}

--- a/experiments/stasm/third/example/example_phrases.ts
+++ b/experiments/stasm/third/example/example_phrases.ts
@@ -1,5 +1,5 @@
 import {Message} from "../impl/model.js";
-import {formatMessage, NumberValue, StringValue} from "../impl/runtime.js";
+import {formatMessage, formatToParts, NumberValue, StringValue} from "../impl/runtime.js";
 
 console.log("==== English ====");
 
@@ -89,6 +89,16 @@ console.log("==== English ====");
 			userGender: new StringValue("feminine"),
 			photoCount: new NumberValue(34),
 		})
+	);
+
+	console.log(
+		Array.of(
+			...formatToParts(message, {
+				userName: new StringValue("Mary"),
+				userGender: new StringValue("feminine"),
+				photoCount: new NumberValue(34),
+			})
+		)
 	);
 }
 

--- a/experiments/stasm/third/impl/intl.d.ts
+++ b/experiments/stasm/third/impl/intl.d.ts
@@ -1,0 +1,25 @@
+declare namespace Intl {
+	interface ListFormatOptions {
+		// I added `string` to avoid having to validate the exact values of options.
+		localeMatcher?: string | "best fit" | "lookup";
+		type?: string | "conjunction" | "disjunction | unit";
+		style?: string | "long" | "short" | "narrow";
+	}
+
+	type ListFormatPartTypes = "literal" | "element";
+
+	interface ListFormatPart {
+		type: ListFormatPartTypes;
+		value: string;
+	}
+
+	interface ListFormat {
+		format(value?: Array<unknown>): string;
+		formatToParts(value?: Array<unknown>): ListFormatPart[];
+	}
+
+	var ListFormat: {
+		new (locales?: string | string[], options?: ListFormatOptions): ListFormat;
+		(locales?: string | string[], options?: ListFormatOptions): ListFormat;
+	};
+}

--- a/experiments/stasm/third/impl/registry.ts
+++ b/experiments/stasm/third/impl/registry.ts
@@ -1,5 +1,12 @@
 import {Argument, Parameter} from "./model.js";
-import {FormattingContext, NumberValue, PluralValue, RuntimeValue, StringValue} from "./runtime.js";
+import {
+	FormattingContext,
+	NumberValue,
+	PatternValue,
+	PluralValue,
+	RuntimeValue,
+	StringValue,
+} from "./runtime.js";
 
 export type RegistryFunc<T> = (
 	ctx: FormattingContext,
@@ -31,7 +38,7 @@ function get_phrase(
 	ctx: FormattingContext,
 	args: Array<Argument>,
 	opts: Record<string, Parameter>
-): StringValue {
+): PatternValue {
 	let phrase_name = ctx.toRuntimeValue(args[0]);
 	if (!(phrase_name instanceof StringValue)) {
 		throw new TypeError();
@@ -39,7 +46,7 @@ function get_phrase(
 
 	let phrase = ctx.message.phrases[phrase_name.value];
 	let variant = ctx.selectVariant(phrase.variants, phrase.selectors);
-	return new StringValue(ctx.formatPattern(variant.value));
+	return new PatternValue(variant.value);
 }
 
 function format_number(

--- a/experiments/stasm/third/impl/runtime.ts
+++ b/experiments/stasm/third/impl/runtime.ts
@@ -24,12 +24,12 @@ export abstract class RuntimeValue<T> {
 		this.value = value;
 	}
 
-	abstract format(ctx: FormattingContext): string;
+	abstract formatToString(ctx: FormattingContext): string;
 	abstract formatToParts(ctx: FormattingContext): IterableIterator<FormattedPart | OpaquePart>;
 }
 
 export class StringValue extends RuntimeValue<string> {
-	format(ctx: FormattingContext): string {
+	formatToString(ctx: FormattingContext): string {
 		return this.value;
 	}
 
@@ -46,7 +46,7 @@ export class NumberValue extends RuntimeValue<number> {
 		this.opts = opts;
 	}
 
-	format(ctx: FormattingContext): string {
+	formatToString(ctx: FormattingContext): string {
 		// TODO(stasm): Cache NumberFormat.
 		return new Intl.NumberFormat(ctx.locale, this.opts).format(this.value);
 	}
@@ -64,7 +64,7 @@ export class PluralValue extends RuntimeValue<number> {
 		this.opts = opts;
 	}
 
-	format(ctx: FormattingContext): string {
+	formatToString(ctx: FormattingContext): string {
 		// TODO(stasm): Cache PluralRules.
 		let pr = new Intl.PluralRules(ctx.locale, this.opts);
 		return pr.select(this.value);
@@ -76,7 +76,7 @@ export class PluralValue extends RuntimeValue<number> {
 }
 
 export class BooleanValue extends RuntimeValue<boolean> {
-	format(ctx: FormattingContext): string {
+	formatToString(ctx: FormattingContext): string {
 		throw new TypeError("BooleanValue is not formattable.");
 	}
 
@@ -86,7 +86,7 @@ export class BooleanValue extends RuntimeValue<boolean> {
 }
 
 export class PatternValue extends RuntimeValue<Array<PatternElement>> {
-	format(ctx: FormattingContext): string {
+	formatToString(ctx: FormattingContext): string {
 		return ctx.formatPattern(this.value);
 	}
 
@@ -115,7 +115,7 @@ export class FormattingContext {
 	formatPattern(pattern: Array<PatternElement>): string {
 		let output = "";
 		for (let value of this.resolvePattern(pattern)) {
-			output += value.format(this);
+			output += value.formatToString(this);
 		}
 		return output;
 	}
@@ -173,7 +173,7 @@ export class FormattingContext {
 					let value = this.vars[selector.expr.name];
 					resolved_selectors.push({
 						value: value.value,
-						string: value.format(this),
+						string: value.formatToString(this),
 						default: selector.default.value,
 					});
 					break;
@@ -183,7 +183,7 @@ export class FormattingContext {
 					let value = callable(this, selector.expr.args, selector.expr.opts);
 					resolved_selectors.push({
 						value: value.value,
-						string: value.format(this),
+						string: value.formatToString(this),
 						default: selector.default.value,
 					});
 					break;

--- a/experiments/stasm/third/package.json
+++ b/experiments/stasm/third/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "example": "tsc && node example/index.js",
-    "start": "tsc && (node example/index.js glossary; node example/index.js list; node example/index.js phrases; node example/index.js number)",
+    "start": "tsc && (node example/index.js glossary; node example/index.js list; node example/index.js phrases; node example/index.js number; node example/index.js opaque)",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Staś Małolepszy <stas@duzodobrze.pl>",


### PR DESCRIPTION
This is a prototype implementation of the `formatToParts` iterator discussed in #41. The approach taken is the one from https://github.com/unicode-org/message-format-wg/issues/41#issuecomment-900198029 by @eemeli with one modification:

- the iterator yields a flat sequence of _parts_,
- a _part_ can either be a  `FormattedPart {type: string, value: string}` or an `OpaquePart`,
- `FormattedPart` doesn't have the `source` field carrying the original raw value; it was easier to do it that way but also it's consistent with existing `formatToParts` specifications,
- patterns coming from message references are flattened into the final sequence.

Examples:

```
let payloadSize = 1.23;
"Transferred {NUMBER $payloadSize STYLE unit UNIT megabyte}."

{ type: 'literal', value: 'Transferred ' },
{ type: 'integer', value: '1' },
{ type: 'decimal', value: '.' },
{ type: 'fraction', value: '23' },
{ type: 'literal', value: ' ' },
{ type: 'unit', value: 'MB' },
{ type: 'literal', value: '.' }
```

```
let submitButton = new SomeUnstringifiableClass();
"Ready? Then {$submitButton}!"

{ type: 'literal', value: 'Ready? Then  ' },
{ type: 'opaque', value: SomeUnstringifiableClass {} },
{ type: 'literal', value: '!' }
```
