### PR TITLE
Add self-closing MarkupEmpty element

### DIFF
--- a/spec/message.ebnf
+++ b/spec/message.ebnf
@@ -10,7 +10,7 @@ VariantKey ::= String | Nmtoken
 Pattern ::= '[' (Text | Placeable)* ']' /* ws: explicit */
 
 /* Placeables */
-Placeable ::= '{' (Expression | MarkupStart | MarkupEnd)? '}'
+Placeable ::= '{' (Expression | MarkupStart | MarkupEnd | MarkupEmpty)? '}'
 
 /* Expressions */
 Expression ::= Operand Annotation? | Annotation
@@ -21,6 +21,7 @@ Option ::= Name '=' (String | Nmtoken | Variable)
 /* Markup Tags */
 MarkupStart ::= Name Option*
 MarkupEnd ::= '/' Name
+MarkupEmpty ::= Name Option* '/'
 
 <?TOKENS?>
 

--- a/spec/message.ebnf
+++ b/spec/message.ebnf
@@ -10,7 +10,7 @@ VariantKey ::= String | Nmtoken
 Pattern ::= '[' (Text | Placeable)* ']' /* ws: explicit */
 
 /* Placeables */
-Placeable ::= '{' (Expression | MarkupStart | MarkupEnd | MarkupEmpty)? '}'
+Placeable ::= '{' (Expression | Markup | MarkupEnd)? '}'
 
 /* Expressions */
 Expression ::= Operand Annotation? | Annotation
@@ -19,9 +19,8 @@ Annotation ::= ':' Name Option*
 Option ::= Name '=' (String | Nmtoken | Variable)
 
 /* Markup Tags */
-MarkupStart ::= Name Option*
+Markup ::= Name Option* '/'?
 MarkupEnd ::= '/' Name
-MarkupEmpty ::= Name Option* '/'
 
 <?TOKENS?>
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -319,7 +319,7 @@ Examples:
 A placeable is a placeholder for an expression or a markup element.
 
 ```ebnf
-Placeable ::= '{' (Expression | MarkupStart | MarkupEnd | MarkupEmpty) '}'
+Placeable ::= '{' (Expression | Markup | MarkupEnd) '}'
 ```
 
 ### Expressions
@@ -370,16 +370,15 @@ $when: datetime month=2-digit
 ### Markup
 
 Markup elements provide a structured way to mark up parts of the content.
-There are three kinds of elements, each with its own syntax:
-start (opening) elements,
-end (closing) elements,
-and empty (self-closing) elements.
+There are two kinds of elements, each with its own syntax:
+Markup (opening) elements and MarkupEnd (closing) elements.
+If a Markup element includes a trailing `/`,
+it is considered to be empty, i.e. self-closing.
 They mimic XML elements, but do not require well-formedness.
 
 ```ebnf
-MarkupStart ::= Name Option*
+Markup ::= Name Option* '/'?
 MarkupEnd ::= '/' Name
-MarkupEmpty ::= Name Option* '/'
 ```
 
 Examples:

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -371,9 +371,10 @@ $when: datetime month=2-digit
 
 Markup elements provide a structured way to mark up parts of the content.
 There are two kinds of elements, each with its own syntax:
-Markup (opening) elements and MarkupEnd (closing) elements.
+Markup (opening or empty) elements and MarkupEnd (closing) elements.
 If a Markup element includes a trailing `/`,
 it is considered to be empty, i.e. self-closing.
+Otherwise, it's an opening element.
 They mimic XML elements, but do not require well-formedness.
 
 ```ebnf

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -316,10 +316,10 @@ Examples:
 
 ### Placeables
 
-A placeable is a placeholder for an expression or an open or close markup element.
+A placeable is a placeholder for an expression or a markup element.
 
 ```ebnf
-Placeable ::= '{' (Expression | MarkupStart | MarkupEnd) '}'
+Placeable ::= '{' (Expression | MarkupStart | MarkupEnd | MarkupEmpty) '}'
 ```
 
 ### Expressions
@@ -370,14 +370,16 @@ $when: datetime month=2-digit
 ### Markup
 
 Markup elements provide a structured way to mark up parts of the content.
-There are two kinds of elements: start (opening) elements and end (closing) elements,
-each with its own syntax.
+There are three kinds of elements, each with its own syntax:
+start (opening) elements,
+end (closing) elements,
+and empty (self-closing) elements.
 They mimic XML elements, but do not require well-formedness.
-Standalone display elements should be represented as function expressions.
 
 ```ebnf
 MarkupStart ::= Name Option*
 MarkupEnd ::= '/' Name
+MarkupEmpty ::= Name Option* '/'
 ```
 
 Examples:
@@ -388,6 +390,10 @@ Examples:
 
 ```
 [{h1 name="above-and-beyond"}Above And Beyond{/h1}]
+```
+
+```
+[{img src="image.png" title="An image" /}]
 ```
 
 ## Tokens


### PR DESCRIPTION
As discussed during this Monday's meeting, this PR adds the empty/standalone/self-closing `MarkupEmpty` element to the proposed spec, to represent elements that do not contain any body. This closes #238.