### PR TITLE
Specify private reserved sigils `^` and `&`

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -42,9 +42,11 @@ unquoted = unquoted-start *name-char
 unquoted-start = name-start / DIGIT / "."
                / %xB7 / %x300-36F / %x203F-2040
 
-; reserve additional sigils for future use
-reserved       = reserved-start reserved-body
-reserved-start = "!" / "@" / "#" / "%" / "^" / "&" / "*" / "<" / ">" / "?" / "~"
+; reserve additional sigils for private use by implementations
+; and for future specification versions
+reserved       = ( future-start / private-start ) reserved-body
+future-start   = "!" / "@" / "#" / "%" / "*" / "<" / ">" / "?" / "~"
+private-start  = "^" / "&"
 reserved-body  = *( [s] 1*(reserved-char / reserved-escape / literal))
 reserved-char  = %x00-08        ; omit HTAB and LF
                / %x0B-0C        ; omit CR

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -412,13 +412,35 @@ option = name [s] "=" [s] (literal / variable)
 
 #### Reserved
 
-**_Reserved_** sequences start with a reserved character
-and are intended for future standardization.
+**_Reserved_** annotations start with a reserved character
+and are intended for future standardization
+as well as private implementation use.
 A reserved sequence MAY be empty or contain arbitrary text.
 A reserved sequence does not include any trailing whitespace.
 
+Implementations MAY define their own meaning and semantics for
+_reserved_ annotations that start with
+the U+0026 AMOERSAND `&` or U+005E CIRCUMFLEX ACCENT `^` characters.
+Implementations MUST NOT define any such meaning or semantics for
+_reserved_ annotations that start with any other character;
+these are reserved for the use of future versions of this specification.
+
 While a reserved sequence is technically "well-formed",
 unrecognized reserved sequences have no meaning and MAY result in errors during formatting.
+
+```abnf
+reserved      = ( future-start / private-start ) reserved-body
+future-start  = "!" / "@" / "#" / "%" / "*" / "<" / ">" / "?" / "~"
+private-start = "^" / "&"
+reserved-body = *( [s] 1*(reserved-char / reserved-escape / literal))
+reserved-char = %x00-08        ; omit HTAB and LF
+              / %x0B-0C        ; omit CR
+              / %x0E-19        ; omit SP
+              / %x21-5B        ; omit \
+              / %x5D-7A        ; omit { | }
+              / %x7E-D7FF      ; omit surrogates
+              / %xE000-10FFFF
+```
 
 ## Tokens
 


### PR DESCRIPTION
Closes #378 

This PR marks the `^` and `&` reserved sigils as available for implementation use, as opposed to being reserved for future spec versions. Language is also added to clarify the distinction.

```abnf
reserved      = ( future-start / private-start ) reserved-body
future-start  = "!" / "@" / "#" / "%" / "*" / "<" / ">" / "?" / "~"
private-start = "^" / "&"
```

Of the sigils remaining for future spec versions, `!` / `?` and `<` / `>` seem like potential matching pairs of some sort, `#` could be a comment or section introducer, and `*` already has a meaning as a catch-all key. That leaves the following semantically unburdened "generic" sigils: `@`, `%`, and `~`. This should be sufficient for future expansion before we really need a 3.0.