### PR TITLE
Add Pattern Selection

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -27,10 +27,9 @@ the Pattern of one of Variants must be selected for formatting.
 An implementation may use any pattern selection method,
 as long as its observable behaviour matches the results of the method defined here.
 
-### Setup
+### Resolve Selectors
 
-To select a Pattern,
-first the resolved values _res_ of the Selector must be determined:
+First, resolve the values of each Selector Expression:
 
 1. Let _res_ be a new empty list of resolved values that support selection.
 2. For each Expression _exp_ of the message's Selector Expressions,
@@ -38,9 +37,9 @@ first the resolved values _res_ of the Selector must be determined:
    2. If selection is supported for _rv_:
       1. Append _rv_ as the last element of the list _res_.
    3. Else:
-      1. Emit a Selection Error.
-      2. Let _nomatch_ be a resolved value for which selection always fails.
-      3. Append _nomatch_ as the last element of the list _res_.
+      1. Let _nomatch_ be a resolved value for which selection always fails.
+      2. Append _nomatch_ as the last element of the list _res_.
+      3. Emit a Selection Error.
 
 The shape of the resolved values must be determined by each implementation,
 along with the manner of determining their support for selection.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -44,7 +44,7 @@ First, resolve the values of each Selector Expression:
 The shape of the resolved values must be determined by each implementation,
 along with the manner of determining their support for selection.
 
-### Variant Tests
+### Select Pattern
 
 Using _res_,
 the Variants are iterated in source order and the following test is performed


### PR DESCRIPTION
This is an attempt to explicitly document how case/variant selection happens with messages that have a `when` Selector statement. The method presented here should match the current implementations ([ICU4J](https://github.com/unicode-org/icu/blob/0b3b83a80966f638fae1704a6a6042596af2a757/icu4j/main/classes/core/src/com/ibm/icu/message2/Mf2DataModelFormatter.java#L139), [Intl.MessageFormat polyfill](https://github.com/messageformat/messageformat/blob/1233b9b3c37b97f6e492d9f1556b92b87dae6174/packages/mf2-messageformat/src/message-value/resolved-message.ts#L8)) in general shape, though some specifics such as error handling may be slightly different.

The overall intent is to minimally but sufficiently define selection, such that two implementations that use similar custom selector functions will make the same selection, when given the same input message and formatting context. In a number of places details are left for each implementation to fill in for themselves, as each may have a different internal representations of resolved and unresolved values and may perform value matching in different ways.

By necessity, the method definition needs to use more formal language than what we have so far in the spec. For that, I've borrowed some of the conventions of the TC39 spec and hope that it's sufficiently readable as is, without us needing separate definitions of e.g. what a "list" is.

An earlier [draft](https://github.com/eemeli/message-format-wg/commit/b6db226) of this PR was reviewed by @stasm.

- Closes #93
- Closes #104
- Closes #105
- Closes #106
- Closes #208
- See also #101
- See also #170