### PR TITLE
(EARLY REVIEW/SPECULATIVE) Refactoring syntax spec

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -2,13 +2,13 @@ message = [s] *(declaration [s]) body [s]
 
 declaration = let s variable [s] "=" [s] expression
 body = pattern
-     / (selector)
+     / (matcher)
 
 pattern  = "{" *(text / expression) "}"
-selector = match_statement 1*([s] variant))
 
-match_statement = match 1*([s] expression)
-variant         = when 1*(s key) [s] pattern
+matcher  = match 1*([s] selector) 1*([s] variant)
+selector = expression
+variant  = when 1*(s key) [s] pattern
 
 key = literal / "*"
 

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -2,21 +2,24 @@ message = [s] *(declaration [s]) body [s]
 
 declaration = let s variable [s] "=" [s] expression
 body = pattern
-     / (selectors 1*([s] variant))
+     / (selector)
 
-pattern = "{" *(text / expression) "}"
-selectors = match 1*([s] expression)
-variant = when 1*(s key) [s] pattern
+pattern  = "{" *(text / expression) "}"
+selector = match_statement 1*([s] variant))
+
+match_statement = match 1*([s] expression)
+variant         = when 1*(s key) [s] pattern
+
 key = literal / "*"
 
 expression = "{" [s] ((operand [s annotation]) / annotation) [s] "}"
-operand = literal / variable
+operand    = literal / variable
 annotation = (function *(s option)) / reserved
 
-literal = quoted / unquoted
+literal  = quoted / unquoted
 variable = "$" name
 function = (":" / "+" / "-") name
-option = name [s] "=" [s] (literal / variable)
+option   = name [s] "=" [s] (literal / variable)
 
 ; reserved keywords are always lowercase
 let   = %x6C.65.74        ; "let"

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -166,7 +166,7 @@ declaration = let s variable [s] "=" [s] expression
 
 ### Body
 
-The **_body_** of a message consists of either a _pattern_ or a _selector_.
+The **_body_** of a message consists of either a _pattern_ or a _match statement_.
 
 ### Pattern
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -192,7 +192,7 @@ various formats regardless of the container's whitespace trimming rules.
 > Example. In a Java `.properties` file, the message `hello` has exactly three spaces before and after
 > the word "Hello":
 > ```properties
-> hello = {  Hello  }
+> hello = {   Hello   }
 > ```
 
 ### Text

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -186,6 +186,40 @@ MUST be preserved during formatting.
 pattern = "{" *(text / expression) "}"
 ```
 
+Embedding a _pattern_ in brackets ensures that simple _messages_ can be embedded into
+various formats regardless of the container's whitespace trimming rules.
+
+> Example. In a Java `.properties` file, the message `hello` has exactly three spaces before and after
+> the word "Hello":
+> ```properties
+> hello = {  Hello  }
+> ```
+
+#### Parts of a Pattern
+
+##### Text
+
+**_text_** is the translatable content of a _pattern_.
+Any Unicode code point is allowed,
+except for surrogate code points U+D800 through U+DFFF.
+The characters `\`, `{`, and `}` MUST be escaped as `\\`, `\{`, and `\}`.
+
+All code points are preserved. Whitespace in text is significant.
+
+```abnf
+text = 1*(text-char / text-escape)
+text-char = %x0-5B         ; omit \
+          / %x5D-7A        ; omit {
+          / %x7C           ; omit }
+          / %x7E-D7FF      ; omit surrogates
+          / %xE000-10FFFF
+```
+
+##### Placeholder
+
+A **_placeholder_** is another word for an _expression_ that appears inside of a _pattern_
+and which will be replaced during the formatting of the _message_.
+
 ### Selector
 
 A **_selector_** selects a specific _pattern_ from a list of available
@@ -222,9 +256,9 @@ selector = match_statment 1*(variant)
 >```
 
 
-### Match
+### Match Statement
 
-A **_match statement_** or just `match` is the portion of a _selector_ that
+A **_match statement_** is the portion of a _selector_ that
 determines how a given _message_ will select the most appropriate _pattern_.
 
 The _match_ consists of the keyword `match` followed by a list of one or more
