### PR TITLE
Update examples to indent 'when' lines by one space

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Messages can interpolate arguments formatted using _formatting functions_:
 Messages can define variants which correspond to the grammatical (or other) requirements of the language:
 
     match {$count :number}
-    when 1 {You have one notification.}
-    when * {You have {$count} notifications.}
+     when 1 {You have one notification.}
+     when * {You have {$count} notifications.}
     
 The message syntax is also capable of expressing more complex translation, for example:
 
@@ -36,20 +36,20 @@ The message syntax is also capable of expressing more complex translation, for e
     
     match {$host :gender} {$guestOther :number}
 
-    when female 0 {{$hostName} does not give a party.}
-    when female 1 {{$hostName} invites {$guestName} to her party.}
-    when female 2 {{$hostName} invites {$guestName} and one other person to her party.}
-    when female * {{$hostName} invites {$guestName} and {$guestsOther} other people to her party.}
+     when female 0 {{$hostName} does not give a party.}
+     when female 1 {{$hostName} invites {$guestName} to her party.}
+     when female 2 {{$hostName} invites {$guestName} and one other person to her party.}
+     when female * {{$hostName} invites {$guestName} and {$guestsOther} other people to her party.}
 
-    when male 0 {{$hostName} does not give a party.}
-    when male 1 {{$hostName} invites {$guestName} to his party.}
-    when male 2 {{$hostName} invites {$guestName} and one other person to his party.}
-    when male * {{$hostName} invites {$guestName} and {$guestsOther} other people to his party.}
+     when male 0 {{$hostName} does not give a party.}
+     when male 1 {{$hostName} invites {$guestName} to his party.}
+     when male 2 {{$hostName} invites {$guestName} and one other person to his party.}
+     when male * {{$hostName} invites {$guestName} and {$guestsOther} other people to his party.}
 
-    when * 0 {{$hostName} does not give a party.}
-    when * 1 {{$hostName} invites {$guestName} to their party.}
-    when * 2 {{$hostName} invites {$guestName} and one other person to their party.}
-    when * * {{$hostName} invites {$guestName} and {$guestsOther} other people to their party.}
+     when * 0 {{$hostName} does not give a party.}
+     when * 1 {{$hostName} invites {$guestName} to their party.}
+     when * 2 {{$hostName} invites {$guestName} and one other person to their party.}
+     when * * {{$hostName} invites {$guestName} and {$guestsOther} other people to their party.}
 
 See more examples and the formal definition of the grammar in [spec/syntax.md](./spec/syntax.md).
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -162,8 +162,8 @@ in a *message* based on the values of *variables* or *expressions*.
 A message with a single selector:
 
     match {$count :number}
-    when 1 {You have one notification.}
-    when * {You have {$count} notifications.}
+     when 1 {You have one notification.}
+     when * {You have {$count} notifications.}
 
 A message with a single selector which is an invocation of
 a custom function `:platform`, formatted on a single line:
@@ -174,19 +174,19 @@ A message with a single selector and a custom `:hasCase` function
 which allows the message to query for presence of grammatical cases required for each variant:
 
     match {$userName :hasCase}
-    when vocative {Hello, {$userName :person case=vocative}!}
-    when accusative {Please welcome {$userName :person case=accusative}!}
-    when * {Hello!}
+     when vocative {Hello, {$userName :person case=vocative}!}
+     when accusative {Please welcome {$userName :person case=accusative}!}
+     when * {Hello!}
 
 A message with 2 selectors:
 
     match {$photoCount :number} {$userGender :equals}
-    when 1 masculine {{$userName} added a new photo to his album.}
-    when 1 feminine {{$userName} added a new photo to her album.}
-    when 1 * {{$userName} added a new photo to their album.}
-    when * masculine {{$userName} added {$photoCount} photos to his album.}
-    when * feminine {{$userName} added {$photoCount} photos to her album.}
-    when * * {{$userName} added {$photoCount} photos to their album.}
+     when 1 masculine {{$userName} added a new photo to his album.}
+     when 1 feminine {{$userName} added a new photo to her album.}
+     when 1 * {{$userName} added a new photo to their album.}
+     when * masculine {{$userName} added {$photoCount} photos to his album.}
+     when * feminine {{$userName} added {$photoCount} photos to her album.}
+     when * * {{$userName} added {$photoCount} photos to their album.}
 
 ### Local Variables
 
