### PR TITLE
Actually omit surrogate code points

### DIFF
--- a/spec/message.ebnf
+++ b/spec/message.ebnf
@@ -26,7 +26,7 @@ Markup ::= MarkupStart Option*
 /* Text */
 Text ::= (TextChar | TextEscape)+
 TextChar ::= AnyChar - ('{' | '}' | Esc)
-AnyChar ::= [#x0-#x10FFFF] - [#xD800-#xDBFF]
+AnyChar ::= [#x0-#x10FFFF] - [#xD800-#xDFFF]
 
 /* Names */
 Variable ::= '$' Name /* ws: explicit */


### PR DESCRIPTION
DBFF is only the high surrogates...

I probably would have done this rule differently, but I noticed the typo just now and can fast-fix it.