### PR TITLE
Link to draft syntax from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Welcome to the home page for the MessageFormat Working Group, a subgroup of the [Unicode CLDR-TC](https://unicode.org/cldr).
 
+See the current [Draft MessageFormat 2.0 Syntax](https://github.com/unicode-org/message-format-wg/blob/develop/spec/syntax.md).
+
 ## Charter
 
 The Message Format Working Group (MFWG) is tasked with developing an industry standard for the representation of localizable message strings to be a successor to ICU MessageFormat. MFWG will recommend how to remove redundancies, make the syntax more usable, and support more complex features, such as gender, inflections, and speech. MFWG will also consider the integration of the new standard with programming environments, including, but not limited to, ICU, DOM, and ECMAScript, and with localization platform interchange. The output of MFWG will be a specification for the new syntax, which is expected to be on track to become a Unicode Technical Standard.


### PR DESCRIPTION
It was confusing to me, when I tried to read about MessageFormat, what the current state of progress was. This PR links to that from the README.