### PR TITLE
Use `"` or `'` instead of `|` as quote delimiter

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -79,7 +79,7 @@ In a _pattern_, the resolved value of an _expression_ is used in its _formatting
 The shapes of resolved values are implementation-dependent,
 and different implementations MAY choose to perform different levels of resolution.
 
-> For example, the resolved value of the _expression_ `{|0.40| :number style=percent}`
+> For example, the resolved value of the _expression_ `{0.40 :number style=percent}`
 > could be an object such as
 >
 > ```
@@ -114,7 +114,7 @@ the formatting function MUST treat its resolved value the same
 whether its value was originally _quoted_ or _unquoted_.
 
 > For example,
-> the _option_ `foo=42` and the _option_ `foo=|42|` are treated as identical.
+> the _option_ `foo=42` and the _option_ `foo='42'` are treated as identical.
 
 The resolution of a _text_ or _literal_ token MUST always succeed.
 
@@ -184,12 +184,12 @@ In each such case, an error MUST be emitted
 and a **_fallback value_** used for the _expression_.
 This value depends on the shape of the _expression_:
 
-- _expression_ with _literal_ _operand_: U+007C VERTICAL LINE `|`
+- _expression_ with _literal_ _operand_: U+0022 QUOTATION MARK `"`
   followed by the value of the Literal,
-  and then by U+007C VERTICAL LINE `|`.
+  and then by U+0022 QUOTATION MARK `"`.
   The same representation is used for both _quoted_ and _unquoted_ values.
 
-  > Examples: `|your horse|`, `|42|`
+  > Examples: `"your horse"`, `"42"`
 
 - _expression_ with _variable_ _operand_: U+0024 DOLLAR SIGN `$`
   followed by the _variable_ _name_ of the _operand_
@@ -216,17 +216,17 @@ rather than the _expression_ in the _selector_ or _pattern_.
 > attempting to format either of the following messages:
 >
 > ```
-> let $var = {|horse| :func}
+> let $var = {"horse" :func}
 > {The value is {$var}.}
 > ```
 >
 > ```
-> let $var = {|horse|}
+> let $var = {'horse'}
 > {The value is {$var :func}.}
 > ```
 >
 > would in both cases result in the _pattern_ _expression_
-> resolving to a _fallback value_ of `|horse|`.
+> resolving to a _fallback value_ of `"horse"`.
 
 _Pattern selection_ is not supported for _fallback values_.
 
@@ -629,7 +629,7 @@ These are divided into the following categories:
   > ```
   >
   > ```
-  > let $var = {|no message body|}
+  > let $var = {"no message body"}
   > ```
 
 - **Data Model errors** occur when a message is invalid due to
@@ -716,7 +716,7 @@ These are divided into the following categories:
     > ```
     >
     > ```
-    > match {|horse| :func}
+    > match {'horse' :func}
     > when 1 {The value is one.}
     > when * {The value is not one.}
     > ```
@@ -730,13 +730,13 @@ These are divided into the following categories:
     > uses a `:plural` selector function which requires its input to be numeric:
     >
     > ```
-    > match {|horse| :plural}
+    > match {'horse' :plural}
     > when 1 {The value is one.}
     > when * {The value is not one.}
     > ```
     >
     > ```
-    > let $sel = {|horse| :plural}
+    > let $sel = {'horse' :plural}
     > match {$sel}
     > when 1 {The value is one.}
     > when * {The value is not one.}

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -30,10 +30,12 @@ text-char = %x0-5B         ; omit \
           / %x7E-D7FF      ; omit surrogates
           / %xE000-10FFFF
 
-quoted      = "|" *(quoted-char / quoted-escape) "|"
-quoted-char = %x0-5B         ; omit \
-            / %x5D-7B        ; omit |
-            / %x7D-D7FF      ; omit surrogates
+quoted      = "'" *(quoted-char / DQUOTE / quoted-escape) "'"
+            / DQUOTE *(quoted-char / "'" / quoted-escape) DQUOTE
+quoted-char = %x0-21         ; omit "
+            / %x23-26        ; omit '
+            / %x28-5B        ; omit \
+            / %x5D-D7FF      ; omit surrogates
             / %xE000-10FFFF
 
 ; based on https://www.w3.org/TR/xml/#NT-Nmtoken,
@@ -47,12 +49,15 @@ unquoted-start = name-start / DIGIT / "."
 reserved       = ( reserved-start / private-start ) reserved-body
 reserved-start = "!" / "@" / "#" / "%" / "*" / "<" / ">" / "/" / "?" / "~"
 private-start  = "^" / "&"
-reserved-body  = *( [s] 1*(reserved-char / reserved-escape / literal))
+reserved-body  = *( [s] 1*(reserved-char / reserved-escape / quoted))
 reserved-char  = %x00-08        ; omit HTAB and LF
                / %x0B-0C        ; omit CR
                / %x0E-19        ; omit SP
-               / %x21-5B        ; omit \
-               / %x5D-7A        ; omit { | }
+               / %x21           ; omit "
+               / %x23-26        ; omit '
+               / %x28-5B        ; omit \
+               / %x5D-7A        ; omit {
+               / %x7C           ; omit }
                / %x7E-D7FF      ; omit surrogates
                / %xE000-10FFFF
 
@@ -68,8 +73,8 @@ name-char  = name-start / DIGIT / "-" / "." / ":"
            / %xB7 / %x300-36F / %x203F-2040
 
 text-escape     = backslash ( backslash / "{" / "}" )
-quoted-escape   = backslash ( backslash / "|" )
-reserved-escape = backslash ( backslash / "{" / "|" / "}" )
+quoted-escape  = backslash ( backslash / "'" / DQUOTE )
+reserve-escape = backslash ( backslash / "{" / "'" / DQUOTE / "}" )
 backslash       = %x5C ; U+005C REVERSE SOLIDUS "\"
 
 s = 1*( SP / HTAB / CR / LF )


### PR DESCRIPTION
Please see the following discussions for context on how we ended up with `|quotes|`:
- #263
- #276
- #359

Now that we've made it possible to use unquoted values as operands, I realise that my opinion on this topic has changed, and so I'm proposing that we allow both `'quoted'` and `"quoted"` literals. I have three reasons for this:
1. With the ability to write an expression like `{42 :number}`, I'm much less bothered by using string-y quote characters for delimiting literal values. In particular, if/once we also allow for negative numbers to not be quoted.
2. Fundamentally, I believe that this would make our syntax less _weird_. We've spent quite a bit of effort on ensuring that MF2 syntax is relatively readable, so that people don't feel like they need to read the spec to understand what a message means, or how to write a message. Using `|` as literal delimiters (or `()` before the current choice) is really rather novel, and that's not really a good thing.
3. Allowing either `'` or `"` should reduce the need to escape these delimiters either due to characters in the literal value, or due to the delimiters of a surrounding resource format.

As one negative consequence of this proposed change, this might mean a little more care is necessary when moving the source of a message from one encapsulation to another one. I think this is well justified given the benefits.