@@ -205,8 +205,8 @@ A message defining two local variables:
     let $countInt = {$count :number maximumFractionDigits=0}
     let $itemAcc = {$item :noun count=$count case=accusative}
     match {$countInt}
-    when one {You bought {$color :adjective article=indefinite accord=$itemAcc} {$itemAcc}.}
-    when * {You bought {$countInt} {$color :adjective accord=$itemAcc} {$itemAcc}.}
+     when one {You bought {$color :adjective article=indefinite accord=$itemAcc} {$itemAcc}.}
+     when * {You bought {$countInt} {$color :adjective accord=$itemAcc} {$itemAcc}.}
 
 ### Complex Messages
 
@@ -221,20 +221,20 @@ A complex message with 2 selectors and 3 local variable definitions:
 
     match {$host :gender} {$guestOther :number}
 
-    when female 0 {{$hostName} does not give a party.}
-    when female 1 {{$hostName} invites {$guestName} to her party.}
-    when female 2 {{$hostName} invites {$guestName} and one other person to her party.}
-    when female * {{$hostName} invites {$guestName} and {$guestsOther} other people to her party.}
+     when female 0 {{$hostName} does not give a party.}
+     when female 1 {{$hostName} invites {$guestName} to her party.}
+     when female 2 {{$hostName} invites {$guestName} and one other person to her party.}
+     when female * {{$hostName} invites {$guestName} and {$guestsOther} other people to her party.}
 
-    when male 0 {{$hostName} does not give a party.}
-    when male 1 {{$hostName} invites {$guestName} to his party.}
-    when male 2 {{$hostName} invites {$guestName} and one other person to his party.}
-    when male * {{$hostName} invites {$guestName} and {$guestsOther} other people to his party.}
+     when male 0 {{$hostName} does not give a party.}
+     when male 1 {{$hostName} invites {$guestName} to his party.}
+     when male 2 {{$hostName} invites {$guestName} and one other person to his party.}
+     when male * {{$hostName} invites {$guestName} and {$guestsOther} other people to his party.}
 
-    when * 0 {{$hostName} does not give a party.}
-    when * 1 {{$hostName} invites {$guestName} to their party.}
-    when * 2 {{$hostName} invites {$guestName} and one other person to their party.}
-    when * * {{$hostName} invites {$guestName} and {$guestsOther} other people to their party.}
+     when * 0 {{$hostName} does not give a party.}
+     when * 1 {{$hostName} invites {$guestName} to their party.}
+     when * 2 {{$hostName} invites {$guestName} and one other person to their party.}
+     when * * {{$hostName} invites {$guestName} and {$guestsOther} other people to their party.}
 
 ## Productions
 
@@ -281,15 +281,15 @@ Examples:
 
 ```
 match {$count :plural}
-when 1 {One apple}
-when * {{$count} apples}
+ when 1 {One apple}
+ when * {{$count} apples}
 ```
 
 ```
 let $frac = {$count: number minFractionDigits=2}
 match {$frac}
-when 1 {One apple}
-when * {{$frac} apples}
+ when 1 {One apple}
+ when * {{$frac} apples}
 ```
 
 ### Variants


### PR DESCRIPTION
I'd like to suggest that, when formatting messages over multiple lines, the _recommended_ formatting for `when` clauses be (a) each one on its own line, and (b) indented by one space. This hopefully can help discern the "logic" parts of complex messages (`let`, `match`) from the "content" parts (`when`).

    let $count = {$count :number fractionDigits=0}
    match {$count :plural}
     when 1 {You have one notification.}
     when * {You have {$count} notifications.}

I'm opening a PR to demonstrate what it would look like. This would be a recommendation, not a mandate. No changes to the grammar are required.