### PR TITLE
Prohibit surrogate code units

### DIFF
--- a/spec/message.ebnf
+++ b/spec/message.ebnf
@@ -26,7 +26,7 @@ Markup ::= MarkupStart Option*
 /* Text */
 Text ::= (TextChar | TextEscape)+
 TextChar ::= AnyChar - ('{' | '}' | Esc)
-AnyChar ::= [#x0-#x10FFFF]
+AnyChar ::= [#x0-#x10FFFF] - [#xD800-#xDBFF]
 
 /* Names */
 Variable ::= '$' Name /* ws: explicit */

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -387,7 +387,7 @@ and `\` (which starts an escape sequence).
 ```ebnf
 Text ::= (TextChar | TextEscape)+ /* ws: explicit */
 TextChar ::= AnyChar - ('{' | '}' | Esc)
-AnyChar ::= [#x0-#x10FFFF]
+AnyChar ::= [#x0-#x10FFFF] - [#xD800-#xDBFF]
 ```
 
 ### Names
@@ -424,13 +424,13 @@ NameChar ::= NameStart | [0-9] | "-" | "." | #xB7
 ### Literal
 
 Any Unicode code point is allowed in literals,
-with the exception of its delimiters `(` and `)`,
-and `\` (which starts an escape sequence).
+with the exception of `(` and `)` (which delimit literals),
+`\` (which starts an escape sequence), and
+surrogate code points U+D800 through U+DBFF (which cannot be encoded into UTF-8).
 
 This includes line-breaking characters (such as U+000A LINE FEED and U+000D CARRIAGE RETURN),
 other control characters (such as U+0000 NULL and U+0009 TAB),
 permanently reserved noncharacters (U+FDD0 through U+FDEF and U+<i>n</i>FFFE and U+<i>n</i>FFFF where <i>n</i> is 0x0 through 0x10),
-surrogate code points (U+D800 through U+DBFF),
 private-use code points (U+E000 through U+F8FF, U+F0000 through U+FFFFD, and U+100000 through U+10FFFD),
 and unassigned code points.
 


### PR DESCRIPTION
Surrogate code units (U+D800 through U+DBFF) cannot be encoded into UTF-8.
Ref #268

This covers the most important part of #268, which is UTF-8 compatibility. I would also like to prohibit permanently reserved-for-Unicode-internal-use noncharacters (U+FDD0 through U+FDEF and U+<i>n</i>FFFE and U+<i>n</i>FFFF where <i>n</i> is 0x0 through 0x10, two of which are also invalid XML characters) and control characters (U+0000 through U+001F and U+007F through U+009F, the first 32 of which are not valid unescaped inside a JSON string or [with specific exceptions allowing tab, line feed, and carriage return] in XML), although those can be addressed in a followup (and any of them that should be allowed in string _contents_ will need a corresponding escape sequence, similar to how `\\` represents a single `\`).