@@ -270,8 +304,6 @@ The key `*` is a "catch-all" key, matching all values from an _expression_.
 The number of _keys_ in the _variant_ MUST match the number of _expressions_ in the 
 _match statement_.
 
-A _variant_ consists of the keyword `when` followed by a list of one or more _keys_.
-
 ```abnf
 variant = when 1*(s key) [s] pattern
 key = literal / "*"
@@ -283,11 +315,6 @@ A **_key_** is a value in a _variant_ for use by a _selector_ when selecting the
 at runtime.
 A _key_ can be either a _literal_ value or the catch-all key `*`.
 
-
-### Placeholder
-
-A **_placeholder_** is an _expression_ that appears inside of a _pattern_
-and which will be replaced during the formatting of the _message_.
 
 ### Expression
 
@@ -466,19 +493,7 @@ reserved-char  = %x00-08        ; omit HTAB and LF
 ### Patterns
 
 A **_pattern_** is a sequence of translatable elements.
-Patterns MUST be delimited with `{` at the start, and `}` at the end.
-This serves 3 purposes:
 
-- The message can be unambiguously embeddable in various container formats
-  regardless of the container's whitespace trimming rules.
-  E.g. in Java `.properties` files,
-  `hello = {Hello}` will unambiguously define the `Hello` message without the space in front of it.
-- The message can be conveniently embeddable in various programming languages
-  without the need to escape characters commonly related to strings, e.g. `"` and `'`.
-  Such need might still occur when a single or double quote is
-  used in the translatable content.
-- The syntax needs to make it as clear as possible which parts of the message body
-  are translatable and which ones are part of the formatting logic definition.
 
 ```abnf
 pattern = "{" *(text / expression) "}"
@@ -608,24 +623,6 @@ Reserved keywords are always lowercase.
 let   = %x6C.65.74        ; "let"
 match = %x6D.61.74.63.68  ; "match"
 when  = %x77.68.65.6E     ; "when"
-```
-
-### Text
-
-**_text_** is the translatable content of a _pattern_.
-Any Unicode code point is allowed,
-except for surrogate code points U+D800 through U+DFFF.
-The characters `\`, `{`, and `}` MUST be escaped as `\\`, `\{`, and `\}`.
-
-All code points are preserved. Whitespace in text is significant.
-
-```abnf
-text = 1*(text-char / text-escape)
-text-char = %x0-5B         ; omit \
-          / %x5D-7A        ; omit {
-          / %x7C           ; omit }
-          / %x7E-D7FF      ; omit surrogates
-          / %xE000-10FFFF
 ```
 
 ### Literals

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -195,9 +195,7 @@ various formats regardless of the container's whitespace trimming rules.
 > hello = {  Hello  }
 > ```
 
-#### Parts of a Pattern
-
-##### Text
+### Text
 
 **_text_** is the translatable content of a _pattern_.
 Any Unicode code point is allowed,
