### PR TITLE
Do not use variable rule within declaration

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -1,6 +1,6 @@
 message = [s] *(declaration [s]) body [s]
 
-declaration = let s variable [s] "=" [s] expression
+declaration = let s "$" name [s] "=" [s] expression
 body = pattern
      / (selectors 1*([s] variant))
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -127,12 +127,12 @@ A _message_ consists of two parts:
 
 ### Declarations
 
-A **_<dfn>declaration</dfn>_** binds a _variable_ identifier to the value of an _expression_ within the scope of a _message_.
-This local variable can then be used in other _expressions_ within the same _message_.
+A **_<dfn>declaration</dfn>_** binds a _name_ to the value of an _expression_ within the scope of a _message_.
+This _name_ can then be used in _variables_ within the same _message_.
 _Declarations_ are optional: many messages will not contain any _declarations_.
 
 ```abnf
-declaration = let s variable [s] "=" [s] expression
+declaration = let s "$" name [s] "=" [s] expression
 ```
 
 ### Body


### PR DESCRIPTION
This applies the suggestion I originally made in https://github.com/unicode-org/message-format-wg/pull/412#issuecomment-1623281789, i.e. changes the declaration rule to be:
```abnf
declaration = let s "$" name [s] "=" [s] expression
```

This makes it a bit clearer that a _variable_ is always a reference to something, rather than doing double duty as also the target of a `let` statement.

The _declaration_ text is correspondingly modified and updated to properly refer to relevant definitions. I've intentionally kept the language very close to its current shape in order to not inveigle this in the larger ongoing discussions about variable shadowing and namespacing.

Ping @catamorphism, whom I apparently can't add as a reviewer.