### PR TITLE
Fix `reserved-body` to use `quoted` rather than `literal`

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -47,7 +47,7 @@ unquoted-start = name-start / DIGIT / "."
 reserved       = ( reserved-start / private-start ) reserved-body
 reserved-start = "!" / "@" / "#" / "%" / "*" / "<" / ">" / "/" / "?" / "~"
 private-start  = "^" / "&"
-reserved-body  = *( [s] 1*(reserved-char / reserved-escape / literal))
+reserved-body  = *( [s] 1*(reserved-char / reserved-escape / quoted))
 reserved-char  = %x00-08        ; omit HTAB and LF
                / %x0B-0C        ; omit CR
                / %x0E-19        ; omit SP

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -436,7 +436,7 @@ unrecognized reserved sequences have no meaning and MAY result in errors during 
 reserved       = ( reserved-start / private-start ) reserved-body
 reserved-start = "!" / "@" / "#" / "%" / "*" / "<" / ">" / "/" / "?" / "~"
 private-start  = "^" / "&"
-reserved-body  = *( [s] 1*(reserved-char / reserved-escape / literal))
+reserved-body  = *( [s] 1*(reserved-char / reserved-escape / quoted))
 reserved-char  = %x00-08        ; omit HTAB and LF
                / %x0B-0C        ; omit CR
                / %x0E-19        ; omit SP


### PR DESCRIPTION
This was missed in #364, which was introduced before but merged after #374. Previously included in #414.

`reserved-body` needs to allow for `quoted` values (which were named `literal` at the time of its writing) to support expressions like
```
{^foo |some {text} here|}
```
as the `{}` within the `|` quotes does not need to be escaped.

As is, the ABNF is a bit broken for `reserved-body` as there are characters that are valid as either `reserved-char` or `literal`.