### PR TITLE
Replace `(literal / variable)` with `operand` in definition of `option`

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -16,7 +16,7 @@ annotation = (function *(s option)) / reserved
 literal = quoted / unquoted
 variable = "$" name
 function = (":" / "+" / "-") name
-option = name [s] "=" [s] (literal / variable)
+option = name [s] "=" [s] operand
 
 ; reserved keywords are always lowercase
 let   = %x6C.65.74        ; "let"


### PR DESCRIPTION
`operand` is now defined as `literal / variable`, so the definition of `option` can use `operand` instead of `(literal / variable)` (and should, for clarity.)