### PR TITLE
Add Literal Resolution section to formatting.md

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -8,6 +8,15 @@ when formatting a message for display in a user interface, or for some later pro
 The document is part of the MessageFormat 2.0 specification,
 the successor to ICU MessageFormat, henceforth called ICU MessageFormat 1.0.
 
+## Literal Resolution
+
+The resolved value of _text_, _literal_ and _nmtoken_ tokens
+is always a string concatenation of its parts,
+with escape sequences resolving to their escaped characters.
+When a literal value is used as a formatting function argument or option value,
+the formatting function MUST treat option values the same independently of their presentation,
+such that e.g. the options `foo=42` and `foo=|42|` have the same effect.
+
 ## Variable Resolution
 
 To resolve the value of a Variable,

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -13,8 +13,9 @@ the successor to ICU MessageFormat, henceforth called ICU MessageFormat 1.0.
 The resolved value of _text_, _literal_ and _nmtoken_ tokens
 is always a string concatenation of its parts,
 with escape sequences resolving to their escaped characters.
-When a literal value is used as a formatting function argument or option value,
-the formatting function MUST treat option values the same independently of their presentation,
+When a _literal_ or _nmtoken_ is used as an _expression_ argument
+or on the right-hand side of an _option_,
+the formatting function MUST treat their resolved values the same independently of their presentation,
 such that e.g. the options `foo=42` and `foo=|42|` have the same effect.
 
 ## Variable Resolution


### PR DESCRIPTION
This is in part a follow-up from this conversation with @aphillips: https://github.com/unicode-org/message-format-wg/pull/364#discussion_r1190848443

The intent here is to be clear and explicit about the meaning of literal values. While putting this together, I started to think that we might need yet another section discussing other treatment of message parts than formatting. For instance, I understand us to be aligned with expecting literal values to by default be presented as non-translatable. It would be good to note this somewhere, but "formatting" isn't really the right place for it.