### PR TITLE
Harmonise spec style

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -6,37 +6,20 @@
    1. [Conformance](#conformance)
    1. [Terminology and Conventions](#terminology-and-conventions)
 1. [Syntax](syntax.md)
-   1. [Design Goals](syntax.md#design-goals)
-   1. [Design Restrictions](syntax.md#design-restrictions)
-   1. [Overview & Examples](syntax.md#overview--examples)
-   1. [Simple Messages](syntax.md#simple-messages)
-   1. [Simple Placeholders](syntax.md#simple-placeholders)
-   1. [Formatting Functions](syntax.md#formatting-functions)
-   1. [Markup Elements](syntax.md#markup-elements)
-   1. [Selection](syntax.md#selection)
-   1. [Local Variables](syntax.md#local-variables)
-   1. [Complex Messages](syntax.md#complex-messages)
-1. [Productions](syntax.md#productions)
-   1. [Message](syntax.md#message)
-   1. [Variable Declarations](syntax.md#variable-declarations)
-   1. [Selectors](syntax.md#selectors)
-   1. [Variants](syntax.md#variants)
-   1. [Patterns](syntax.md#patterns)
-   1. [Placeholders](syntax.md#placeholders)
-   1. [Expressions](syntax.md#expressions)
-   1. [Markup Elements](syntax.md#markup-elements)
-1. [Tokens](syntax.md#tokens)
-   1. [Text](syntax.md#text)
-   1. [Names](syntax.md#names)
-   1. [Quoted Strings](syntax.md#quoted-strings)
-   1. [Escape Sequences](syntax.md#escape-sequences)
-   1. [Whitespace](syntax.md#whitespace)
-1. [Complete ABNF](syntax.md#complete-abnf)
+   1. [Productions](syntax.md#productions)
+   1. [Tokens](syntax.md#tokens)
+   1. [`message.abnf`](message.abnf)
+1. [Registry](registry.md)
+   1. [`registry.dtd`](registry.dtd)
 1. [Formatting](formatting.md)
 
 ## Introduction
 
-One of the challenges in adapting software to work for users with different languages and cultures is the need for ***dynamic messages***. Whenever a user interface needs to present data as part of a larger string, that data needs to be formatted (and the message may need to be altered) to make it culturally accepted and grammatically correct.
+One of the challenges in adapting software to work for
+users with different languages and cultures is the need for **_dynamic messages_**.
+Whenever a user interface needs to present data as part of a larger string,
+that data needs to be formatted (and the message may need to be altered)
+to make it culturally accepted and grammatically correct.
 
 For example, if your US English interface has a message like:
 
@@ -50,20 +33,29 @@ Or Japanese:
 
 > あなたのアイテムは 2023 年 4 月 3 日に 1,023 回閲覧されました。
 
-This specification defines the data model, syntax, processing, and conformance requirements for the next generation of _dynamic messages_. It is intended for adoption by programming languages and APIs. This will enable the integration of existing internationalization APIs (such as the date and number formats shown above), grammatical matching (such as plurals or genders), as well as user-defined formats and message selectors.
+This specification defines the
+data model, syntax, processing, and conformance requirements
+for the next generation of _dynamic messages_.
+It is intended for adoption by programming languages and APIs.
+This will enable the integration of
+existing internationalization APIs (such as the date and number formats shown above),
+grammatical matching (such as plurals or genders),
+as well as user-defined formats and message selectors.
 
-The document is the successor to ICU MessageFormat, henceforth called ICU MessageFormat 1.0.
+The document is the successor to ICU MessageFormat,
+henceforth called ICU MessageFormat 1.0.
 
 ### Conformance
 
-Everything in this specification is normative except for: sections marked 
-as non-normative, all authoring guidelines, diagrams, examples, and notes.
+Everything in this specification is normative except for:
+sections marked as non-normative,
+all authoring guidelines, diagrams, examples, and notes.
 
-The key words `MAY`, `MUST`, `MUST NOT`, `OPTIONAL`, `RECOMMENDED`, 
-`SHOULD`, and `SHOULD NOT` in this document are to be interpreted as 
-described in BCP 14 [RFC2119] [RFC8174]. 
+The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED,
+SHOULD, and SHOULD NOT in this document are to be interpreted as
+described in BCP 14 [RFC2119] [RFC8174].
 
 ### Terminology and Conventions
 
-When a term is defined in this document, it is marked like ***this***. When
-a term is referenced in this document it is marked like _this_.
+When a term is defined in this document, it is marked like **_this_**.
+When a term is referenced in this document it is marked like _this_.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -20,8 +20,8 @@ such that e.g. the options `foo=42` and `foo=|42|` have the same effect.
 
 ## Variable Resolution
 
-To resolve the value of a Variable,
-its Name is used to identify either a local variable,
+To resolve the value of a _variable_,
+its _name_ is used to identify either a local variable,
 or a variable defined elsewhere.
 If a local variable and an externally defined one use the same name,
 the local variable takes precedence.
@@ -155,11 +155,13 @@ as long as it satisfies the following requirements:
 1. Let `sortable` be an arbitrary list of (integer, _variant_) tuples.
 1. Let `sorted` be `SortVariants(sortable)`.
 1. `sorted` is the result of sorting `sortable` using the following comparator:
-    1. `(i1, v1)` <= `(i2, v2)` if and only if `i1 <= i2`.
+   1. `(i1, v1)` <= `(i2, v2)` if and only if `i1 <= i2`.
 1. The sort is stable (pairs of tuples from `sortable` that are equal
    in their first element have the same relative order in `sorted`).
 
 ### Examples
+
+_This section is non-normative._
 
 #### Example 1
 
@@ -270,7 +272,7 @@ when * {Other match}
    This is then sorted as:<br>
    « ( 0, `1` ), ( 1, `one` ), ( 2, `*` ) »<br>
 
-5. The pattern `{Exact match}` of the most preferred `1` variant is selected.
+4. The pattern `{Exact match}` of the most preferred `1` variant is selected.
 
 ## Error Handling
 
@@ -286,150 +288,150 @@ These are divided into the following categories:
 
 - **Syntax errors** occur when the syntax representation of a message is not well-formed.
 
-  Example invalid messages resulting in a Syntax error:
-
-  ```
-  {Missing end brace
-  ```
-
-  ```
-  {Unknown {#expression#}}
-  ```
-
-  ```
-  let $var = {|no message body|}
-  ```
+  > Example invalid messages resulting in a Syntax error:
+  >
+  > ```
+  > {Missing end brace
+  > ```
+  >
+  > ```
+  > {Unknown {{expression}}}
+  > ```
+  >
+  > ```
+  > let $var = {|no message body|}
+  > ```
 
 - **Data Model errors** occur when a message is invalid due to
   violating one of the semantic requirements on its structure:
 
-  - **Variant Key Mismatch errors** occur when the number of keys on a Variant
-    does not equal the number of Selectors.
+  - **Variant Key Mismatch errors** occur when the number of keys on a _variant_
+    does not equal the number of _selectors_.
 
-    Example invalid messages resulting in a Variant Key Mismatch error:
-
-    ```
-    match {$one}
-    when 1 2 {Too many}
-    when * {Otherwise}
-    ```
-
-    ```
-    match {$one} {$two}
-    when 1 2 {Two keys}
-    when * {Missing a key}
-    when * * {Otherwise}
-    ```
+    > Example invalid messages resulting in a Variant Key Mismatch error:
+    >
+    > ```
+    > match {$one}
+    > when 1 2 {Too many}
+    > when * {Otherwise}
+    > ```
+    >
+    > ```
+    > match {$one} {$two}
+    > when 1 2 {Two keys}
+    > when * {Missing a key}
+    > when * * {Otherwise}
+    > ```
 
   - **Missing Fallback Variant errors** occur when the message
-    does not include a Variant with only catch-all keys.
+    does not include a _variant_ with only catch-all keys.
 
-    Example invalid messages resulting in a Missing Fallback Variant error:
-
-    ```
-    match {$one}
-    when 1 {Value is one}
-    when 2 {Value is two}
-    ```
-
-    ```
-    match {$one} {$two}
-    when 1 * {First is one}
-    when * 1 {Second is one}
-    ```
+    > Example invalid messages resulting in a Missing Fallback Variant error:
+    >
+    > ```
+    > match {$one}
+    > when 1 {Value is one}
+    > when 2 {Value is two}
+    > ```
+    >
+    > ```
+    > match {$one} {$two}
+    > when 1 * {First is one}
+    > when * 1 {Second is one}
+    > ```
 
 - **Resolution errors** occur when the runtime value of a part of a message
   cannot be determined.
 
   - **Unresolved Variable errors** occur when a variable reference cannot be resolved.
 
-    For example, attempting to format either of the following messages
-    must result in an Unresolved Variable error if done within a context that
-    does not provide for the variable reference `$var` to be successfully resolved:
+    > For example, attempting to format either of the following messages
+    > must result in an Unresolved Variable error if done within a context that
+    > does not provide for the variable reference `$var` to be successfully resolved:
+    >
+    > ```
+    > {The value is {$var}.}
+    > ```
+    >
+    > ```
+    > match {$var}
+    > when 1 {The value is one.}
+    > when * {The value is not one.}
+    > ```
 
-    ```
-    {The value is {$var}.}
-    ```
-
-    ```
-    match {$var}
-    when 1 {The value is one.}
-    when * {The value is not one.}
-    ```
-
-  - **Unknown Function errors** occur when an Expression includes
+  - **Unknown Function errors** occur when an _expression_ includes
     a reference to a function which cannot be resolved.
 
-    For example, attempting to format either of the following messages
-    must result in an Unknown Function error if done within a context that
-    does not provide for the function `:func` to be successfully resolved:
-
-    ```
-    {The value is {horse :func}.}
-    ```
-
-    ```
-    match {|horse| :func}
-    when 1 {The value is one.}
-    when * {The value is not one.}
-    ```
+    > For example, attempting to format either of the following messages
+    > must result in an Unknown Function error if done within a context that
+    > does not provide for the function `:func` to be successfully resolved:
+    >
+    > ```
+    > {The value is {horse :func}.}
+    > ```
+    >
+    > ```
+    > match {|horse| :func}
+    > when 1 {The value is one.}
+    > when * {The value is not one.}
+    > ```
 
 - **Selection errors** occur when message selection fails.
 
   - **Selector errors** are failures in the matching of a key to a specific selector.
 
-    For example, attempting to format either of the following messages
-    might result in a Selector error if done within a context that
-    uses a `:plural` selector function which requires its input to be numeric:
-
-    ```
-    match {|horse| :plural}
-    when 1 {The value is one.}
-    when * {The value is not one.}
-    ```
-
-    ```
-    let $sel = {|horse| :plural}
-    match {$sel}
-    when 1 {The value is one.}
-    when * {The value is not one.}
-    ```
+    > For example, attempting to format either of the following messages
+    > might result in a Selector error if done within a context that
+    > uses a `:plural` selector function which requires its input to be numeric:
+    >
+    > ```
+    > match {|horse| :plural}
+    > when 1 {The value is one.}
+    > when * {The value is not one.}
+    > ```
+    >
+    > ```
+    > let $sel = {|horse| :plural}
+    > match {$sel}
+    > when 1 {The value is one.}
+    > when * {The value is not one.}
+    > ```
 
 - **Formatting errors** occur during the formatting of a resolved value,
   for example when encountering a value with an unsupported type
   or an internally inconsistent set of options.
 
-  For example, attempting to format any of the following messages
-  might result in a Formatting error if done within a context that
-
-  1. provides for the variable reference `$user` to resolve to
-     an object `{ name: 'Kat', id: 1234 }`,
-  2. provides for the variable reference `$field` to resolve to
-     a string `'address'`, and
-  3. uses a `:get` formatting function which requires its argument to be an object and
-     an option `field` to be provided with a string value,
-
-  ```
-  {Hello, {horse :get field=name}!}
-  ```
-
-  ```
-  {Hello, {$user :get}!}
-  ```
-
-  ```
-  let $id = {$user :get field=id}
-  {Hello, {$id :get field=name}!}
-  ```
-
-  ```
-  {Your {$field} is {$id :get field=$field}}
-  ```
+  > For example, attempting to format any of the following messages
+  > might result in a Formatting error if done within a context that
+  >
+  > 1. provides for the variable reference `$user` to resolve to
+  >    an object `{ name: 'Kat', id: 1234 }`,
+  > 2. provides for the variable reference `$field` to resolve to
+  >    a string `'address'`, and
+  > 3. uses a `:get` formatting function which requires its argument to be an object and
+  >    an option `field` to be provided with a string value,
+  >
+  > ```
+  > {Hello, {horse :get field=name}!}
+  > ```
+  >
+  > ```
+  > {Hello, {$user :get}!}
+  > ```
+  >
+  > ```
+  > let $id = {$user :get field=id}
+  > {Hello, {$id :get field=name}!}
+  > ```
+  >
+  > ```
+  > {Your {$field} is {$id :get field=$field}}
+  > ```
 
 Syntax and Data Model errors must be emitted as soon as possible.
 
-During selection, an Expression handler must only emit Resolution and Selection errors.
-During formatting, an Expression handler must only emit Resolution and Formatting errors.
+During selection, an _expression_ handler must only emit Resolution and Selection errors.
+During formatting, an _expression_ handler must only emit Resolution and Formatting errors.
 
 In all cases, when encountering an error,
 a message formatter must provide some representation of the message.
@@ -439,13 +441,13 @@ or contains some error which leads to further errors,
 an implementation which does not emit all of the errors
 should prioritise Syntax and Data Model errors over others.
 
-When an error occurs in the resolution of an Expression,
-the Expression in question is processed as if the option were not defined.
+When an error occurs in the resolution of an _expression_,
+the _expression_ in question is processed as if the option were not defined.
 This may allow for the fallback handling described below to be avoided,
 though an error must still be emitted.
 
-When an error occurs within a Selector,
-the selector must not match any VariantKey other than the catch-all `*`
+When an error occurs within a _selector_,
+the _selector_ must not match any _variant_ _key_ other than the catch-all `*`
 and a Resolution or Selector error is emitted.
 
 ## Fallback String Representations
@@ -458,61 +460,64 @@ If a fallback string is not defined,
 the U+FFFD REPLACEMENT CHARACTER `�` character is used,
 resulting in the string `{�}`.
 
-When an error occurs in an Expression that is being formatted,
-the fallback string representation of the Expression
+When an error occurs in an _expression_ that is being formatted,
+the fallback string representation of the _expression_
 always starts with U+007B LEFT CURLY BRACKET `{`
 and ends with U+007D RIGHT CURLY BRACKET `}`.
 Between the brackets, the following contents are used:
 
-- Expression with Literal Operand: U+007C VERTICAL LINE `|`
+- _expression_ with _literal_ operand: U+007C VERTICAL LINE `|`
   followed by the value of the Literal,
   and then by U+007C VERTICAL LINE `|`
 
-  Examples: `{|your horse|}`, `{|42|}`
+  > Examples: `{|your horse|}`, `{|42|}`
 
-- Expression with Variable Operand: U+0024 DOLLAR SIGN `$`
-  followed by the Variable Name of the Operand
+- _expression_ with _variable_ operand: U+0024 DOLLAR SIGN `$`
+  followed by the _variable_ _name_ of the operand
 
-  Example: `{$user}`
+  > Example: `{$user}`
 
-- Standalone expression with no Operand: U+003A COLON `:` followed by the Expression Name
+- Standalone _expression_ with no operand:
+  U+003A COLON `:` followed by the _function_ _name_
 
-  Example: `{:platform}`
+  > Example: `{:platform}`
 
-- Opening expression with no Operand: U+002B PLUS SIGN `+` followed by the Expression Name
+- Opening _expression_ with no operand:
+  U+002B PLUS SIGN `+` followed by the _function_ _name_
 
-  Example: `{+tag}`
+  > Example: `{+tag}`
 
-- Closing expression with no Operand: U+002D HYPHEN-MINUS `-` followed by the Expression Name
+- Closing _expression_ with no operand:
+  U+002D HYPHEN-MINUS `-` followed by the _function_ _name_
 
-  Example: `{-tag}`
+  > Example: `{-tag}`
 
 - Otherwise: The U+FFFD REPLACEMENT CHARACTER `�` character
 
-  Example: `{�}`
+  > Example: `{�}`
 
-Option names and values are not included in the fallback string representations.
+_Option_ names and values are not included in the fallback string representations.
 
-When an error occurs in an Expression with a Variable Operand
-and the Variable refers to a local variable Declaration,
-the fallback string is formatted based on the Expression of the Declaration,
-rather than the Expression in the Selector or Pattern.
+When an error occurs in an _expression_ with a _variable_ operand
+and the _variable_ refers to a local _declaration_,
+the fallback string is formatted based on the _expression_ of the _declaration_,
+rather than the _expression_ in the _selector_ or _pattern_.
 
-For example, attempting to format either of the following messages within a context that
-does not provide for the function `:func` to be successfully resolved:
-
-```
-let $var = {|horse| :func}
-{The value is {$var}.}
-```
-
-```
-let $var = {|horse|}
-{The value is {$var :func}.}
-```
-
-would result in both cases with this formatted string representation:
-
-```
-The value is {|horse|}.
-```
+> For example, attempting to format either of the following messages within a context that
+> does not provide for the function `:func` to be successfully resolved:
+>
+> ```
+> let $var = {|horse| :func}
+> {The value is {$var}.}
+> ```
+>
+> ```
+> let $var = {|horse|}
+> {The value is {$var :func}.}
+> ```
+>
+> would result in both cases with this formatted string representation:
+>
+> ```
+> The value is {|horse|}.
+> ```

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -2,27 +2,28 @@
 
 _This document is non-normative._
 
-The implementations and tooling can greatly benefit from a structured definition of formatting and matching functions available to messages at runtime.
+The implementations and tooling can greatly benefit from a
+structured definition of formatting and matching functions available to messages at runtime.
 The _registry_ is a mechanism for storing such declarations in a portable manner.
 
 ## Goals
 
-The registry provides a machine-readable description of MessageFormat extensions (custom functions),
+The registry provides a machine-readable description of MessageFormat 2 extensions (custom functions),
 in order to support the following goals and use-cases:
 
-* Validate semantic properties of messages. For example:
-    * Type-check values passed into functions.
-    * Validate that matching functions are only called in selectors.
-    * Validate that formatting functions are only called in placeholders.
-    * Verify the exhaustiveness of variant keys given a selector.
-* Support the localization roundtrip. For example:
-    * Generate variant keys for a given locale during XLIFF extraction.
-* Improve the authoring experience. For example:
-    * Forbid edits to certain function options (e.g. currency options).
-    * Autocomplete function and option names.
-    * Display on-hover tooltips for function signatures with documentation.
-    * Display/edit known message metadata.
-    * Restrict input in GUI by providing a dropdown with all viable option values.
+- Validate semantic properties of messages. For example:
+  - Type-check values passed into functions.
+  - Validate that matching functions are only called in selectors.
+  - Validate that formatting functions are only called in placeholders.
+  - Verify the exhaustiveness of variant keys given a selector.
+- Support the localization roundtrip. For example:
+  - Generate variant keys for a given locale during XLIFF extraction.
+- Improve the authoring experience. For example:
+  - Forbid edits to certain function options (e.g. currency options).
+  - Autocomplete function and option names.
+  - Display on-hover tooltips for function signatures with documentation.
+  - Display/edit known message metadata.
+  - Restrict input in GUI by providing a dropdown with all viable option values.
 
 ## Data Model
 
@@ -33,20 +34,24 @@ The main building block of the registry is the `<function>` element.
 It represents an implementation of a custom function available to translation at runtime.
 A function defines a human-readable _description_ of its behavior
 and one or more machine-readable _signatures_ of how to call it.
-Named `<pattern>` elements can optionally define regex validation rules for literals, option values, and variant keys.
+Named `<pattern>` elements can optionally define regex validation rules for
+literals, option values, and variant keys.
 
-MessageFormat functions can be invoked in two contexts:
-* inside placeholders, to produce a part of the message's formatted output;
+MessageFormat 2 functions can be invoked in two contexts:
+
+- inside placeholders, to produce a part of the message's formatted output;
   for example, a raw value of `|1.5|` may be formatted to `1,5` in a language which uses commas as decimal separators,
-* inside selectors, to contribute to selecting the appropriate variant among all given variants.
+- inside selectors, to contribute to selecting the appropriate variant among all given variants.
 
 A single _function name_ may be used in both contexts,
 regardless of whether it's implemented as one or multiple functions.
 
-A _signature_ defines one particular set of at most one argument and any number of named options that can be used together in a single call to the function.
+A _signature_ defines one particular set of at most one argument and any number of named options
+that can be used together in a single call to the function.
 `<formatSignature>` corresponds to a function call inside a placeholder inside translatable text.
 `<matchSignature>` corresponds to a function call inside a selector.
-Signatures with a non-empty `locales` attribute are locale-specific and only available in translations in the given languages.
+Signatures with a non-empty `locales` attribute are locale-specific
+and only available in translations in the given languages.
 
 A signature may define the positional argument of the function with the `<input>` element.
 If the `<input>` element is not present, the function is defined as a nullary function.
@@ -116,9 +121,11 @@ For the sake of brevity, only `locales="en"` is considered.
 
 Given the above description, the `:number` function is defined to work both in a selector and a placeholder:
 
-    match {$count :number}
-    when 1 {One new message}
-    when other {{$count :number} new messages}
+```
+match {$count :number}
+when 1 {One new message}
+when * {{$count :number} new messages}
+```
 
 Furthermore,
 `:number`'s `<matchSignature>` contains two `<match>` elements
@@ -126,12 +133,12 @@ which allow to validate the variant keys.
 If at least one `<match>` validation rules passes,
 a variant key is considered valid.
 
-* `<match pattern="anyNumber"/>` can be used to valide the `when 1` variant
-by testing the `1` key against the `anyNumber` regular expression defined in the registry file.
-* `<match values="one other"/>` can be used to valide the `when other` variant
-by verifying that the `other` key is present in the list of enumarated values: `one other`.
+- `<match pattern="anyNumber"/>` can be used to valide the `when 1` variant
+  by testing the `1` key against the `anyNumber` regular expression defined in the registry file.
+- `<match values="one other"/>` can be used to valide the `when other` variant
+  by verifying that the `other` key is present in the list of enumarated values: `one other`.
 
-----
+---
 
 A localization engineer can then extend the registry by defining the following `customRegistry.xml` file.
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -19,7 +19,7 @@
    1. [Variants](#variants)
    1. [Patterns](#patterns)
    1. [Expressions](#expressions)
-       1. [Reserved Sequences](#reserved)
+      1. [Reserved Sequences](#reserved)
 1. [Tokens](#tokens)
    1. [Keywords](#keywords)
    1. [Text](#text)
@@ -52,7 +52,7 @@ The design goals of the syntax specification are as follows:
    as well as making the selection logic predictable and easy to reason about.
 
    - _Non-Goal_: Make the syntax intuitive enough for non-technical translators to hand-edit.
-     Instead, we assume that most translators will work with MessageFormat 2.0
+     Instead, we assume that most translators will work with MessageFormat 2
      by means of GUI tooling, CAT workbenches etc.
 
 1. The syntax surrounding translatable content should be easy to write and edit
@@ -285,20 +285,20 @@ which will be used to choose one of the _variants_ during formatting.
 selectors = match 1*([s] expression)
 ```
 
-Examples:
-
-```
-match {$count :plural}
-when 1 {One apple}
-when * {{$count} apples}
-```
-
-```
-let $frac = {$count: number minFractionDigits=2}
-match {$frac}
-when 1 {One apple}
-when * {{$frac} apples}
-```
+> Examples:
+>
+> ```
+> match {$count :plural}
+> when 1 {One apple}
+> when * {{$count} apples}
+> ```
+>
+> ```
+> let $frac = {$count: number minFractionDigits=2}
+> match {$frac}
+> when 1 {One apple}
+> when * {{$frac} apples}
+> ```
 
 ### Variants
 
@@ -337,23 +337,26 @@ This serves 3 purposes:
 pattern = "{" *(text / expression) "}"
 ```
 
-Examples:
-
-```
-{Hello, world!}
-```
+> Example:
+>
+> ```
+> {Hello, world!}
+> ```
 
 Whitespace within a _pattern_ is meaningful and MUST be preserved.
 
 ### Expressions
 
-_Expressions_ ***must*** start with a _literal_, a _variable_, or an _annotation_. An _expression_ ***must not*** be empty.
+**_Expressions_** MUST start with a _literal_, a _variable_, or an _annotation_.
+An _expression_ MUST NOT be empty.
 
-A _literal_ or _variable_ ***may*** be optionally followed by an _annotation_. 
+A _literal_ or _variable_ MAY be optionally followed by an _annotation_.
 
-An _annotation_ consists of a _function_ and its named _options_, or consists of a _reserved_ sequence.
+An **_annotation_** consists of a _function_ and its named _options_,
+or consists of a _reserved_ sequence.
 
-_Functions_ do not accept any positional arguments other than the _literal_ or _variable_ in front of them.
+_Functions_ do not accept any positional arguments
+other than the _literal_ or _variable_ in front of them.
 
 ```abnf
 expression = "{" [s] (((literal / variable) [s annotation]) / annotation) [s] "}"
@@ -361,56 +364,59 @@ annotation = (function *(s option)) / reserved
 option = name [s] "=" [s] (literal / variable)
 ```
 
-Expression examples:
-
-```
-{1.23}
-```
-
-```
-{|-1.23|}
-```
-
-```
-{1.23 :number maxFractionDigits=1}
-```
-
-```
-{|Thu Jan 01 1970 14:37:00 GMT+0100 (CET)| :datetime weekday=long}
-```
-
-```
-{|My Brand Name| :linkify href=|foobar.com|}
-```
-
-```
-{$when :datetime month=2-digit}
-```
-
-```
-{:message id=some_other_message}
-```
-
-```
-{+ssml.emphasis level=strong}
-```
-
-Message examples:
-
-```
-{This is {+b}bold{-b}.}
-```
-
-```
-{{+h1 name=above-and-beyond}Above And Beyond{-h1}}
-```
+> Expression examples:
+>
+> ```
+> {1.23}
+> ```
+>
+> ```
+> {|-1.23|}
+> ```
+>
+> ```
+> {1.23 :number maxFractionDigits=1}
+> ```
+>
+> ```
+> {|Thu Jan 01 1970 14:37:00 GMT+0100 (CET)| :datetime weekday=long}
+> ```
+>
+> ```
+> {|My Brand Name| :linkify href=|foobar.com|}
+> ```
+>
+> ```
+> {$when :datetime month=2-digit}
+> ```
+>
+> ```
+> {:message id=some_other_message}
+> ```
+>
+> ```
+> {+ssml.emphasis level=strong}
+> ```
+>
+> Message examples:
+>
+> ```
+> {This is {+b}bold{-b}.}
+> ```
+>
+> ```
+> {{+h1 name=above-and-beyond}Above And Beyond{-h1}}
+> ```
 
 #### Reserved
 
-_Reserved_ sequences start with a reserved character and are intended for future standardization. 
-A reserved sequence can be empty or contain arbitrary text. 
+**_Reserved_** sequences start with a reserved character
+and are intended for future standardization.
+A reserved sequence MAY be empty or contain arbitrary text.
 A reserved sequence does not include any trailing whitespace.
-While a reserved sequence is technically "well-formed", unrecognized reserved sequences have no meaning and might result in errors during formatting.
+
+While a reserved sequence is technically "well-formed",
+unrecognized reserved sequences have no meaning and MAY result in errors during formatting.
 
 ## Tokens
 
@@ -429,7 +435,7 @@ when  = %x77.68.65.6E     ; "when"
 
 ### Text
 
-_Text_ is the translatable content of a _pattern_.
+**_text_** is the translatable content of a _pattern_.
 Any Unicode code point is allowed,
 except for surrogate code points U+D800 through U+DFFF.
 The characters `\`, `{`, and `}` MUST be escaped as `\\`, `\{`, and `\}`.
@@ -447,11 +453,13 @@ text-char = %x0-5B         ; omit \
 
 ### Literals
 
-_Literal_ is used for matching variants and providing input to _expressions_.
-_Quoted_ literals may include content with any Unicode code point,
+**_Literal_** is used for matching variants and providing input to _expressions_.
+
+**_Quoted_** literals may include content with any Unicode code point,
 except for surrogate code points U+D800 through U+DFFF.
 The characters `\` and `|` MUST be escaped as `\\` and `\|`.
-_Unquoted_ literals have a much more restricted range that
+
+**_Unquoted_** literals have a much more restricted range that
 is intentionally close to the XML's [Nmtoken](https://www.w3.org/TR/xml/#NT-Nmtoken),
 with the restriction that it MUST NOT start with `-` or `:`,
 as those would conflict with _function_ start characters.
@@ -474,7 +482,7 @@ unquoted-start = name-start / DIGIT / "."
 
 ### Names
 
-The _name_ token is used for variable names (prefixed with `$`),
+The **_name_** token is used for variable names (prefixed with `$`),
 function names (prefixed with `:`, `+` or `-`),
 as well as option names.
 It is based on XML's [Name](https://www.w3.org/TR/xml/#NT-Name),
@@ -516,7 +524,6 @@ backslash      = %x5C ; U+005C REVERSE SOLIDUS "\"
 Inside _patterns_,
 whitespace is part of the translatable content and is recorded and stored verbatim.
 Whitespace is not significant outside translatable text, except where required by the syntax.
-
 
 ```abnf
 s = 1*( SP / HTAB / CR / LF )


### PR DESCRIPTION
This fixes the following editorial issues in the spec:
- Always style normative key words using all caps: MUST, MAY, etc.
- Always use **_definition_** and _reference_ styles
- Always use `>` block quotes for examples
- Always use semantic line breaks
- Apply Prettier markdown styling
- Update ToC in readme