### PR TITLE
 Add details to "Missing Selector Annotation error" section

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -677,8 +677,14 @@ These are divided into the following categories:
     > ```
 
   - A **_Missing Selector Annotation error_** is an error that occurs when the _message_
-    contains a _selector_ that does not directly or indirectly reference
-    an _expression_ with an _annotation_.
+    contains a _selector_ without an _annotation_.
+
+    An implementation MUST NOT emit this error for a _selector_ _expression_
+    that would have an _annotation_
+    if each local _variable_ in it were replaced
+    with the _expression_ of its binding _declaration_,
+    repeating this process until the _expression_
+    contains no local _variable_s.
 
     > Example invalid messages resulting in a _Missing Selector Annotation error_:
     >

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -695,24 +695,8 @@ These are divided into the following categories:
     > when * {Value is not one}
     > ```
     >
-    > Example valid messages that do not result in a _Missing Selector Annotation error_:
-    >
-    >
-    > ```
-    > match {$two :func}
-    > when 1 {Value is one}
-    > when * {Value is not one}
-    > ```
-    >
-    > ```
-    > let $one = {|The one| :func}
-    > let $two = {$one}
-    > match {$two}
-    > when 1 {Value is one}
-    > when * {Value is not one}
-    > ```
-    
-  - **Duplicate Option Name errors** occur when the same _name_ 
+
+- **Duplicate Option Name errors** occur when the same _name_ 
     appears on the left-hand side
     of more than one _option_ in the same _expression_.
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -677,8 +677,8 @@ These are divided into the following categories:
     > ```
 
   - A **_Missing Selector Annotation error_** is an error that occurs when the _message_
-    contains a _selector_ that does not have an _annotation_,
-    or contains a _variable_ that does not directly or indirectly reference a _declaration_ with an _annotation_.
+    contains a _selector_ that does not directly or indirectly reference
+    an _expression_ with an _annotation_.
 
     > Example invalid messages resulting in a _Missing Selector Annotation error_:
     >
@@ -695,6 +695,15 @@ These are divided into the following categories:
     > when * {Value is not one}
     > ```
     >
+    > Example **valid** messages that do _not_ result in a _Missing Selector Annotation error_:
+    >
+    >
+    > ```
+    > match {$two :func}
+    > when 1 {Value is one}
+    > when * {Value is not one}
+    > ```
+    >
     > ```
     > let $one = {|The one| :func}
     > let $two = {$one}
@@ -702,7 +711,10 @@ These are divided into the following categories:
     > when 1 {Value is one}
     > when * {Value is not one}
     > ```
-
+    >
+    > The second message is valid because `$two` refers to the expression `$one`,
+    > and `$one` refers to the expression ` {|The one| :func}`, which has an annotation.
+    
   - **Duplicate Option Name errors** occur when the same _name_ 
     appears on the left-hand side
     of more than one _option_ in the same _expression_.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -695,7 +695,7 @@ These are divided into the following categories:
     > when * {Value is not one}
     > ```
     >
-    > Example **valid** messages that do _not_ result in a _Missing Selector Annotation error_:
+    > Example valid messages that do not result in a _Missing Selector Annotation error_:
     >
     >
     > ```
@@ -711,9 +711,6 @@ These are divided into the following categories:
     > when 1 {Value is one}
     > when * {Value is not one}
     > ```
-    >
-    > The second message is valid because `$two` refers to the expression `$one`,
-    > and `$one` refers to the expression ` {|The one| :func}`, which has an annotation.
     
   - **Duplicate Option Name errors** occur when the same _name_ 
     appears on the left-hand side


### PR DESCRIPTION
I found this text to be confusing: "...or contains a _variable_ that does not directly or indirectly reference a _declaration_ with an _annotation_". Read literally, this implies _all_ variables must be annotated or indirectly reference expressions that have annotations. I tried to clarify that this only refers to variables used in a selector context.

Also, one of the "invalid" examples was actually valid, according to the "directly or indirectly" rule, because `$two` indirectly refers to `{|The one| : func}`, which has an annotation. I added a "valid examples" section since I wasn't sure how else to explain the rule about indirect references.