### PR TITLE
Propose reserving additional sigils for future use

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -11,12 +11,10 @@ variant = when 1*(s key) [s] pattern
 key = nmtoken / literal / "*"
 
 placeholder = "{" [s] expression [s] "}"
-            / "{" [s] markup-start *(s option) [s] "}"
-            / "{" [s] markup-end [s] "}"
 
 expression = ((literal / variable) [s annotation])
            / annotation
-annotation = function *(s option)
+annotation = (function / markup / reserved) *(s option)
 option = name [s] "=" [s] (literal / nmtoken / variable)
 
 ; reserved keywords are always lowercase
@@ -39,8 +37,8 @@ literal-char = %x0-5B         ; omit \
 
 variable = "$" name
 function = ":" name
-markup-start = "+" name
-markup-end = "-" name
+markup = ("+" / "-") name
+reserved = ("!" / "@" / "#" / "$" / "%" / "^" / "&" / "*" / "<" / ">" / "?") name
 
 name    = name-start *name-char ; matches XML https://www.w3.org/TR/xml/#NT-Name
 nmtoken = 1*name-char           ; matches XML https://www.w3.org/TR/xml/#NT-Nmtokens


### PR DESCRIPTION
This proposal proposes to reserve sigils for future use with reserved sigils allowed in the same place that function names are currently, e.g. standalone (`{%foo}`), with options (`{%foo key=val}`), or subsidiary to variable/literals (`{|quote me| %foo}` or `{$var %foo}`).

A case could be made for reserving a comment syntax that allows a placeholder with prose in it (and I would suggest using the `%` for it). @eemeli's proposal is effectively this. I didn't propose this because of the impact on parsers in the future. Let's discuss.