### PR TITLE
Styling and structure changes to syntax.md

### DIFF
--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -471,8 +471,8 @@ option = name [s] "=" [s] (literal / variable)
 A **_reserved_** _annotation_ is an _annotation_ whose syntax is reserved
 for future standardization.
 
-A _reserved_ annotation starts with a reserved character.
-A _reserved_ _annotation_ MAY be empty or contain arbitrary text.
+A _reserved_ _annotation_ starts with a reserved character.
+A _reserved_ _annotation_ MAY be empty or contain arbitrary text after its first character.
 This allows maximum flexibility in future standardization,
 as future definitions are expected to define additional semantics and constraints
 on the contents of these _annotations_.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -281,8 +281,9 @@ of the selection process.
 
 A **_match statement_** signals that the _message_ contains more than one
 _variant_ that can potentially be used to format as output.
-A _match_ statement MUST begin with the keyword `match`.
-A _match_ statement MUST be followed by one or more _selector expressions_.
+A _match statement_ MUST begin with the keyword `match`.
+A _match statement_ MUST contain one or more _selector expressions_.
+A _match statement_ MUST be followed by at least one _variant_.
 
 ```abnf
 selectors = match 1*([s] expression)

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -520,8 +520,8 @@ text-char = %x0-5B         ; omit \
 A **_literal_** is a character sequence that appears outside
 of _text_ in various parts of a _message_.
 A _literal_ can appear in a _declaration_, as a _key_ value,
-as an _operand_, or in the value of an _option_. A _literal_ MAY
-include any Unicode code point
+as an _operand_, or in the value of an _option_.
+A _literal_ MAY include any Unicode code point
 except for surrogate code points U+D800 through U+DFFF.
 
 All code points are preserved.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -424,7 +424,7 @@ pattern = "{" *(text / expression) "}"
 ### Expressions
 
 An _expression_ can appear as a local variable value, as a _selector_, and within a _pattern_.
-Each _expression_ MUST start with an _operand_ or an _annotation_.
+The contents of each _expression_ MUST start with an _operand_ or an _annotation_.
 An _expression_ MUST NOT be empty.
 
 An **_operand_** is a _literal_ or a _variable_ to be evaluated in an _expression_.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -329,7 +329,7 @@ that varies in content or form depending on values determined at runtime.
 A **_selector expression_** is an _expression_ that will be used as part 
 of the selection process.
 
-A **_match statement_** indicates that the _message_ contains more than one
+A **_match statement_** indicates that the _message_ contains at least one
 _variant_ that can potentially be used to format as output.
 A _match statement_ MUST begin with the keyword `match`.
 A _match statement_ MUST contain one or more _selector expressions_.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -104,15 +104,18 @@ to be formatted as a unit.
 All _patterns_, including simple ones, begin with U+007B LEFT CURLY BRACKET `{` 
 and end with U+007D RIGHT CURLY BRACKET `}`.
 
->    {Hello, world!}
+> A _message_ consisting of a simple _pattern_:
+>>```
+>>{Hello, world!}
+>>```
 
->The same message defined in a `.properties` file:
+>The same _message_ defined in a `.properties` file:
 >
 >>```properties
 >>app.greetings.hello = {Hello, world!}
 >>```
 
->The same message defined inline in JavaScript:
+>The same _message_ defined inline in JavaScript:
 >
 >>```js
 >>let hello = new MessageFormat('{Hello, world!}')

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -6,7 +6,7 @@
    1. [Design Goals](#design-goals)
    1. [Design Restrictions](#design-restrictions)
 1. [Overview & Examples](#overview--examples)
-   1. [Messages](#message)
+   1. [Messages and Patterns](#messages-and-patterns)
    1. [Expressions](#expression)
    1. [Formatting Functions](#function)
    1. [Selection](#selection)
@@ -91,11 +91,17 @@ The syntax specification takes into account the following design restrictions:
 
 _This section is non-normative._
 
-### Message
+### Messages and Patterns
 
 A **_message_** is the complete template for a specific message formatting request.
 
-All _messages_, including simple ones, begin with U+007B LEFT CURLY BRACKET `{` 
+All _messages_ MUST contain either a _pattern_ or _selectors_. 
+A _message_ MAY contain zero or more _declarations_.
+(Implication: the empty string is not a valid message)
+
+A **_pattern_** is a combination of _text_ and _placeholders_ 
+to be formatted as a unit.
+All _patterns_, including simple ones, begin with U+007B LEFT CURLY BRACKET `{` 
 and end with U+007D RIGHT CURLY BRACKET `}`.
 
 >    {Hello, world!}

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -576,7 +576,7 @@ The grammar defines the following tokens for the purpose of the lexical analysis
 
 ### Keywords
 
-A **_keyword_** is a reserved token that is part of the _message_ syntax.
+A **_keyword_** is a reserved token that has a unique meaning in the _message_ syntax.
 
 The following three keywords are reserved: `let`, `match`, and `when`.
 Reserved keywords are always lowercase.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -89,15 +89,15 @@ The syntax specification takes into account the following design restrictions:
 
 ## Overview & Examples
 
-_This section is non-normative._
-
 ### Messages and Patterns
 
 A **_message_** is the complete template for a specific message formatting request.
 
-All _messages_ MUST contain either a _pattern_ or _selectors_. 
-A _message_ MAY contain zero or more _declarations_.
+All _messages_ MUST contain a _body_.
+The _body_ of a _message_ consists of either a _pattern_ or of _selectors_. 
 An empty string is not a valid _message_.
+
+A _message_ MAY also contain zero or more _declarations_ before the _body_.
 
 A **_pattern_** is a combination of _text_ and _placeholders_ 
 to be formatted as a unit.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -374,6 +374,7 @@ A _well-formed_ message is considered _valid_ if the following requirements are 
 ### Patterns
 
 A **_pattern_** is a sequence of translatable elements.
+A _pattern_ MAY be empty.
 Patterns MUST be delimited with `{` at the start, and `}` at the end.
 This serves 3 purposes:
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -192,7 +192,7 @@ A **_selector_** selects a specific _pattern_ from a list of available _patterns
 in a _message_ based on the value of its _expression_.
 A message can have multiple selectors.
 
->A message with a single _selector_:
+>A message with a single _selector_, `{$count :number}`. `:number` is a built-in function. 
 >
 >```
 >match {$count :number}

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -279,7 +279,7 @@ that varies in content or form depending on values determined at runtime.
 A **_selector expression_** is an _expression_ that will be used as part 
 of the selection process.
 
-A **_match statement_** signals that the _message_ contains more than one
+A **_match statement_** indicates that the _message_ contains more than one
 _variant_ that can potentially be used to format as output.
 A _match statement_ MUST begin with the keyword `match`.
 A _match statement_ MUST contain one or more _selector expressions_.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -374,8 +374,9 @@ A _well-formed_ message is considered _valid_ if the following requirements are 
 ### Patterns
 
 A **_pattern_** is a sequence of translatable elements.
-A _pattern_ MAY be empty.
 Patterns MUST be delimited with `{` at the start, and `}` at the end.
+A _pattern_'s contents MAY be empty.
+Whitespace within a _pattern_ is meaningful and MUST be preserved.
 This serves 3 purposes:
 
 - The message can be unambiguously embeddable in various container formats
@@ -393,13 +394,29 @@ This serves 3 purposes:
 pattern = "{" *(text / expression) "}"
 ```
 
-> Example:
->
+> **Example**
+> 
+> A simple _pattern_ containing _text_:
 > ```
 > {Hello, world!}
 > ```
-
-Whitespace within a _pattern_ is meaningful and MUST be preserved.
+>
+> An empty _pattern_:
+> ```
+> {}
+> ```
+>
+> Some _patterns_ with _expressions_:
+> ```
+> {{$foo}}
+> {Hello {$user}!}
+> {You sent {$count :number maxFractionDigits=0} notifications to {$numFriends :number type=spellout} friends.}
+> ```
+>
+> A _pattern_ containing three spaces:
+> ```
+> {   }
+> ```
 
 ### Expressions
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -407,7 +407,7 @@ that is evaluated during the formatting process.
 Each _expression_ MUST start with an _operand_ or an _annotation_.
 An _expression_ MUST NOT be empty.
 
-An **_operand_** is a _literal_ or a _variable_ to be evaluated in a _placeholder_.
+An **_operand_** is a _literal_ or a _variable_ to be evaluated in an _expression_.
 An _operand_ MAY be optionally followed by an _annotation_.
 
 An **_annotation_** consists of a _function_ and its named _options_,

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -97,7 +97,7 @@ A **_message_** is the complete template for a specific message formatting reque
 
 All _messages_ MUST contain either a _pattern_ or _selectors_. 
 A _message_ MAY contain zero or more _declarations_.
-(Implication: the empty string is not a valid message)
+An empty string is not a valid _message_.
 
 A **_pattern_** is a combination of _text_ and _placeholders_ 
 to be formatted as a unit.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -354,8 +354,8 @@ Whitespace within a _pattern_ is meaningful and MUST be preserved.
 ### Expressions
 
 An **_expression_** is a _selector_ or a placeholder in a _pattern_
-that is evaluated during the formatting process. Each _expression_ MUST 
-start with an _operand_ or an _annotation_.
+that is evaluated during the formatting process.
+Each _expression_ MUST start with an _operand_ or an _annotation_.
 An _expression_ MUST NOT be empty.
 
 An **_operand_** is either a _literal_ or a _variable_ that is the "subject"

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -402,8 +402,7 @@ Whitespace within a _pattern_ is meaningful and MUST be preserved.
 
 ### Expressions
 
-An **_expression_** is a _selector_ or a _placeholder_ in a _pattern_
-that is evaluated during the formatting process.
+An _expression_ can appear as a local variable value, as a _selector_, and within a _pattern_.
 Each _expression_ MUST start with an _operand_ or an _annotation_.
 An _expression_ MUST NOT be empty.
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -358,7 +358,7 @@ selectors = match 1*([s] expression)
 
 A **_variant_** is a _pattern_ associated with a set of _keys_.
 Each _variant_ MUST begin with the _keyword_ `when`,
-be followed by a sequence of _keys_,
+be followed by a non-empty sequence of _keys_,
 and terminate with a valid _pattern_.
 The key `*` is a "catch-all" key, matching all selector values.
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -96,11 +96,11 @@ A **_message_** is the complete template for a specific message formatting reque
 
 All _messages_ MUST contain a _body_.
 The _body_ of a _message_ consists of either a _pattern_ or of _selectors_. 
-An empty string is not a valid _message_.
+An empty string is not a _well-formed_ _message_.
 
 A _message_ MAY also contain one or more _declarations_ before the _body_.
 
-A **_pattern_** is a combination of _text_ and _placeholders_ 
+A **_pattern_** is a sequence of _text_ and _placeholders_ 
 to be formatted as a unit.
 All _patterns_, including simple ones, begin with U+007B LEFT CURLY BRACKET `{` 
 and end with U+007D RIGHT CURLY BRACKET `}`.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -559,7 +559,7 @@ except for surrogate code points U+D800 through U+DFFF.
 
 All code points are preserved.
 
-A **_quoted_** literal begins and ends with U+005E VERTICAL BAR.
+A **_quoted_** literal begins and ends with U+005E VERTICAL BAR `|`.
 The characters `\` and `|` within a _quoted_ literal MUST be 
 escaped as `\\` and `\|`.
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -97,7 +97,7 @@ All _messages_ MUST contain a _body_.
 The _body_ of a _message_ consists of either a _pattern_ or of _selectors_. 
 An empty string is not a valid _message_.
 
-A _message_ MAY also contain zero or more _declarations_ before the _body_.
+A _message_ MAY also contain one or more _declarations_ before the _body_.
 
 A **_pattern_** is a combination of _text_ and _placeholders_ 
 to be formatted as a unit.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -105,22 +105,22 @@ All _patterns_, including simple ones, begin with U+007B LEFT CURLY BRACKET `{`
 and end with U+007D RIGHT CURLY BRACKET `}`.
 
 > A _message_ consisting of a simple _pattern_:
->>```
->>{Hello, world!}
->>```
+>```
+>{Hello, world!}
+>```
 
 >The same _message_ defined in a `.properties` file:
 >
->>```properties
->>app.greetings.hello = {Hello, world!}
->>```
+>```properties
+>app.greetings.hello = {Hello, world!}
+>```
 
 >The same _message_ defined inline in JavaScript:
 >
->>```js
->>let hello = new MessageFormat('{Hello, world!}')
->>hello.format()
->>```
+>```js
+>let hello = new MessageFormat('{Hello, world!}')
+>hello.format()
+>```
 
 ### Expression
 
@@ -137,9 +137,9 @@ An _expression_ can appear as a local variable value, as a _selector_, and withi
 
 > A simple _expression_ containing a variable:
 >
->>```
->>    {Hello, {$userName}!}
->>```
+>```
+>{Hello, {$userName}!}
+>```
 
 ### Function
 
@@ -148,25 +148,25 @@ A _function_ MAY be followed by zero or more _options_
 
 >For example, a _message_ with a `$date` _variable_ formatted with the `:datetime` _function_:
 >
->>```
->>    {Today is {$date :datetime weekday=long}.}
->>```
+>```
+>{Today is {$date :datetime weekday=long}.}
+>```
 
 >A _message_ with a `$userName` _variable_ formatted with
 >the custom `:person` _function_ capable of
 >declension (using either a fixed dictionary, algorithmic declension, ML, etc.):
 >
->>```
->>    {Hello, {$userName :person case=vocative}!}
->>```
+>```
+>{Hello, {$userName :person case=vocative}!}
+>```
 
 >A _message_ with a `$userObj` _variable_ formatted with
 >the custom `:person` _function_ capable of
 >plucking the first name from the object representing a person:
 >
->>```
->>    {Hello, {$userObj :person firstName=long}!}
->>```
+>```
+>{Hello, {$userObj :person firstName=long}!}
+>```
 
 _Functions_ can be _standalone_, or can be an _opening element_ or _closing element_.
 
@@ -180,9 +180,9 @@ and vice versa.
 >A message with two markup-like _functions_, `button` and `link`,
 >which the runtime can use to construct a document tree structure for a UI framework:
 >
->>```
->>    {{+button}Submit{-button} or {+link}cancel{-link}.}
->>```
+>```
+>{{+button}Submit{-button} or {+link}cancel{-link}.}
+>```
 
 
 ### Selection
@@ -193,40 +193,40 @@ A message can have multiple selectors.
 
 >A message with a single _selector_:
 >
->>```
->>    match {$count :number}
->>    when 1 {You have one notification.}
->>    when * {You have {$count} notifications.}
->>```
+>```
+>match {$count :number}
+>when 1 {You have one notification.}
+>when * {You have {$count} notifications.}
+>```
 
 >A message with a single _selector_ which is an invocation of
 >a custom function `:platform`, formatted on a single line:
 >
->>```
->>    match {:platform} when windows {Settings} when * {Preferences}
->>```
+>```
+>match {:platform} when windows {Settings} when * {Preferences}
+>```
 
 >A message with a single _selector_ and a custom `:hasCase` function
 >which allows the message to query for presence of grammatical cases required for each variant:
 >
->>```
->>    match {$userName :hasCase}
->>    when vocative {Hello, {$userName :person case=vocative}!}
->>    when accusative {Please welcome {$userName :person case=accusative}!}
->>    when * {Hello!}
->>```
+>```
+>match {$userName :hasCase}
+>when vocative {Hello, {$userName :person case=vocative}!}
+>when accusative {Please welcome {$userName :person case=accusative}!}
+>when * {Hello!}
+>```
 
 >A message with two _selectors_:
 >
->>```
->>    match {$photoCount :number} {$userGender :equals}
->>    when 1 masculine {{$userName} added a new photo to his album.}
->>    when 1 feminine {{$userName} added a new photo to her album.}
->>    when 1 * {{$userName} added a new photo to their album.}
->>    when * masculine {{$userName} added {$photoCount} photos to his album.}
->>    when * feminine {{$userName} added {$photoCount} photos to her album.}
->>    when * * {{$userName} added {$photoCount} photos to their album.}
->>```
+>```
+>match {$photoCount :number} {$userGender :equals}
+>when 1 masculine {{$userName} added a new photo to his album.}
+>when 1 feminine  {{$userName} added a new photo to her album.}
+>when 1 *         {{$userName} added a new photo to their album.}
+>when * masculine {{$userName} added {$photoCount} photos to his album.}
+>when * feminine  {{$userName} added {$photoCount} photos to her album.}
+>when * *         {{$userName} added {$photoCount} photos to their album.}
+>```
 
 ### Local Variables
 
@@ -239,21 +239,21 @@ which defines the value of a named local variable.
 >A _message_ containing a _declaration_ defining a local variable `$whom`
 >which is then used twice inside the pattern:
 >
->>```
->>    let $whom = {$monster :noun case=accusative}
->>    {You see {$quality :adjective article=indefinite accord=$whom} {$whom}!}
->>```
+>```
+>let $whom = {$monster :noun case=accusative}
+>{You see {$quality :adjective article=indefinite accord=$whom} {$whom}!}
+>```
 
 >A _message_ defining two local variables:
 >`$itemAcc` and `$countInt`, and using `$countInt` as a selector:
 >
->>```
->>    let $countInt = {$count :number maximumFractionDigits=0}
->>    let $itemAcc = {$item :noun count=$count case=accusative}
->>    match {$countInt}
->>    when one {You bought {$color :adjective article=indefinite accord=$itemAcc} {$itemAcc}.}
->>    when * {You bought {$countInt} {$color :adjective accord=$itemAcc} {$itemAcc}.}
->>```
+>```
+>let $countInt = {$count :number maximumFractionDigits=0}
+>let $itemAcc = {$item :noun count=$count case=accusative}
+>match {$countInt}
+>when one {You bought {$color :adjective article=indefinite accord=$itemAcc} {$itemAcc}.}
+>when * {You bought {$countInt} {$color :adjective accord=$itemAcc} {$itemAcc}.}
+>```
 
 ### Complex Messages
 
@@ -262,28 +262,28 @@ _declarations_, _selectors_, _functions_, and more.
 
 >A complex message with 2 _selectors_ and 3 local variable _declarations_:
 >
->>```
->>    let $hostName = {$host :person firstName=long}
->>    let $guestName = {$guest :person firstName=long}
->>    let $guestsOther = {$guestCount :number offset=1}
->>
->>    match {$host :gender} {$guestOther :number}
->>
->>    when female 0 {{$hostName} does not give a party.}
->>    when female 1 {{$hostName} invites {$guestName} to her party.}
->>    when female 2 {{$hostName} invites {$guestName} and one other person to her party.}
->>    when female * {{$hostName} invites {$guestName} and {$guestsOther} other people to her party.}
->>
->>    when male 0 {{$hostName} does not give a party.}
->>    when male 1 {{$hostName} invites {$guestName} to his party.}
->>    when male 2 {{$hostName} invites {$guestName} and one other person to his party.}
->>    when male * {{$hostName} invites {$guestName} and {$guestsOther} other people to his party.}
->>
->>    when * 0 {{$hostName} does not give a party.}
->>    when * 1 {{$hostName} invites {$guestName} to their party.}
->>    when * 2 {{$hostName} invites {$guestName} and one other person to their party.}
->>    when * * {{$hostName} invites {$guestName} and {$guestsOther} other people to their party.}
->>```
+>```
+>let $hostName = {$host :person firstName=long}
+>let $guestName = {$guest :person firstName=long}
+>let $guestsOther = {$guestCount :number offset=1}
+>
+>match {$host :gender} {$guestOther :number}
+>
+>when female 0 {{$hostName} does not give a party.}
+>when female 1 {{$hostName} invites {$guestName} to her party.}
+>when female 2 {{$hostName} invites {$guestName} and one other person to her party.}
+>when female * {{$hostName} invites {$guestName} and {$guestsOther} other people to her party.}
+>
+>when male 0 {{$hostName} does not give a party.}
+>when male 1 {{$hostName} invites {$guestName} to his party.}
+>when male 2 {{$hostName} invites {$guestName} and one other person to his party.}
+>when male * {{$hostName} invites {$guestName} and {$guestsOther} other people to his party.}
+>
+>when * 0 {{$hostName} does not give a party.}
+>when * 1 {{$hostName} invites {$guestName} to their party.}
+>when * 2 {{$hostName} invites {$guestName} and one other person to their party.}
+>when * * {{$hostName} invites {$guestName} and {$guestsOther} other people to their party.}
+>```
 
 ## Productions
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -534,9 +534,9 @@ An **_unquoted_** literal is a _literal_ that does not require the `|`
 quotes around it to be distinct from the rest of the _message_ syntax.
 An _unquoted_ MAY be used when the content of the _literal_
 contains no whitespace and otherwise matches the `unquoted` production.
-Any _unquoted_ literal MAY be _quoted_. Implementations MUST NOT distinguish
-between _quoted_ and _unquoted_ literals that have the same sequence of 
-code points.
+Any _unquoted_ literal MAY be _quoted_.
+Implementations MUST NOT distinguish between _quoted_ and _unquoted_ literals
+that have the same sequence of code points.
 
 _Unquoted_ literals have a much more restricted range that
 is intentionally close to the XML's [Nmtoken](https://www.w3.org/TR/xml/#NT-Nmtoken),

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -584,7 +584,7 @@ name-char  = name-start / DIGIT / "-" / "." / ":"
 ### Escape Sequences
 
 An **_escape sequence_** is a two-character sequence starting with
-`\` U+005C REVERSE SOLIDUS. 
+U+005C REVERSE SOLIDUS `\`.
 
 An _escape sequence_ allows the appearance of lexically meaningful characters
 in the body of `text`, `quoted`, or `reserved` sequences respectively:

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -135,7 +135,7 @@ and ends with U+007D RIGHT CURLY BRACKET `}`.
 
 An _expression_ can appear as a local variable value, as a _selector_, and within a _pattern_.
 
-> A simple _expression_ is a bare variable name:
+> A simple _expression_ containing a variable:
 >
 >>```
 >>    {Hello, {$userName}!}

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -306,9 +306,10 @@ selectors = match 1*([s] expression)
 
 ### Variants
 
-A **_variant_** is a _pattern_ associated with a set of _keys_. Each _variant_ 
-MUST begin with the _keyword_ `when`,be followed by a sequence of _keys_, and
-terminate with a valid _pattern_.
+A **_variant_** is a _pattern_ associated with a set of _keys_.
+Each _variant_ MUST begin with the _keyword_ `when`,
+be followed by a sequence of _keys_,
+and terminate with a valid _pattern_.
 The key `*` is a "catch-all" key, matching all selector values.
 
 ```abnf

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -236,7 +236,8 @@ or providing additional data to an _expression_.
 Local variables appear in a _declaration_,
 which defines the value of a named local variable.
 
->A _message_ containing a _declaration_ defining a local variable `$whom` which is then used twice inside the pattern:
+>A _message_ containing a _declaration_ defining a local variable `$whom`
+>which is then used twice inside the pattern:
 >
 >>```
 >>    let $whom = {$monster :noun case=accusative}


### PR DESCRIPTION
This includes fixing the style of **_definitions_** and their _references_.

In the course of doing this change, I made some non-editorial changes:

* Introduce terms and definitions to clarify _selectors_, _match statement_, and _selector_ and concepts. Our text was difficult to read because there was no way to refer to the `match` clearly (because the production is called `selectors`) or to refer to a specific _selector_ (or just the selector expressions minus the keyword `match`). Hopefully this is a step in the right direction. This transformation is incomplete, since there are several places that refer to `match` rather than _match statement_, etc.

* I split `private-use` from `reserved`, although that really should be a separate PR.

* I modified the structure and description of the _quoted_ and _unquoted_ literals to make their relationship clearer.

* I reorganized and made normative text in several places. I believe that the normative changes are not a material change: they are just applying the SHOUTY KEYWORDS appropriately or making explicit what is only implied by the ABNF.

* I added `quoted` to the list of places where whitespace is meaningful. I think this was previously an oversight.

I expect tons of comments/hate mail ;-)