### PR TITLE
Implement `private-use` separately from `reserved`

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -42,11 +42,15 @@ unquoted = unquoted-start *name-char
 unquoted-start = name-start / DIGIT / "."
                / %xB7 / %x300-36F / %x203F-2040
 
-; reserve additional sigils for use by future versions of this
-; specification or for private use by implementations
-reserved       = ( reserved-start / private-start ) reserved-body
-reserved-start = "!" / "@" / "#" / "%" / "*" / "<" / ">" / "/" / "?" / "~"
+
+; reserve sigils for private-use by implementations
+private-use    = private-start 1*(text)
 private-start  = "^" / "&"
+
+; reserve additional sigils for use by 
+; future versions of this specification
+reserved       = reserved-start reserved-body
+reserved-start = "!" / "@" / "#" / "%" / "*" / "<" / ">" / "/" / "?" / "~"
 reserved-body  = *( [s] 1*(reserved-char / reserved-escape / literal))
 reserved-char  = %x00-08        ; omit HTAB and LF
                / %x0B-0C        ; omit CR

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -10,8 +10,8 @@ variant = when 1*(s key) [s] pattern
 key = literal / "*"
 
 expression = "{" [s] ((operand [s annotation]) / annotation) [s] "}"
-operand = literal / variable
-annotation = (function *(s option)) / reserved
+operand    = literal / variable
+annotation = (function *(s option)) / reserved / private-use
 
 literal = quoted / unquoted
 variable = "$" name

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -20,6 +20,7 @@
    1. [Patterns](#patterns)
    1. [Expressions](#expressions)
       1. [Reserved Sequences](#reserved)
+      2. [Private-Use Sequences](#private-use)
 1. [Tokens](#tokens)
    1. [Keywords](#keywords)
    1. [Text](#text)
@@ -413,17 +414,13 @@ option = name [s] "=" [s] (literal / variable)
 #### Reserved
 
 **_Reserved_** annotations start with a reserved character
-and are intended for future standardization
-as well as private implementation use.
+and are intended for future standardization.
 A _reserved_ _annotation_ MAY be empty or contain arbitrary text.
 This allows maximum flexibility in future standardization,
-as future definitions are expected to define additional semantics and constraints
+as future definitions MAY define additional semantics and constraints
 on the contents of these _annotations_.
 A _reserved_ _annotation_ does not include trailing whitespace.
 
-Implementations MAY define their own meaning and semantics for
-_reserved_ annotations that start with
-the U+0026 AMPERSAND `&` or U+005E CIRCUMFLEX ACCENT `^` characters.
 Implementations MUST NOT assign meaning or semantics to
 an _annotation_ starting with `reserved-start`:
 these are reserved for future standardization.
@@ -433,9 +430,8 @@ While a reserved sequence is technically "well-formed",
 unrecognized reserved sequences have no meaning and MAY result in errors during formatting.
 
 ```abnf
-reserved       = ( reserved-start / private-start ) reserved-body
+reserved       = reserved-start reserved-body
 reserved-start = "!" / "@" / "#" / "%" / "*" / "<" / ">" / "/" / "?" / "~"
-private-start  = "^" / "&"
 reserved-body  = *( [s] 1*(reserved-char / reserved-escape / literal))
 reserved-char  = %x00-08        ; omit HTAB and LF
                / %x0B-0C        ; omit CR
@@ -445,6 +441,37 @@ reserved-char  = %x00-08        ; omit HTAB and LF
                / %x7E-D7FF      ; omit surrogates
                / %xE000-10FFFF
 ```
+
+#### Private-Use
+
+A **_private-use_** _annotation_ is an _annotation_ whose syntax is reserved
+for use by a specific implementation or by private agreement between multiple
+implementations. 
+Implementations MAY define their own meaning and semantics for _private-use_ annotations.
+
+A _private-use_ annotation starts with either U+0026 AMPERSAND `&` or U+005E CIRCUMFLEX ACCENT `^`.
+The characters `\`, `{`, and `}` MUST be escaped as `\\`, `\{`, and `\}` when they 
+appear as part of a _private-use_ annotation. 
+ 
+All other characters, including whitespace, are assigned meaning by the implementation.
+A _private-use_ _annotation_ MAY be empty. 
+
+**NOTE:** Users are cautioned that _private-use_ sequences cannot be reliably exchanged
+and can result in errors during formatting. It is generally a better idea to use
+the function registry to define additional formatting or annotation options.
+
+```abnf
+private-use   = private-start 1*(text)
+private-start = "&" / "^"
+```
+
+> Here are some examples of what _private-use_ sequences might look like:
+>> ```
+>> {Here's private use with an operand: {$foo &function}}
+>> {Here's a placeholder that is entirely private-use: {&function anything here}}
+>> {Stop {& "translate 'stop' as a verb" might be a translator instruction or comment }}
+>> {Protect stuff in {^ph}<a>{^/ph}private use{^ph}</a>{^/ph}}
+>>```
 
 ## Tokens
 


### PR DESCRIPTION
- creates a separate section in the syntax spec
- creates a separate rule in abnf
- adjusts the text in `reserved` to suit

Note that I did not include changing `reserved` to use `*(text)` in this PR, but did change `private-use` to do so.