### PR TITLE
Add Resource data model

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -91,7 +91,6 @@ but may be constructed from any source.
 It is not necessary for an implementation to use Resources to hold messages.
 
 ```ts
-// Abstract data types
 interface Resource {
   id: string
   locale: string
@@ -99,19 +98,6 @@ interface Resource {
 }
 
 interface MessageGroup {
-  entries: Record<string, Message | MessageGroup>
-}
-
-// Canonical JSON representations
-interface Resource {
-  type: 'resource'
-  id: string
-  locale: string
-  entries: Record<string, Message | MessageGroup>
-}
-
-interface MessageGroup {
-  type: 'group'
   entries: Record<string, Message | MessageGroup>
 }
 ```

--- a/spec.md
+++ b/spec.md
@@ -78,16 +78,16 @@ and eventually have it accepted as a Unicode Technical Standard (UTS).
 
 ## Data Model
 
-As practically speaking all MessageFormat use cases make use of more than one related message,
-It is beneficial to be able to group and organise them in the data model.
+As practically all MessageFormat use cases will make use of more than one related message,
+it is beneficial to be able to group and organise related messages in the data model.
 
 A Resource provides an externally addressable set of messages,
 which all share a single _locale_ identifier.
 Within a Resource, the structure of Messages may be completely flat,
-or use MessageGroups to provide a hierarchy of messages.
+or MessageGroups may be used to provide a hierarchy of messages.
 
 A Resource is often the data model representation of a single file,
-but may be constructed from any source.
+but may be constructed from any number and type of sources.
 It is not necessary for an implementation to use Resources to hold messages.
 
 ```ts

--- a/spec.md
+++ b/spec.md
@@ -78,7 +78,43 @@ and eventually have it accepted as a Unicode Technical Standard (UTS).
 
 ## Data Model
 
-> _The data-only representation of a message resource._
+As practically speaking all MessageFormat use cases make use of more than one related message,
+It is beneficial to be able to group and organise them in the data model.
+
+A Resource provides an externally addressable set of messages,
+which all share a single _locale_ identifier.
+Within a Resource, the structure of Messages may be completely flat,
+or use MessageGroups to provide a hierarchy of messages.
+
+A Resource is often the data model representation of a single file,
+but may be constructed from any source.
+It is not necessary for an implementation to use Resources to hold messages.
+
+```ts
+// Abstract data types
+interface Resource {
+  id: string
+  locale: string
+  entries: Record<string, Message | MessageGroup>
+}
+
+interface MessageGroup {
+  entries: Record<string, Message | MessageGroup>
+}
+
+// Canonical JSON representations
+interface Resource {
+  type: 'resource'
+  id: string
+  locale: string
+  entries: Record<string, Message | MessageGroup>
+}
+
+interface MessageGroup {
+  type: 'group'
+  entries: Record<string, Message | MessageGroup>
+}
+```
 
 ## Message Resolution
 


### PR DESCRIPTION
This PR adds the data model for message resources and groups, i.e. groupings and hierarchical structures of messages. It refers to the `Message` data type, which is defined in #195.

As requested by @mihnita in the message data model PR, the interfaces' abstract data types are defined separately from their canonical JSON representations, and the metadata is left out. It is my belief that later work with the specification will indicate that it's simpler to merge these definitions, without creating a cost for implementations that choose to use a different internal representation than the canonical JSON.

I am aware of PR #203, and would be happy to work on a design document for this as well as other PRs, once it's defined what that ought to look like and if such a document is desired for this PR.

In my own code, these interfaces are [defined here](https://github.com/messageformat/messageformat/blob/a880c3d2/packages/messageformat/src/data-model.ts#L5-L23). The generic type parameter is used by the PatternMessage and SelectMessage interfaces to narrow down the pattern element types appropriately. In actual formatting use, these types are used by [ResourceReader](https://github.com/messageformat/messageformat/blob/a880c3d2/packages/messageformat/src/resource-reader.ts), which provides a more limited interface; this allows for e.g. non-enumerable message resources to be accessed. The ResourceReader API is in turn used by the [`getMessage()` method](https://github.com/messageformat/messageformat/blob/a880c3d2/packages/messageformat/src/messageformat.ts#L89-L98) of MessageFormat.

In addition to formatting, Resource is also used by [@messageformat/compiler](https://github.com/messageformat/messageformat/tree/mf2/packages/compiler) when converting MF1 and Fluent messages to MF2, and by [@messageformat/xliff](https://github.com/messageformat/messageformat/tree/mf2/packages/xliff) during conversion to and from XLIFF 2.