### PR TITLE
Clarify that variables declarations may override previous ones

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -14,9 +14,11 @@ To resolve the value of a Variable,
 its Name is used to identify either a local variable,
 or a variable defined elsewhere.
 If a local variable and an externally defined one use the same name,
-the local variable takes precedence.
+the local variable takes precedence after its variable declaration.
+A variable declaration may refer in its expression
+to a previous or external variable with the same name as the declaration's target.
 
-It is an error for a local variable definition to
+It is an error for a variable declaration to
 refer to a local variable that's defined after it in the message.
 
 ## Error Handling

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -14,7 +14,7 @@ To resolve the value of a _variable_,
 its _name_ is used to identify either a local variable,
 or a variable defined elsewhere.
 
-If more than one _declaration_ binds a value to the same _name_,
+If the left-hand side _variable_ of more than one _declaration_ uses the same _name_,
 or if an externally defined variable and a _declaration_ use the same _name_,
 the resolved value of the most recent _declaration_ preceding the _variable_ is used.
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -18,7 +18,7 @@ If more than one _declaration_ binds a value to the same _name_,
 or if an externally defined variable and a _declaration_ use the same _name_,
 the resolved value of the most recent _declaration_ preceding the _variable_ is used.
 
-A _declaration_ MAY overwrite the value of a _variable_ for later parts of the _message_.
+A _declaration_ MAY override the value of a _variable_ for later parts of the _message_.
 
 Attempting to resolve a _variable_ with no preceding _declaration_ or external definition
 binding a value to its _name_ results in an Unresolved Variable error.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -10,16 +10,18 @@ the successor to ICU MessageFormat, henceforth called ICU MessageFormat 1.0.
 
 ## Variable Resolution
 
-To resolve the value of a Variable,
-its Name is used to identify either a local variable,
+To resolve the value of a _variable_,
+its _name_ is used to identify either a local variable,
 or a variable defined elsewhere.
-If a local variable and an externally defined one use the same name,
-the local variable takes precedence after its variable declaration.
-A variable declaration may refer in its expression
-to a previous or external variable with the same name as the declaration's target.
 
-It is an error for a variable declaration to
-refer to a local variable that's defined after it in the message.
+If more than one _declaration_ binds a value to the same _name_,
+or if an externally defined variable and a _declaration_ use the same _name_,
+the resolved value of the most recent _declaration_ preceding the _variable_ is used.
+
+A _declaration_ MAY overwrite the value of a _variable_ for later parts of the _message_.
+
+Attempting to resolve a _variable_ with no preceding _declaration_ or external definition
+binding a value to its _name_ results in an Unresolved Variable error.
 
 ## Error Handling
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -275,6 +275,20 @@ This local variable can then be used in other expressions within the same messag
 declaration = let s variable [s] "=" [s] expression
 ```
 
+Declaration examples:
+
+```
+let $foo = {|A literal value|}
+```
+
+```
+let $foo = {:func opt=$bar}
+```
+
+```
+let $foo = {$foo :number minimumFractionDigits=2}
+```
+
 ### Selectors
 
 A `match` statement contains one or more **_selectors_**


### PR DESCRIPTION
Naming things is hard, so we should make it as easy as possible. Specifically, I'm thinking here about the named parameters/arguments that a formatting call makes available within a message via variable references.

Let's say we have a numerical argument like `count` that we'd like to format using some set of options. That raw value will be initially represented as `$count` within the message, but what about the value-with-formatter-and-options that we'd like to derive from it? Could that not also be `$count`?

To use a minimal example, I would like for something like this to be valid and have the obvious meaning:
```
let $count = {$count :number minimumFractionDigits=2}
```

This PR adds spec language and examples clarifying that this is valid.