### PR TITLE
Draft of the registry specification

### DIFF
--- a/spec/registry.dtd
+++ b/spec/registry.dtd
@@ -1,0 +1,33 @@
+<!ELEMENT registry (function*|pattern*)>
+
+<!ELEMENT function (description|signature+)>
+<!ATTLIST function name NMTOKEN #REQUIRED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT pattern EMPTY>
+<!ATTLIST pattern id ID #REQUIRED>
+<!ATTLIST pattern regex CDATA #REQUIRED>
+
+<!ELEMENT signature (input*|param*|match*)>
+<!ATTLIST signature type (match|format) #REQUIRED>
+<!ATTLIST signature position (open|close|standalone) "standalone">
+<!ATTLIST signature locales NMTOKENS #IMPLIED>
+
+<!ELEMENT input EMPTY>
+<!ATTLIST input title CDATA #IMPLIED>
+<!ATTLIST input values NMTOKENS #IMPLIED>
+<!ATTLIST input pattern NMTOKEN #IMPLIED>
+
+<!ELEMENT param EMPTY>
+<!ATTLIST param title CDATA #IMPLIED>
+<!ATTLIST param name NMTOKEN #REQUIRED>
+<!ATTLIST param values NMTOKENS #IMPLIED>
+<!ATTLIST param default NMTOKEN #IMPLIED>
+<!ATTLIST param pattern IDREF #IMPLIED>
+<!ATTLIST param required (true|false) "false">
+<!ATTLIST param readonly (true|false) "false">
+
+<!ELEMENT match EMPTY>
+<!ATTLIST match values NMTOKENS #IMPLIED>
+<!ATTLIST match pattern NMTOKEN #IMPLIED>

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -1,0 +1,162 @@
+# WIP DRAFT MessageFormat 2.0 Registry
+
+_This document is non-normative._
+
+The implementations and tooling can greatly benefit from a structured definition of formatting and matching functions available to messages at runtime.
+The _registry_ is a mechanism for storing such declarations in a portable manner.
+
+## Goals
+
+The goal of the registry is to provide a machine-readable description of MessageFormat extensions (custom functions) in order to:
+
+* support the localization roundtrip,
+* validate message correctness, and
+* improve the authoring experience.
+
+## Use Cases
+
+The registry enables the following usage scenarios:
+
+* Generate variant keys for a given locale during XLIFF extraction.
+* Verify the exhaustiveness of variant keys given a selector.
+* Type-check values passed into functions.
+* Validate that matching functions are only called in selectors.
+* Validate that formatting functions are only called in placeholders.
+* Forbid edits to certain function options (e.g. currency options).
+* Autocomplete function and option names.
+* Display on-hover tooltips for function signatures with documentation.
+* Display/edit known message metadata.
+* Restrict input in GUI by providing a dropdown with all viable option values.
+
+## Data Model
+
+The registry contains descriptions of function signatures.
+[`registry.dtd`](./registry.dtd) describes its data model.
+
+The main building block of the registry is the `<function>` element.
+It represents an implementation of a custom function available to translation at runtime.
+A function defines a human-readable _description_ of its behavior
+and one or more machine-readable _signatures_ of how to call it.
+Named `<pattern>` elements can optionally define regex validation rules for input, optional values, and variant keys.
+
+The `<signature>` element defines one particular signature of the custom function,
+i.e. the set of arguments and named options that can be used together in a single call to the function.
+The `type` attribute specifies the calling context of the signature.
+A `type="format"` function can only be called inside a placeholder inside translatable text.
+A `type="match"` function can only be called inside a selector.
+Signatures with a non-empty `locales` attribute are locale-specific and only available in translations in the given languages.
+
+A signature may define the type of input it accepts with zero or more `<input>` elments.
+In MessageFormat 2.0 functions can only ever accept at most one positional argument.
+Multiple `<input>` elements can be used to define different validation rules for this single argument input,
+together with appropriate human-readable descriptions.
+
+A signature may also define one or more `<param>` elements representing _named options_ to the function.
+Parameters are optional by default,
+unless the `required` attribute is present.
+They accept either a finite enumeration of values (the `values` attribute)
+or validate they input with a regular expression (the `pattern` attribute).
+Read-only parameters (the `readonly` attribute) can be displayed to translators in CAT tools, but may not be edited.
+
+Matching-function signatures additionally include one or more `<match>` elements
+to define the keys against which they can match when used as selectors.
+
+## Example
+
+The following `registry.xml` is an example of a registry file
+which may be provided by an implementation to describe its built-in functions.
+For the sake of brevity, only `locales="en"` is considered.
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE registry SYSTEM "./registry.dtd">
+
+<registry>
+    <function name="platform">
+        <description>Match the current OS.</description>
+        <signature type="match">
+            <match values="windows linux macos android ios"/>
+        </signature>
+    </function>
+
+    <pattern id="anyNumber" regex="-?[0-9]+(\.[0-9]+)"/>
+    <pattern id="positiveInteger" regex="[0-9]+"/>
+    <pattern id="currencyCode" regex="[A-Z]{3}"/>
+
+    <function name="number">
+        <description>
+            Format a number.
+            Match a numerical value against CLDR plural categories or against a number literal.
+        </description>
+
+        <signature type="match" locales="en">
+            <input pattern="anyNumber"/>
+            <param name="type" values="cardinal ordinal"/>
+            <param name="minimumIntegerDigits" pattern="positiveInteger"/>
+            <param name="minimumFractionDigits" pattern="positiveInteger"/>
+            <param name="maximumFractionDigits" pattern="positiveInteger"/>
+            <param name="minimumSignificantDigits" pattern="positiveInteger"/>
+            <param name="maximumSignificantDigits" pattern="positiveInteger"/>
+            <match values="one other"/>
+            <match pattern="anyNumber"/>
+        </signature>
+
+        <signature type="format" locales="en">
+            <input pattern="anyNumber"/>
+            <param name="minimumIntegerDigits" pattern="positiveInteger"/>
+            <param name="minimumFractionDigits" pattern="positiveInteger"/>
+            <param name="maximumFractionDigits" pattern="positiveInteger"/>
+            <param name="minimumSignificantDigits" pattern="positiveInteger"/>
+            <param name="maximumSignificantDigits" pattern="positiveInteger"/>
+            <param name="style" readonly="true" values="decimal currency percent unit" default="decimal"/>
+            <param name="currency" readonly="true" pattern="currencyCode"/>
+        </signature>
+    </function>
+</registry>
+```
+
+A localization engineer can then extend the registry by defining the following `customRegistry.xml` file.
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE registry SYSTEM "./registry.dtd">
+
+<registry>
+    <function name="noun">
+        <description>Handle the grammar of a noun.</description>
+        <signature type="format" locales="en">
+            <input title="Noun id"/>
+            <param name="article" values="definite indefinite"/>
+            <param name="plural" values="one other"/>
+            <param name="case" values="nominative genitive" default="nominative"/>
+        </signature>
+    </function>
+
+    <function name="adjective">
+        <description>Handle the grammar of an adjective.</description>
+        <signature type="format" locales="en">
+            <input title="Adjective id"/>
+            <param name="article" values="definite indefinite"/>
+            <param name="plural" values="one other"/>
+            <param name="case" values="nominative genitive" default="nominative"/>
+        </signature>
+        <signature type="format" locales="en">
+            <input title="Adjective id"/>
+            <param name="article" values="definite indefinite"/>
+            <param name="accord"/>
+        </signature>
+    </function>
+</registry>
+```
+
+Messages can now use the `:noun` and the `:adjective` functions.
+The following message references the first signature of `:adjective`,
+which expects the `plural` and `case` options:
+
+    {You see {$color adjective article=indefinite plural=one case=nominative} {$object :noun case=nominative}!}
+
+The following message references the second signature of `:adjective`,
+which only expects the `accord` option:
+
+    let $obj = {$object :noun case=nominative}
+    {You see {$color adjective article=indefinite accord=$obj} {$obj}!}


### PR DESCRIPTION
This PR includes 2 files:

* `registry.dtd` is the schema for defining regestries in XML; it is normative.
* `registry.md` is the non-normative documentation explaining the motivation and the schema. It also includes examples.

This PR is based on my [old spec proposal from January 2022](https://github.com/unicode-org/message-format-wg/discussions/218), and the more recent [presentation](https://github.com/unicode-org/message-format-wg/blob/main/meetings/2023/notes-2023-02-06.md) that I did to resume the work on the design of the registry.

For now, I've focused on describing custom functions by defining their signatures. A single signature corresponds to one set of: the current locale, the argument, and the options bag.

I didn't address all feedback from our February 6 meeting in this PR. Looking at my notes, here are the topics for future discussions:

* [ ] Not all options should be locale-specific.
* [ ] Some options should be common to all signatures of a given function.
* Support other data types besides functions:
  * [ ] markup,
  * [ ] metadata (comments, max length, screenshot URL, etc.),
  * [ ] global variables.
* [ ] Describe the interface of runtime arguments and local variables (i.e. the return types of formatting functions). Right now the validation of arguments and option values only applies to literal values.