### PR TITLE
Add Feedback discussion category link to issue template selector

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Feedback
+    url: https://github.com/unicode-org/message-format-wg/discussions/categories/feedback
+    about: Comments, criticisms and other user feedback for the MF2 tech preview

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Feedback
     url: https://github.com/unicode-org/message-format-wg/discussions/categories/feedback
-    about: Comments, criticisms and other user feedback for the MF2 tech preview
+    about: Comments, suggestions and other user feedback for the MessageFormat 2.0 Technical Preview

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Feedback
     url: https://github.com/unicode-org/message-format-wg/discussions/categories/feedback
-    about: Comments, suggestions and other user feedback for the MessageFormat 2.0 Technical Preview
+    about: Comments, suggestions and other user feedback for the MessageFormat 2 Technical Preview


### PR DESCRIPTION
As discussed during today's call, I've added a "Feedback" category to the discussions here: https://github.com/unicode-org/message-format-wg/discussions/categories/feedback

This PR adds a link to that URL to this repo's "New issue" page as a third button: https://github.com/unicode-org/message-format-wg/issues/new/choose