### PR TITLE
Add WIP draft document defining formatting behaviour

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -1,0 +1,9 @@
+# WIP DRAFT MessageFormat 2.0 Formatting Behaviour
+
+## Introduction
+
+This document defines the behaviour of a MessageFormat 2.0 implementation
+when formatting a message for display in a user interface, or for some later processing.
+
+The document is part of the MessageFormat 2.0 specification,
+the successor to ICU MessageFormat, henceforth called ICU MessageFormat 1.0.


### PR DESCRIPTION
As we're discussing the MF2 formatting behaviour, it'd be good if we could start codifying it as well.

This PR adds an essentially empty document `spec/formatting.md` that's marked as a "WIP DRAFT" for this purpose.

Later PRs may then add sections to this that'll let us close issues on which we've reached agreement.