### PR TITLE
Change the syntax of the #open and /close function calls

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -483,14 +483,14 @@ Between the brackets, the following contents are used:
   > Example: `{:platform}`
 
 - Opening _expression_ with no operand:
-  U+002B PLUS SIGN `+` followed by the _function_ _name_
+  U+005C REVERSE SOLIDUS `\` followed by the _function_ _name_
 
-  > Example: `{+tag}`
+  > Example: `{\tag}`
 
 - Closing _expression_ with no operand:
-  U+002D HYPHEN-MINUS `-` followed by the _function_ _name_
+  U+002F SOLIDUS `/` followed by the _function_ _name_
 
-  > Example: `{-tag}`
+  > Example: `{/tag}`
 
 - Otherwise: The U+FFFD REPLACEMENT CHARACTER `�` character
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -483,9 +483,9 @@ Between the brackets, the following contents are used:
   > Example: `{:platform}`
 
 - Opening _expression_ with no operand:
-  U+005C REVERSE SOLIDUS `\` followed by the _function_ _name_
+  U+0023 NUMBER SIGN `#` followed by the _function_ _name_
 
-  > Example: `{\tag}`
+  > Example: `{#tag}`
 
 - Closing _expression_ with no operand:
   U+002F SOLIDUS `/` followed by the _function_ _name_

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -14,7 +14,7 @@ annotation = (function *(s option)) / reserved
 
 literal = quoted / unquoted
 variable = "$" name
-function = (":" / "+" / "-") name
+function = (":" / "\" / "/") name
 option = name [s] "=" [s] (literal / variable)
 
 ; reserved keywords are always lowercase

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -14,7 +14,7 @@ annotation = (function *(s option)) / reserved
 
 literal = quoted / unquoted
 variable = "$" name
-function = (":" / "\" / "/") name
+function = (":" / "#" / "/") name
 option = name [s] "=" [s] (literal / variable)
 
 ; reserved keywords are always lowercase

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -146,13 +146,13 @@ plucking the first name from the object representing a person:
 Functions use one of the following prefix sigils:
 
 - `:` for standalone content
-- `\` for starting or opening elements
+- `#` for starting or opening elements
 - `/` for ending or closing elements
 
 A message with two markup-like _functions_, `button` and `link`,
 which the runtime can use to construct a document tree structure for a UI framework:
 
-    {{\button}Submit{/button} or {\link}cancel{/link}.}
+    {{#button}Submit{/button} or {#link}cancel{/link}.}
 
 An opening element MAY be present in a message without a corresponding closing element,
 and vice versa.
@@ -395,17 +395,17 @@ option = name [s] "=" [s] (literal / variable)
 > ```
 >
 > ```
-> {\ssml.emphasis level=strong}
+> {#ssml.emphasis level=strong}
 > ```
 >
 > Message examples:
 >
 > ```
-> {This is {\b}bold{/b}.}
+> {This is {#b}bold{/b}.}
 > ```
 >
 > ```
-> {{\h1 name=above-and-beyond}Above And Beyond{/h1}}
+> {{#h1 name=above-and-beyond}Above And Beyond{/h1}}
 > ```
 
 #### Reserved
@@ -483,7 +483,7 @@ unquoted-start = name-start / DIGIT / "."
 ### Names
 
 The **_name_** token is used for variable names (prefixed with `$`),
-function names (prefixed with `:`, `\` or `/`),
+function names (prefixed with `:`, `#` or `/`),
 as well as option names.
 It is based on XML's [Name](https://www.w3.org/TR/xml/#NT-Name),
 with the restriction that it MUST NOT start with `:`,
@@ -492,7 +492,7 @@ Otherwise, the set of characters allowed in names is large.
 
 ```abnf
 variable = "$" name
-function = (":" / "\" / "/") name
+function = (":" / "#" / "/") name
 
 name = name-start *name-char
 name-start = ALPHA / "_"

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -146,13 +146,13 @@ plucking the first name from the object representing a person:
 Functions use one of the following prefix sigils:
 
 - `:` for standalone content
-- `+` for starting or opening elements
-- `-` for ending or closing elements
+- `\` for starting or opening elements
+- `/` for ending or closing elements
 
 A message with two markup-like _functions_, `button` and `link`,
 which the runtime can use to construct a document tree structure for a UI framework:
 
-    {{+button}Submit{-button} or {+link}cancel{-link}.}
+    {{\button}Submit{/button} or {\link}cancel{/link}.}
 
 An opening element MAY be present in a message without a corresponding closing element,
 and vice versa.
@@ -395,17 +395,17 @@ option = name [s] "=" [s] (literal / variable)
 > ```
 >
 > ```
-> {+ssml.emphasis level=strong}
+> {\ssml.emphasis level=strong}
 > ```
 >
 > Message examples:
 >
 > ```
-> {This is {+b}bold{-b}.}
+> {This is {\b}bold{/b}.}
 > ```
 >
 > ```
-> {{+h1 name=above-and-beyond}Above And Beyond{-h1}}
+> {{\h1 name=above-and-beyond}Above And Beyond{/h1}}
 > ```
 
 #### Reserved
@@ -483,7 +483,7 @@ unquoted-start = name-start / DIGIT / "."
 ### Names
 
 The **_name_** token is used for variable names (prefixed with `$`),
-function names (prefixed with `:`, `+` or `-`),
+function names (prefixed with `:`, `\` or `/`),
 as well as option names.
 It is based on XML's [Name](https://www.w3.org/TR/xml/#NT-Name),
 with the restriction that it MUST NOT start with `:`,
@@ -492,7 +492,7 @@ Otherwise, the set of characters allowed in names is large.
 
 ```abnf
 variable = "$" name
-function = (":" / "+" / "-") name
+function = (":" / "\" / "/") name
 
 name = name-start *name-char
 name-start = ALPHA / "_"


### PR DESCRIPTION
This is an alternative to #397, which I'd like to collect feedback on. It's an attempt to find a pair of convenient single-char-long prefixes which don't conflict with signed number literals.

<del>The opening syntax, `\func`, is inspired by TeX. The closing syntax, `/func`, is inspired by HTML.</del>

---

#### July 2 Update

I've morphed this PR to propose `{#open}...{/close}`. See https://github.com/unicode-org/message-format-wg/pull/398#issuecomment-1616559995.

	main: {+button title=|Click me!|}Submit{-button}
	#397: {::button title=|Click me!|}Submit{:/button}
	this: {#button title=|Click me!|}Submit{/button}
