### PR TITLE
Add examples for multiline/complex resources for other languages

### DIFF
--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -156,6 +156,23 @@ A message with a single selector:
         1 [You have one notification.]
         * [You have {$count} notifications.]
 
+The same message defined in a `.properties` file:
+
+```properties
+app.greetings.notification = {$count: number}\
+    1 [You have one notification.]\
+    _ [You have {$count} notifications.]
+```
+
+The same message defined inline in JavaScript:
+
+```js
+let notification = new MessageFormat(`{$count: number}
+    1 [You have one notification.]
+    _ [You have {$count} notifications.]`)
+notification.format({ count: 3 })
+```
+
 A message with a single selector which is an invocation of
 a custom function `platform`, formatted on a single line:
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -161,7 +161,7 @@ The same message defined in a `.properties` file:
 ```properties
 app.greetings.notification = {$count: number}\
     1 [You have one notification.]\
-    _ [You have {$count} notifications.]
+    * [You have {$count} notifications.]
 ```
 
 The same message defined inline in JavaScript:
@@ -169,7 +169,7 @@ The same message defined inline in JavaScript:
 ```js
 let notification = new MessageFormat(`{$count: number}
     1 [You have one notification.]
-    _ [You have {$count} notifications.]`)
+    * [You have {$count} notifications.]`)
 notification.format({ count: 3 })
 ```
 


### PR DESCRIPTION
It's not clear how multi line/complex examples will look like in `.properties` & `.js` files.