### PR TITLE
Add specification text outline

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,227 @@
+# PROPOSED DRAFT: The MessageFormat 2.0 Specification
+
+## META
+
+This document is the incomplete working draft of the MF2 specification.
+It _will_ experience breaking changes,
+and should not be depended on by anyone for anything.
+For now, there isn't even an expectation for various parts of the spec
+to be in agreement with each other.
+
+To **add** content to or **change** a section of this document
+or to **reorganise** sections,
+please file a PR to this repo's `master` branch.
+Each PR should only either add or change one section
+(i.e. content directly under a `#` header or under a single `##` section title),
+or reorganise sections.
+Once a valid PR has been open for at least **two weeks**
+it may be merged if:
+
+- It is approved by:
+  - **one active member** of the WG,
+    if the PR adds a new section or reorganises sections
+  - **three active members** of the WG,
+    if the PR changes the contents of a section.
+- No active members of the WG have reviewed it with "Request changes",
+  or the specific concerns presented in their review have been addressed.
+  Such a block on progress should only apply to the explicit minimal scope of the PR,
+  so wanting it to be expanded should not prevent the smaller PR to be merged first.
+- If an active member of the WG has requested additional time to review the PR,
+  the PR has been open for **four weeks**,
+  or said member has concluded their review.
+- No other similarly approved PR exists with contents for the same section.
+  If the PRs cannot be combined or have all but one withdrawn,
+  the choice will be discussed at the next plenary meeting of the WG.
+  If the plenary meeting does not conclude with a decision:
+  - For PRs adding new sections or reorganising sections,
+    a **simple coin toss** or some other fair random selection method
+    will decide which PR gets initially merged at the end of the meeting.
+  - For PRs changing the contents of an existing section,
+    discussion will **continue offline** and at subsequent plenary meetings.
+
+Contents of this working draft of the spec should be written in
+[GitHub-flavoured markdown](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax),
+with [semantic line breaks](https://sembr.org/)
+separating sentences and other substantial units of thought.
+Trailing whitespace should be trimmed,
+and exactly one empty line should separate content blocks.
+Typo fixes and other non-normative editorial corrections
+may be merged with no regard for the minimum open time or other requirements,
+as long as they have at least one approval and no change requests from active WG members.
+Sections containing a single indented sentence _in italics_ should be considered empty,
+as that is intended as an template for the section's contents.
+
+This initial META section will not be a part of the final specification,
+but the same above-defined rules apply to changing its contents.
+The intent is to publish the specification first as a Draft Unicode Technical Standard (D-UTS)
+and eventually have it accepted as a Unicode Technical Standard (UTS).
+
+---
+
+# Introduction
+
+> _Why this thing exists, what it's trying to be, and what it's not._
+
+## Terminology
+
+## Goals
+
+## Non-goals
+
+# Conformance
+
+> _How we define compliance with the spec._
+
+# Message Resources
+
+> _The structures that hold messages within them._
+
+## Data Model
+
+> _The data-only representation of a message resource._
+
+## Message Resolution
+
+> _The runtime interface for getting a message or other data from a message resource._
+
+### getId()
+
+### getMessage()
+
+## Mapping Other Message Structures to MessageFormat Resources
+
+> _How messages stored in various formats can or may be represented in MF2._
+
+# Messages
+
+## Data Model
+
+> _The data-only representation of a message._
+
+## Select Case Resolution
+
+> _How a single pattern is selected from a SelectMessage at runtime._
+
+# Pattern Elements
+
+> _The types of pieces that can make up a message._
+
+## Pattern Formatter Interface
+
+> _The runtime interface required of all pattern element formatters._
+
+### initContext()
+
+### getValue()
+
+### formatToString()
+
+### formatToParts()
+
+## Literal
+
+> _Values that are defined directly in the message data._
+
+### Data Model
+
+## Variable
+
+> _Values that are provided as runtime arguments or parameters to the formatter._
+
+### Data Model
+
+### Runtime Scope
+
+> _How the formatting arguments/parameters are accessed._
+
+## Function
+
+> _Values defined by a user-definable function call._
+
+### Data Model
+
+### Function Call Signature
+
+> _The arguments and return type for user-definable functions._
+
+### Function Options
+
+> _How to define the options that a function provides._
+
+### Default Function Registry
+
+> _The functions that are always available._
+
+#### number()
+
+#### datetime()
+
+## Term
+
+> _Include one message within another message._
+
+### Data Model
+
+### Message Access
+
+## Supporting Custom Pattern Elements
+
+> _How to extend the spec when you need to._
+
+## Fallback Behaviour for Unknown Pattern Elements
+
+> _What to do on encountering a pattern element of an unsupported type._
+
+# Formatting Messages
+
+> _How the runtime actually runs._
+
+## Formattables
+
+> _Representations of runtime values with associated options, metadata and formatters._
+
+### getValue()
+
+### matchSelectKey()
+
+### toString()
+
+### toParts()
+
+### FormattableNumber
+
+### FormattableDateTime
+
+## formatToString()
+
+> _Turning a message into a string._
+
+## formatToParts()
+
+> _Turning a message into a sequence of parts._
+
+## Error Handling
+
+> _How to always provide some output, and loudly complain only in dev mode._
+
+# Syntax
+
+> _How MF2 messages look like to programmers, and sometimes translators._
+
+## Message Contents
+
+> _The representation of a message's contents, embeddable in various file formats._
+
+## Message Resources
+
+> _The canonical file format for MF2._
+
+# XLIFF 2 Interoperability
+
+> _How MF2 messages and resources map to XLIFF._
+
+## The XLIFF 2 MessageFormat Module
+
+## MessageFormat to XLIFF
+
+## XLIFF to MessageFormat


### PR DESCRIPTION
As a follow-on to discussion #191, this PR adds a bare-bones outline for us to start filling out with the MessageFormat 2.0 specification text.

The document includes an initial "Meta" section that specifies how additions and changes to the document may be proposed and accepted, along with a conflict resolution process. As it makes clear at its start:
> This document is the incomplete working draft of the MF2 specification. It _will_ experience breaking changes, and should not be depended on by anyone for anything. For now, there isn't even an expectation for various parts of the spec to be in agreement with each other.

The process by which the document may develop is intended to itself develop as we advance with this work. Its initial parameters are entirely adjustable or even replaceable if we so desire. The explicit intent of these rules is to enable a system with the following properties:
- The current state of the text is not required or expected to represent the consensus view of the full working group.
- Additions and changes may be made asynchronously of the plenary meetings.
- Individual changes are limited in scope.
- It's easier to have a more limited change land first, and expand it later.
- Adding content to new sections is relatively easy, and cannot be indefinitely blocked.
- Changing existing sections requires a bit more effort, but is still pretty painless.
- No-one is rushed to review changes, and may ask for additional time.
- Blocking progress requires explicit expression of what the concerns are.
- For contentious topics, proposing an alternative is the most effective way of raising the issue for discussion in the plenary meetings.

As an exercise in dogfooding, I'd like to recommend that we apply the proposed "change" rules to this PR, and require three approvals, all specific change requests addressed, and no other current spec framework proposals before landing this.

To submit your review, switch to the "Files changed" tab of this PR, where there's a "Review changes" button in the top right corner. Under that tab you may also comment on individual lines of the PR and even suggest specific changes to them (the ± button in the comment toolbar). Note that you may do so even if you're not a "member" of this repo, but do consider yourself a member of the working group.

As we're looking to eventually publish the spec as a UTS under the CLDR-TC, it makes sense to have it in this repo and format it using markdown, as that should allow us to eventually use the same tooling as is used for UTS#35.