### PR TITLE
Simplify MatchSelectorKeys() arguments

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -297,21 +297,28 @@ Next, using `res`, resolve the preferential order for all message keys:
 
 1. Let `pref` be a new empty list of lists of strings.
 1. For each index `i` in `res`:
-   1. Let `keys` be a new empty list of strings.
+   1. Let `keys` be a new empty set of strings.
    1. For each _variant_ `var` of the message:
       1. Let `key` be the `var` key at position `i`.
       1. If `key` is not the catch-all key `'*'`:
          1. Assert that `key` is a _literal_.
          1. Let `ks` be the resolved value of `key`.
-         1. Append `ks` as the last element of the list `keys`.
+         1. Add `ks` as to the set `keys`.
+   1. Let `matches` be a new empty list of strings.
    1. Let `rv` be the resolved value at index `i` of `res`.
-   1. Let `matches` be the result of calling the method MatchSelectorKeys(`rv`, `keys`)
+   1. Let `selpref` be the result of calling the method MatchSelectorKeys(`rv`).
+   1. If the call succeeds and `selpref` is a list of strings:
+      1. For each string `ks` of `selpref`:
+         1. If `ks` is in `keys`:
+            1. Append `ks` as the last element of the list `matches`.
+   1. Else:
+      1. Emit a Selection Error.
    1. Append `matches` as the last element of the list `pref`.
 
 The method MatchSelectorKeys is determined by the implementation.
-It takes as arguments a resolved _selector_ value `rv` and a list of string keys `keys`,
+It takes as an argument a resolved _selector_ value `rv`,
 and returns a list of string keys in preferential order.
-The returned list MUST contain only unique elements of the input list `keys`.
+The returned list MUST contain only unique elements.
 The returned list MAY be empty.
 The most-preferred key is first,
 with each successive key appearing in order by decreasing preference.


### PR DESCRIPTION
I think we can simplify our requirements for selector implementations a bit without changing how we actually do selection.

At the moment, with `MatchSelectorKeys(rv, keys)` a selector needs to answer the question, "Given the resolved selector expression `rv` and this list of `keys`, filter _and_ sort them into your preferred order."

My proposal is to drop the second argument, and with `MatchSelectorKeys(rv)` ask instead, "Given the resolved selector expression `rv`, give your preferred order of keys."

The difference here is that if we leave the `keys` out, we may apply the filtering part within the MF2 implementation with no loss of expressivity, while decreasing the burden on custom selector implementors.

For example, with an English plural selection on the value 1 I would expect for the method to return
```
['1', 'one', 'other']
```
while for the value 2 it would return
```
['2', 'other']
```

For a custom `:device-category` selector, the response could be something like
```
['phone', 'portable', 'electronics']
```

Removing the `keys` argument would also ensure that a selector cannot alter its behaviour depending on the keys. This is currently possible, allowing for something like
```
match {$count :maybe-plural}
when one {The one}
when * {Not one}
```
to duck-type its variant keys and match the input `1` with the key `one`, while in a message
```
match {$count :maybe-plural}
when one {The one}
when foo {The foo}
when * {The other}
```
the duck-typing would fail, and the selector would not apply plural category selection to its inputs.

I also clarified what happens if calling the user- or implementation-defined function fails, because that was previously missing.