### PR TITLE
Replace `nmtoken` with `unquoted`

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -363,7 +363,7 @@ These are divided into the following categories:
     uses a `:plural` selector function which requires its input to be numeric:
 
     ```
-    match {horse :plural}
+    match {|horse| :plural}
     when 1 {The value is one.}
     when * {The value is not one.}
     ```

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -445,7 +445,7 @@ and ends with U+007D RIGHT CURLY BRACKET `}`.
 Between the brackets, the following contents are used:
 
 - Expression with Literal Operand: U+007C VERTICAL LINE `|`
-  followed by the Quoted or Unquoted value,
+  followed by the value of the Literal,
   and then by U+007C VERTICAL LINE `|`
 
   Examples: `{|your horse|}`, `{|42|}`

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -345,7 +345,7 @@ These are divided into the following categories:
     does not provide for the function `:func` to be successfully resolved:
 
     ```
-    {The value is {|horse| :func}.}
+    {The value is {horse :func}.}
     ```
 
     ```
@@ -363,7 +363,7 @@ These are divided into the following categories:
     uses a `:plural` selector function which requires its input to be numeric:
 
     ```
-    match {|horse| :plural}
+    match {horse :plural}
     when 1 {The value is one.}
     when * {The value is not one.}
     ```
@@ -390,7 +390,7 @@ These are divided into the following categories:
      an option `field` to be provided with a string value,
 
   ```
-  {Hello, {|horse| :get field=name}!}
+  {Hello, {horse :get field=name}!}
   ```
 
   ```
@@ -445,10 +445,10 @@ and ends with U+007D RIGHT CURLY BRACKET `}`.
 Between the brackets, the following contents are used:
 
 - Expression with Literal Operand: U+007C VERTICAL LINE `|`
-  followed by the value of the Literal,
+  followed by the Quoted or Unquoted value,
   and then by U+007C VERTICAL LINE `|`
 
-  Examples: `{|horse|}`, `{|42|}`
+  Examples: `{|your horse|}`, `{|42|}`
 
 - Expression with Variable Operand: U+0024 DOLLAR SIGN `$`
   followed by the Variable Name of the Operand

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -35,8 +35,9 @@ quoted-char = %x0-5B         ; omit \
             / %x7D-D7FF      ; omit surrogates
             / %xE000-10FFFF
 
-unquoted = unquoted-start *name-char ; based on https://www.w3.org/TR/xml/#NT-Nmtoken,
-                                     ; but cannot start with U+002D HYPHEN-MINUS or U+003A COLON ":"
+; based on https://www.w3.org/TR/xml/#NT-Nmtoken,
+; but cannot start with U+002D HYPHEN-MINUS or U+003A COLON ":"
+unquoted = unquoted-start *name-char
 unquoted-start = name-start / DIGIT / "."
                / %xB7 / %x300-36F / %x203F-2040
 
@@ -52,8 +53,9 @@ reserved-char  = %x00-08        ; omit HTAB and LF
                / %x7E-D7FF      ; omit surrogates
                / %xE000-10FFFF
 
-name = name-start *name-char ; based on https://www.w3.org/TR/xml/#NT-Name,
-                             ; but cannot start with U+003A COLON ":"
+; based on https://www.w3.org/TR/xml/#NT-Name,
+; but cannot start with U+003A COLON ":"
+name = name-start *name-char
 name-start = ALPHA / "_"
            / %xC0-D6 / %xD8-F6 / %xF8-2FF
            / %x370-37D / %x37F-1FFF / %x200C-200D

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -7,12 +7,15 @@ body = pattern
 pattern = "{" *(text / expression) "}"
 selectors = match 1*([s] expression)
 variant = when 1*(s key) [s] pattern
-key = nmtoken / literal / "*"
+key = literal / "*"
 
 expression = "{" [s] (((literal / variable) [s annotation]) / annotation) [s] "}"
 annotation = (function *(s option)) / reserved
 