@@ -215,7 +213,7 @@ text-char = %x0-5B         ; omit \
           / %xE000-10FFFF
 ```
 
-##### Placeholder
+### Placeholder
 
 A **_placeholder_** is another word for an _expression_ that appears inside of a _pattern_
 and which will be replaced during the formatting of the _message_.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -156,7 +156,7 @@ if it meets additional semantic requirements about its structure, defined below.
 
 ### Declarations
 
-A **_declaration_** is binds a variable identifier
+A **_declaration_** binds a variable identifier
 to the value of an _expression_ within the scope of a _message_.
 This local variable can then be used in other _expressions_ within the same _message_.
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -319,7 +319,7 @@ A _key_ can be either a _literal_ value or the catch-all key `*`.
 An **_expression_** is a part of a _message_ that will be determined
 during the _message_'s formatting.
 
-An _expression_ MUST being with a U+007B LEFT CURLY BRACKET `{` 
+An _expression_ MUST begin with a U+007B LEFT CURLY BRACKET `{` 
 and end with a U+007D RIGHT CURLY BRACKET `}`. 
 An _expression_ MUST NOT be empty.
 An _expression_ can contain an _operand_, an _annotation_, or an _operand_ followed by
@@ -488,129 +488,6 @@ reserved-char  = %x00-08        ; omit HTAB and LF
 ```
 
 
-### Patterns
-
-A **_pattern_** is a sequence of translatable elements.
-
-
-```abnf
-pattern = "{" *(text / expression) "}"
-```
-
-> Example:
->
-> ```
-> {Hello, world!}
-> ```
-
-Whitespace within a _pattern_ is meaningful and MUST be preserved.
-
-### Expressions
-
-**_Expressions_** MUST start with an _operand_ or an _annotation_.
-An _expression_ MUST NOT be empty.
-
-An **_operand_** is either a _literal_ or a _variable_.
-An _operand_ MAY be optionally followed by an _annotation_.
-
-An **_annotation_** consists of a _function_ and its named _options_,
-or consists of a _reserved_ sequence.
-
-_Functions_ do not accept any positional arguments
-other than the _operand_ in front of them.
-
-_Functions_ use one of the following prefix sigils:
-
-- `:` for standalone content
-- `+` for starting or opening _expressions_
-- `-` for ending or closing _expressions_
-
-```abnf
-expression = "{" [s] ((operand [s annotation]) / annotation) [s] "}"
-operand = literal / variable
-annotation = (function *(s option)) / reserved
-option = name [s] "=" [s] (literal / variable)
-```
-
-> Expression examples:
->
-> ```
-> {1.23}
-> ```
->
-> ```
-> {|-1.23|}
-> ```
->
-> ```
-> {1.23 :number maxFractionDigits=1}
-> ```
->
-> ```
-> {|Thu Jan 01 1970 14:37:00 GMT+0100 (CET)| :datetime weekday=long}
-> ```
->
-> ```
-> {|My Brand Name| :linkify href=|foobar.com|}
-> ```
->
-> ```
-> {$when :datetime month=2-digit}
-> ```
->
-> ```
-> {:message id=some_other_message}
-> ```
->
-> ```
-> {+ssml.emphasis level=strong}
-> ```
->
-> Message examples:
->
-> ```
-> {This is {+b}bold{-b}.}
-> ```
->
-> ```
-> {{+h1 name=above-and-beyond}Above And Beyond{-h1}}
-> ```
-
-#### Reserved
-
-**_Reserved_** annotations start with a reserved character
-and are intended for future standardization
-as well as private implementation use.
-A _reserved_ _annotation_ MAY be empty or contain arbitrary text.
-This allows maximum flexibility in future standardization,
-as future definitions are expected to define additional semantics and constraints
-on the contents of these _annotations_.
-A _reserved_ _annotation_ does not include trailing whitespace.
-
-Implementations MAY define their own meaning and semantics for
-_reserved_ annotations that start with
-the U+0026 AMPERSAND `&` or U+005E CIRCUMFLEX ACCENT `^` characters.
-Implementations MUST NOT assign meaning or semantics to
-an _annotation_ starting with `reserved-start`:
-these are reserved for future standardization.
-Implementations MUST NOT remove or alter the contents of a _reserved_ _annotation_.
-
-While a reserved sequence is technically "well-formed",
-unrecognized reserved sequences have no meaning and MAY result in errors during formatting.
-
-```abnf
-reserved       = ( reserved-start / private-start ) reserved-body
-reserved-start = "!" / "@" / "#" / "%" / "*" / "<" / ">" / "/" / "?" / "~"
-private-start  = "^" / "&"
-reserved-body  = *( [s] 1*(reserved-char / reserved-escape / literal))
-reserved-char  = %x00-08        ; omit HTAB and LF
-               / %x0B-0C        ; omit CR
-               / %x0E-19        ; omit SP
-               / %x21-5B        ; omit \
-               / %x5D-7A        ; omit { | }
-               / %x7E-D7FF      ; omit surrogates
-               / %xE000-10FFFF
-```
 
 ### Keywords
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -218,25 +218,26 @@ text-char = %x0-5B         ; omit \
 A **_placeholder_** is another word for an _expression_ that appears inside of a _pattern_
 and which will be replaced during the formatting of the _message_.
 
-### Selector
+### Matcher
 
-A **_selector_** selects a specific _pattern_ from a list of available
+A **_matcher_** is a _message_ _body_ that allows the _pattern_ to vary
+in content or form depending on values determined at runtime.
+A _matcher_ selects a specific _pattern_ from a list of available
 _variants_ in a _message_.
-_Selectors_ provide the ability for a _message_ to use a _pattern_ that 
-varies in content or form depending on values determined at runtime.
 
-A _selector_ consists of a _match_ statement followed by at least one _variant_.
+A _matcher_ consists of the keyword `match` followed by at least one _selector_ and
+at least one _variant_.
 
-When the _selector_ is processed, the result will be a single _pattern_ that serves
+When the _matcher_ is processed, the result will be a single _pattern_ that serves
 as the template for the formatting process.
 
 A _message_ can only be considered _well-formed_ if the following requirements are satisfied:
 
-*   The number of _keys_ on each _variant_ MUST be equal to the number of _expressions_ in the _match statement_.
+*   The number of _keys_ on each _variant_ MUST be equal to the number of _selectors_.
 *   At least one _variant_'s MUST exist whose _keys_ are all equal to the catch-all key (`*`).
 
 ```abnf
-selector = match_statment 1*(variant)
+matcher = match 1*(selector) 1*(variant)
 ```
 
 >A _message_ containing a _selector_:
@@ -254,24 +255,23 @@ selector = match_statment 1*(variant)
 >```
 
 
-### Match Statement
+### Selector
 
-A **_match statement_** is the portion of a _selector_ that
+
+A **_selector_** is an _expression_ that
 determines how a given _message_ will select the most appropriate _pattern_.
 
-The _match_ consists of the keyword `match` followed by a list of one or more
-_expressions_.
-There MUST be at least one _expression_.
-There MAY be any number of additional _expressions_.
-An _implementation_ MAY limit the total number of _expressions_: when it does so 
-it MUST support at least 5 _expressions_ to be considered conformant.
-Limiting the number of _expressions_ is NOT RECOMMENDED.
+There MUST be at least one _selector_ in a _matcher_.
+There MAY be any number of additional _selectors_.
+An _implementation_ MAY limit the total number of _selectors_: when it does so 
+it MUST support at least 5 _selectors_ to be considered conformant.
+Limiting the number of _selectors_ is NOT RECOMMENDED.
 
 ```abnf
-match_statement = match 1*([s] expression)
+selector = expression
 ```
 
->A _match statement_ with a single _expression_ that uses a custom `:hasCase` _function_
+>A _matcher_ with a single _selector_ that uses a custom `:hasCase` _function_
 >which allows the _selector_ to choose a _pattern_ based on grammatical case:
 >
 >```
@@ -281,7 +281,7 @@ match_statement = match 1*([s] expression)
 >when * {Hello!}
 >```
 
->A _match statement with two _expressions_:
+>A _matcher_ with two _selectors_:
 >
 >```
 >match {$photoCount :number} {$userGender :equals}
@@ -298,9 +298,9 @@ match_statement = match 1*([s] expression)
 A **_variant_** is a _pattern_ associated with a set of _keys_. 
 Each _variant_ MUST begin with the keyword `when`, be followed by a sequence of _keys_,
 and terminate with a valid _pattern_. 
-The key `*` is a "catch-all" key, matching all values from an _expression_.
-The number of _keys_ in the _variant_ MUST match the number of _expressions_ in the 
-_match statement_.
+The key `*` is a "catch-all" key, matching all values from a _selector_.
+The number of _keys_ in the _variant_ MUST match the number of _selectors_ in the 
+_matcher_.
 
 ```abnf
 variant = when 1*(s key) [s] pattern


### PR DESCRIPTION
In my effort to make the formatting correct, I found that the spec was repetitious and somewhat difficult to read. Here is a prototype refactor for early review.

This makes some normative changes, particularly it splits up `selectors` into named parts. 

Some sections could stand to be sub-sections. Have a look at it (preview it in the branch `aphillips-syntax-refactor` if that helps) and see if this is worth bringing to the larger group.

Note: the TOC has not been updated, so ignore it.

