### PR TITLE
Forbid empty placeholders in the syntax

### DIFF
--- a/spec/message.ebnf
+++ b/spec/message.ebnf
@@ -10,7 +10,7 @@ VariantKey ::= Literal | Nmtoken | '*'
 Pattern ::= '{' (Text | Placeholder)* '}' /* ws: explicit */
 
 /* Placeholders */
-Placeholder ::= '{' (Expression | Markup | MarkupEnd)? '}'
+Placeholder ::= '{' (Expression | Markup | MarkupEnd) '}'
 
 /* Expressions */
 Expression ::= Operand Annotation? | Annotation


### PR DESCRIPTION
* There isn't an evident use-case for empty placeholders at this time.
* Empty placeholders are invalid in ICU MF1.
* Forbidding them will make it a bit easier to specify the precise rules of whitespace.
* The EBNF snippet in `syntax.md` actually requires them. I don't know at which point `syntax.md` and `message.ebnf` diverged.

_Fixes #345._