-option = name [s] "=" [s] (literal / nmtoken / variable)
+literal = quoted / unquoted
+variable = "$" name
+function = (":" / "+" / "-") name
+option = name [s] "=" [s] (literal / variable)
 
 ; reserved keywords are always lowercase
 let   = %x6C.65.74        ; "let"
@@ -26,14 +29,16 @@ text-char = %x0-5B         ; omit \
           / %x7E-D7FF      ; omit surrogates
           / %xE000-10FFFF
 
-literal      = "|" *(literal-char / literal-escape) "|"
-literal-char = %x0-5B         ; omit \
-             / %x5D-7B        ; omit |
-             / %x7D-D7FF      ; omit surrogates
-             / %xE000-10FFFF
+quoted      = "|" *(quoted-char / quoted-escape) "|"
+quoted-char = %x0-5B         ; omit \
+            / %x5D-7B        ; omit |
+            / %x7D-D7FF      ; omit surrogates
+            / %xE000-10FFFF
 
-variable = "$" name
-function = (":" / "+" / "-") name
+unquoted = unquoted-start *name-char ; based on https://www.w3.org/TR/xml/#NT-Nmtoken,
+                                     ; but cannot start with U+002D HYPHEN-MINUS or U+003A COLON ":"
+unquoted-start = name-start / DIGIT / "."
+               / %xB7 / %x300-36F / %x203F-2040
 
 ; reserve additional sigils for future use
 reserved       = reserved-start reserved-body
@@ -47,18 +52,18 @@ reserved-char  = %x00-08        ; omit HTAB and LF
                / %x7E-D7FF      ; omit surrogates
                / %xE000-10FFFF
 
-name    = name-start *name-char ; based on https://www.w3.org/TR/xml/#NT-Name, but cannot start with U+003A COLON ":"
-nmtoken = 1*name-char           ; equal to https://www.w3.org/TR/xml/#NT-Nmtoken
+name = name-start *name-char ; based on https://www.w3.org/TR/xml/#NT-Name,
+                             ; but cannot start with U+003A COLON ":"
 name-start = ALPHA / "_"
            / %xC0-D6 / %xD8-F6 / %xF8-2FF
            / %x370-37D / %x37F-1FFF / %x200C-200D
            / %x2070-218F / %x2C00-2FEF / %x3001-D7FF
            / %xF900-FDCF / %xFDF0-FFFD / %x10000-EFFFF
-name-char = name-start / DIGIT / "-" / "." / ":"
-          / %xB7 / %x0300-036F / %x203F-2040
+name-char  = name-start / DIGIT / "-" / "." / ":"
+           / %xB7 / %x300-36F / %x203F-2040
 
 text-escape     = backslash ( backslash / "{" / "}" )
-literal-escape  = backslash ( backslash / "|" )
+quoted-escape   = backslash ( backslash / "|" )
 reserved-escape = backslash ( backslash / "{" / "|" / "}" )
 backslash       = %x5C ; U+005C REVERSE SOLIDUS "\"
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -478,7 +478,8 @@ The _name_ token is used for variable names (prefixed with `$`),
 function names (prefixed with `:`, `+` or `-`),
 as well as option names.
 It is based on XML's [Name](https://www.w3.org/TR/xml/#NT-Name),
-with the restriction that it MUST NOT start with an ASCII digit and certain basic combining characters.
+with the restriction that it MUST NOT start with `:`,
+as that would conflict with _function_ start characters.
 Otherwise, the set of characters allowed in names is large.
 
 ```abnf


### PR DESCRIPTION
Currently, a valid `nmtoken` like `42` or `foo` can be used directly as an option value `key=42 bar=foo`, but needs to be quoted when used as an argument: `{|42| :number|`, `{|foo|}`. This is a bit of a wtf, and there should be no need for this difference.

This is a relic from when the syntax considered a placeholder with just an `nmtoken` to be a markup-start, but this was changed in #283. This PR allows for all `nmtoken` excpet for ones starting with a `-` to be used as an expression argument.