### PR TITLE
Specification refactor "v2"

### DIFF
--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -151,7 +151,7 @@ A **_declaration_** binds a _variable_ identifier to the value of an _expression
 This local variable can then be used in other _expressions_ within the same _message_.
 _Declarations_ are optional: many messages will not contain any _declarations_.
 
-```
+```abnf
 declaration = let s variable [s] "=" [s] expression
 ```
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -264,7 +264,7 @@ matcher = match 1*(selector) 1*(variant)
 ### Selector
 
 A **_selector_** is an _expression_ that ranks or excludes the
- _keys_ from the available _variants_ in a _message_.
+_variants_ based on the value of its corresponding _key_ in each _variant_.
 The combination of _selectors_ in a _matcher_ thus determines 
 which _pattern_ will be used during formatting.
 
@@ -305,8 +305,8 @@ be followed by a sequence of _keys_,
 and terminate with a valid _pattern_.
 The number of _keys_ in each _variant_ MUST match the number of _selectors_ in the _matcher_.
 
-_Keys_ are separated from the keyword `when` and from each other by whitespace.
-Whitespace is not required between the last _key_ and the _pattern_.
+Each _key_ is separated from the keyword `when` and from each other by whitespace.
+Whitespace is permitted but not required between the last _key_ and the _pattern_.
 
 ```abnf
 variant = when 1*(s key) [s] pattern
@@ -322,7 +322,7 @@ A _key_ can be either a _literal_ value or the "catch-all" key `*`.
 The **_catch-all key_** is a special key, represented by `*`,
 that matches all values for a given _selector_.
 
-### Expression
+## Expressions
 
 An **_expression_** is a part of a _message_ that will be determined
 during the _message_'s formatting.
@@ -335,14 +335,35 @@ an _annotation_,
 or an _operand_ followed by an _annotation_;
 or it can consist of a _private-use_ or _reserved_ sequence.
 
-A _selector_ or a _placeholder_ are both _expressions_.
-The value portion of a _declaration_ is also an expression.
-
 ```abnf
 expression = "{" [s] ((operand [s annotation]) / annotation) [s] "}"
 operand = literal / variable
 annotation = (function *(s option)) / private-use / reserved
 ```
+
+There are several types of _expression_ that can appear in a _message_.
+All _expressions_ share a common syntax. The types of _expression_ are:
+1. The value of a _declaration_
+2. A _selector_
+3. A _placeholder_ in a _pattern_
+
+> Examples of different types of _expression_
+>
+> Declarations:
+> ```
+> let $x = {|This is an expression|}
+> let $y = {$operand :function option=operand}
+> ```
+> Selectors:
+> ```
+> match {$selector :functionRequired}
+> ```
+> Placeholders:
+> ```
+> {This contains an {|expression|}}
+> {This references an {$operand}}
+> {This expression calls a {$operand :function with=options}}
+> ```
 
 ### Operand
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -423,8 +423,8 @@ No other positional arguments are possible.
 _Functions_ can be _standalone_, or can be an _opening element_ or _closing element_.
 
 A **_<dfn>standalone</dfn>_** _function_ is not expected to be paired with another _function_.
-An **_<dfn>opening element</dfn>_** is a _function_ that SHOULD be paired with a _closing function_.
-A **_<dfn>closing element</dfn>_** is a _function_ that SHOULD be paired with an _opening function_.
+An **_<dfn>opening element</dfn>_** is a _function_ that SHOULD be paired with a _closing element_.
+A **_<dfn>closing element</dfn>_** is a _function_ that SHOULD be paired with an _opening element_.
 
 An _opening element_ MAY be present in a message without a corresponding _closing element_,
 and vice versa.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -451,7 +451,8 @@ _Options_ are not required.
 
 ##### Options
 
-An **_<dfn>option</dfn>_** is a key-value pair containing arguments passed to a _function_.
+An **_<dfn>option</dfn>_** is a key-value pair
+containing a named argument that is passed to a _function_.
 
 An _option_ has a _name_ and a _value_.
 The _name_ is separated from the _value_ by an U+003D EQUALS SIGN `=` along with

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -653,8 +653,8 @@ name-char  = name-start / DIGIT / "-" / "." / ":"
 
 > **Note**
 > _External variables_ can be passed in that are not valid _names_.
-> Such variables cannot be referenced in a _message_, but are not otherwise
-> errors.
+> Such variables cannot be referenced in a _message_,
+> but are not otherwise errors.
 
 ### Escape Sequences
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -21,13 +21,14 @@
    1. [Operand](#operand)
    2. [Annotation](#annotation)
    3. [Function](#function)
+      1. [Options](#options)
       1. [Private-Use](#private-use)
       2. [Reserved](#reserved)
-   4. [Keywords](#keywords)
-   5. [Literals](#literals)
-   6. [Names](#names)
-   7. [Escape Sequences](#escape-sequences)
-   8. [Whitespace](#whitespace)
+   5. [Keywords](#keywords)
+   6. [Literals](#literals)
+   7. [Names](#names)
+   8. [Escape Sequences](#escape-sequences)
+   9. [Whitespace](#whitespace)
 1. [Complete ABNF](#complete-abnf)
 
 ### Introduction
@@ -418,6 +419,26 @@ See [function registry](./) for more information.
 A _function_ MAY accept an _operand_.
 No other positional arguments are possible.
 
+_Functions_ can be _standalone_, or can be an _opening element_ or _closing element_.
+
+A **_<dfn>standalone</dfn>_** _function_ is not expected to be paired with another _function_.
+An **_<dfn>opening element</dfn>_** is a _function_ that SHOULD be paired with a _closing function_.
+A **_<dfn>closing element</dfn>_** is a _function_ that SHOULD be paired with an _opening function_.
+
+An _opening element_ MAY be present in a message without a corresponding _closing element_,
+and vice versa.
+
+>A _message_ with a _standalone_ _function_ operating on the _variable_ `$now`:
+>```
+>{{$now :datetime}}
+>```
+>A _message_ with two markup-like _functions_, `button` and `link`,
+>which the runtime can use to construct a document tree structure for a UI framework:
+>
+>```
+>{{+button}Submit{-button} or {+link}cancel{-link}.}
+>```
+
 A _function_ consists of a prefix sigil followed by a _name_.
 The following sigils are used for _functions_:
 - `:` for a _standalone_ function
@@ -427,7 +448,25 @@ The following sigils are used for _functions_:
 A _function_ MAY be followed by one or more _options_.
 _Options_ are not required.
 
->For example, a _message_ with a `$date` _variable_ formatted with the `:datetime` _function_:
+#### Options
+
+An **_<dfn>option</dfn>_** is a key-value pair containing arguments passed to a _function_.
+
+An _option_ has a _name_ and a _value_.
+The _name_ is separated from the _value_ by an U+003D EQUALS SIGN `=` along with
+optional whitespace.
+The value of an _option_ can be either a _literal_ or a _variable_.
+
+Multiple _options_ are permitted in an _annotation_.
+Each _option_ is separated by whitespace.
+
+```abnf
+option = name [s] "=" [s] (literal / variable)
+```
+
+> Examples of _functions_ with _options_
+>
+> A _message_ with a `$date` _variable_ formatted with the `:datetime` _function_:
 >
 >```
 >{Today is {$date :datetime weekday=long}.}
@@ -449,21 +488,6 @@ _Options_ are not required.
 >{Hello, {$userObj :person firstName=long}!}
 >```
 
-_Functions_ can be _standalone_, or can be an _opening element_ or _closing element_.
-
-A **_<dfn>standalone</dfn>_** _function_ is not expected to be paired with another _function_.
-An **_<dfn>opening element</dfn>_** is a _function_ that SHOULD be paired with a _closing function_.
-A **_<dfn>closing element</dfn>_** is a _function_ that SHOULD be paired with an _opening function_.
-
-An _opening element_ MAY be present in a message without a corresponding _closing element_,
-and vice versa.
-
->A message with two markup-like _functions_, `button` and `link`,
->which the runtime can use to construct a document tree structure for a UI framework:
->
->```
->{{+button}Submit{-button} or {+link}cancel{-link}.}
->```
 
 #### Private-Use
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -110,14 +110,14 @@ The complete formal syntax of a _message_ is described by the [ABNF](./message.a
 
 ### Well-formed vs. Valid Messages
 
-A _message_ is **_well-formed_** if it satisfies all the rules of the grammar.
+A _message_ is **_<dfn>well-formed</dfn>_** if it satisfies all the rules of the grammar.
 
-A _message_ is **_valid_** if it is _well-formed_ and **also** meets the additional content restrictions
+A _message_ is **_<dfn>valid</dfn>_** if it is _well-formed_ and **also** meets the additional content restrictions
 and semantic requirements about its structure defined below.
 
 ## The Message
 
-A <dfn>**_message_**</dfn> is the complete template for a specific message formatting request.
+A **_<dfn>message</dfn>_** is the complete template for a specific message formatting request.
 
 > **Note**
 > This syntax is designed to be embeddable into many different programming languages and formats.
@@ -147,7 +147,7 @@ A _message_ consists of two parts:
 
 ### Declarations
 
-A **_declaration_** binds a _variable_ identifier to the value of an _expression_ within the scope of a _message_.
+A **_<dfn>declaration</dfn>_** binds a _variable_ identifier to the value of an _expression_ within the scope of a _message_.
 This local variable can then be used in other _expressions_ within the same _message_.
 _Declarations_ are optional: many messages will not contain any _declarations_.
 
@@ -157,7 +157,7 @@ declaration = let s variable [s] "=" [s] expression
 
 ### Body
 
-The **_body_** of a _message_ is the part that will be formatted.
+The **_body</dfn>_** of a _message_ is the part that will be formatted.
 The _body_ consists of either a _pattern_ or a _matcher_.
 
 ```abnf
@@ -185,7 +185,7 @@ An empty string is not a _well-formed_ _message_.
 
 ## Pattern
 
-A **_pattern_** contains a sequence of _text_ and _placeholders_ to be formatted as a unit.
+A **_<dfn>pattern</dfn>_** contains a sequence of _text_ and _placeholders_ to be formatted as a unit.
 All _patterns_ begin with U+007B LEFT CURLY BRACKET `{` and end with U+007D RIGHT CURLY BRACKET `}`.
 Unless there is an error, resolving a _message_ always results in the formatting
 of a single _pattern_.
@@ -206,7 +206,7 @@ during the formatting process.
 
 ### Text
 
-**_text_** is the translateable content of a _pattern_.
+**_<dfn>text</dfn>_** is the translateable content of a _pattern_.
 Any Unicode code point is allowed, except for surrogate code points U+D800
 through U+DFFF inclusive.
 The characters `\`, `{`, and `}` MUST be escaped as `\\`, `\{`, and `\}`
@@ -237,7 +237,7 @@ text-char = %x0-5B         ; omit \
 
 ### Placeholder
 
-A **_placeholder_** is an _expression_ that appears inside of a _pattern_
+A **_<dfn>placeholder</dfn>_** is an _expression_ that appears inside of a _pattern_
 and which will be replaced during the formatting of a _message_.
 
 ```abnf
@@ -246,7 +246,7 @@ placeholder = expression
 
 ## Matcher
 
-A **_matcher_** is the _body_ of a _message_ that allows runtime selection
+A **_<dfn>matcher</dfn>_** is the _body_ of a _message_ that allows runtime selection
 of the _pattern_ to use for formatting.
 This allows the form or content of a _message_ to vary based on values
 determined at runtime.
@@ -280,7 +280,7 @@ matcher = match 1*(selector) 1*(variant)
 
 ### Selector
 
-A **_selector_** is an _expression_ that ranks or excludes the
+A **_<dfn>selector</dfn>_** is an _expression_ that ranks or excludes the
 _variants_ based on the value of its corresponding _key_ in each _variant_.
 The combination of _selectors_ in a _matcher_ thus determines 
 which _pattern_ will be used during formatting.
@@ -316,7 +316,7 @@ There MAY be any number of additional _selectors_.
 
 ### Variant
 
-A **_variant_** is a _pattern_ associated with a set of _keys_ in a _matcher_.
+A **_<dfn>variant</dfn>_** is a _pattern_ associated with a set of _keys_ in a _matcher_.
 Each _variant_ MUST begin with the keyword `when`,
 be followed by a sequence of _keys_,
 and terminate with a valid _pattern_.
@@ -332,16 +332,16 @@ key = literal / "*"
 
 #### Key
 
-A **_key_** is a value in a _variant_ for use by a _selector_ when ranking
+A **_<dfn>key</dfn>_** is a value in a _variant_ for use by a _selector_ when ranking
 or excluding _variants_ during the _matcher_ process. 
 A _key_ can be either a _literal_ value or the "catch-all" key `*`.
 
-The **_catch-all key_** is a special key, represented by `*`,
+The **_<dfn>catch-all key</dfn>_** is a special key, represented by `*`,
 that matches all values for a given _selector_.
 
 ## Expressions
 
-An **_expression_** is a part of a _message_ that will be determined
+An **_<dfn>expression</dfn>_** is a part of a _message_ that will be determined
 during the _message_'s formatting.
 
 An _expression_ MUST begin with U+007B LEFT CURLY BRACKET `{` 
@@ -383,7 +383,7 @@ All _expressions_ share a common syntax. The types of _expression_ are:
 
 ### Operand
 
-An **_operand_** is a _literal_ or a _variable_ to be evaluated in an _expression_.
+An **_<dfn>operand</dfn>_** is a _literal_ or a _variable_ to be evaluated in an _expression_.
 An _operand_ MAY optionally be followed by an _annotation_.
 
 ```abnf
@@ -392,7 +392,7 @@ operand    = literal / variable
 
 ### Annotation
 
-An **_annotation_** is part of an _expression_ containing either 
+An **_<dfn>annotation</dfn>_** is part of an _expression_ containing either 
 a _function_ together with its associated _options_, or
 a _private-use_ or _reserved_ sequence.
 
@@ -402,7 +402,7 @@ annotation = (function *(s option)) / reserved / private-use
 
 ### Function
 
-A **_function_** is a used to evaluate, format, select, or otherwise process an _operand_,
+A **_<dfn>function</dfn>_** is a used to evaluate, format, select, or otherwise process an _operand_,
 or, if lacking an _operand_, its _options_.
 A _function_ accepts only an _operand_ as a positional argument.
 
@@ -439,9 +439,9 @@ _Options_ are not required.
 
 _Functions_ can be _standalone_, or can be an _opening element_ or _closing element_.
 
-A **_standalone_** _function_ is not expected to be paired with another _function_.
-An **_opening element_** is a _function_ that SHOULD be paired with a _closing function_.
-A **_closing element_** is a _function_ that SHOULD be paired with an _opening function_.
+A **_<dfn>standalone</dfn>_** _function_ is not expected to be paired with another _function_.
+An **_<dfn>opening element</dfn>_** is a _function_ that SHOULD be paired with a _closing function_.
+A **_<dfn>closing element</dfn>_** is a _function_ that SHOULD be paired with an _opening function_.
 
 An _opening element_ MAY be present in a message without a corresponding _closing element_,
 and vice versa.
@@ -455,7 +455,7 @@ and vice versa.
 
 #### Private-Use
 
-A **_private-use_** _annotation_ is an _annotation_ whose syntax is reserved
+A **_<dfn>private-use</dfn>_** _annotation_ is an _annotation_ whose syntax is reserved
 for use by a specific implementation or by private agreement between multiple implementations. 
 Implementations MAY define their own meaning and semantics for _private-use_ annotations.
 
@@ -495,7 +495,7 @@ private-start = "&" / "^"
 
 #### Reserved
 
-A **_reserved_** _annotation_ is an _annotation_ whose syntax is reserved
+A **_<dfn>reserved</dfn>_** _annotation_ is an _annotation_ whose syntax is reserved
 for future standardization.
 
 A _reserved_ _annotation_ starts with a reserved character.
@@ -531,7 +531,7 @@ reserved-char  = %x00-08        ; omit HTAB and LF
 
 ### Keywords
 
-A **_keyword_** is a reserved token that has a unique meaning in the _message_ syntax.
+A **_<dfn>keyword</dfn>_** is a reserved token that has a unique meaning in the _message_ syntax.
 
 The following three keywords are reserved: `let`, `match`, and `when`.
 Reserved keywords are always lowercase.
@@ -544,7 +544,7 @@ when  = %x77.68.65.6E     ; "when"
 
 ### Literals
 
-A **_literal_** is a character sequence that appears outside
+A **_<dfn>literal</dfn>_** is a character sequence that appears outside
 of _text_ in various parts of a _message_.
 A _literal_ can appear in a _declaration_, 
 as a _key_ value,
@@ -555,11 +555,11 @@ except for surrogate code points U+D800 through U+DFFF.
 
 All code points are preserved.
 
-A **_quoted_** literal begins and ends with U+005E VERTICAL BAR `|`.
+A **_<dfn>quoted</dfn>_** literal begins and ends with U+005E VERTICAL BAR `|`.
 The characters `\` and `|` within a _quoted_ literal MUST be 
 escaped as `\\` and `\|`.
 
-An **_unquoted_** literal is a _literal_ that does not require the `|`
+An **_<dfn>unquoted</dfn>_** literal is a _literal_ that does not require the `|`
 quotes around it to be distinct from the rest of the _message_ syntax.
 An _unquoted_ MAY be used when the content of the _literal_
 contains no whitespace and otherwise matches the `unquoted` production.
@@ -588,7 +588,7 @@ unquoted-start = name-start / DIGIT / "."
 
 ### Names
 
-A <dfn>**_name_**</dfn> is an identifier for a _variable_ (prefixed with `$`),
+A **_<dfn>name</dfn>_**</dfn> is an identifier for a _variable_ (prefixed with `$`),
 for a _function_ (prefixed with `:`, `+` or `-`),
 or for an _option_ (these have no prefix).
 The namespace for _names_ is based on XML's [Name](https://www.w3.org/TR/xml/#NT-Name),
@@ -615,7 +615,7 @@ name-char  = name-start / DIGIT / "-" / "." / ":"
 
 ### Escape Sequences
 
-An **_escape sequence_** is a two-character sequence starting with
+An **_<dfn>escape sequence</dfn>_** is a two-character sequence starting with
 U+005C REVERSE SOLIDUS `\`.
 
 An _escape sequence_ allows the appearance of lexically meaningful characters
@@ -631,7 +631,7 @@ backslash      = %x5C ; U+005C REVERSE SOLIDUS "\"
 
 ### Whitespace
 
-**_Whitespace_** is defined as tab, carriage return, line feed, or the space character.
+**_<dfn>Whitespace</dfn>_** is defined as tab, carriage return, line feed, or the space character.
 
 Inside _patterns_ and _quoted literals_,
 whitespace is part of the content and is recorded and stored verbatim.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -259,8 +259,8 @@ as the template for the formatting process.
 
 A _message_ can only be considered _valid_ if the following requirements are
 satisfied:
-* The number of _keys_ on each _variant_ MUST be equal to the number of _selectors_.
-* At least one _variant_ MUST exist whose _keys_ are all equal to the "catch-all" key `*`.
+- The number of _keys_ on each _variant_ MUST be equal to the number of _selectors_.
+- At least one _variant_ MUST exist whose _keys_ are all equal to the "catch-all" key `*`.
 
 ```abnf
 matcher = match 1*(selector) 1*(variant)
@@ -408,9 +408,9 @@ A _function_ accepts only an _operand_ as a positional argument.
 
 A _function_ consists of a prefix sigil followed by a _name_.
 The following sigils are used for _functions_:
-* `:` for standalone content
-* `+` for starting or opening _expressions_
-* `-` for ending or closing _expressions_
+- `:` for standalone content
+- `+` for starting or opening _expressions_
+- `-` for ending or closing _expressions_
 
 A _function_ MAY be followed by one or more _options_.
 _Options_ are not required.
@@ -465,9 +465,9 @@ Characters, including whitespace, are assigned meaning by the implementation.
 The definition of escapes in the `reserved-body` production, used for the body of
 a _private-use_ annotation is an affordance to implementations that 
 wish to use a syntax exactly like other functions. Specifically:
-* The characters `\`, `{`, and `}` MUST be escaped as `\\`, `\{`, and `\}` respectively
+- The characters `\`, `{`, and `}` MUST be escaped as `\\`, `\{`, and `\}` respectively
 when they appear in the body of a _private-use_ annotation. 
-* The character `|` is special: it SHOULD be escaped as `\|` in a _private-use_ annotation,
+- The character `|` is special: it SHOULD be escaped as `\|` in a _private-use_ annotation,
 but can appear unescaped as long as it is paired with another `|`. This is an affordance to
 allow _literals_ to appear in the private use syntax.
 
@@ -648,36 +648,6 @@ using the ABNF notation,
 as specified by [RFC 5234](https://datatracker.ietf.org/doc/html/rfc5234).
 
 
-
-### Complex Messages
-
-The various features can be used to produce arbitrarily complex _messages_ by combining
-_declarations_, _selectors_, _functions_, and more.
-
->A complex message with 2 _selectors_ and 3 local variable _declarations_:
->
->```
->let $hostName = {$host :person firstName=long}
->let $guestName = {$guest :person firstName=long}
->let $guestsOther = {$guestCount :number offset=1}
->
->match {$host :gender} {$guestOther :number}
->
->when female 0 {{$hostName} does not give a party.}
->when female 1 {{$hostName} invites {$guestName} to her party.}
->when female 2 {{$hostName} invites {$guestName} and one other person to her party.}
->when female * {{$hostName} invites {$guestName} and {$guestsOther} other people to her party.}
->
->when male 0 {{$hostName} does not give a party.}
->when male 1 {{$hostName} invites {$guestName} to his party.}
->when male 2 {{$hostName} invites {$guestName} and one other person to his party.}
->when male * {{$hostName} invites {$guestName} and {$guestsOther} other people to his party.}
->
->when * 0 {{$hostName} does not give a party.}
->when * 1 {{$hostName} invites {$guestName} to their party.}
->when * 2 {{$hostName} invites {$guestName} and one other person to their party.}
->when * * {{$hostName} invites {$guestName} and {$guestsOther} other people to their party.}
->```
 
 
 > Expression examples:

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -349,8 +349,7 @@ and end with U+007D RIGHT CURLY BRACKET `}`.
 An _expression_ MUST NOT be empty.
 An _expression_ can contain an _operand_, 
 an _annotation_, 
-or an _operand_ followed by an _annotation_;
-or it can consist of a _private-use_ or _reserved_ sequence.
+or an _operand_ followed by an _annotation_.
 
 ```abnf
 expression = "{" [s] ((operand [s annotation]) / annotation) [s] "}"

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -25,11 +25,11 @@
       2. [Private-Use](#private-use)
       3. [Reserved](#reserved)
 1. [Other Syntax Elements](#other-syntax-elements)
-   6. [Keywords](#keywords)
-   7. [Literals](#literals)
-   8. [Names](#names)
-   9. [Escape Sequences](#escape-sequences)
-   10. [Whitespace](#whitespace)
+   1. [Keywords](#keywords)
+   1. [Literals](#literals)
+   1. [Names](#names)
+   1. [Escape Sequences](#escape-sequences)
+   1. [Whitespace](#whitespace)
 1. [Complete ABNF](#complete-abnf)
 
 ### Introduction

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -88,7 +88,7 @@ The syntax specification takes into account the following design restrictions:
    private-use code points (U+E000 through U+F8FF, U+F0000 through U+FFFFD, and
    U+100000 through U+10FFFD), unassigned code points, and other potentially confusing content.
 
-## Core Concepts
+## Messages and their Syntax
 
 The purpose of MessageFormat is the allow content to vary at runtime.
 This variation might be due to placing a value into the content
@@ -102,25 +102,22 @@ to select between different content items) are called _external variables_.
 The author of a _message_ can also assign _local variables_, including
 variables that modify _external variables_.
 
-Values are operated on using _functions_.
-_Functions_ described by the function registry. 
-Some functions are used for _formatting_, that is, preparing a data value for display.
-Other functions are used for _selection_, that is, choosing between different 
-content items.
-Some functions can be used for both.
+This part of the MessageFormat specification defines the syntax for a _message_,
+along with the concepts and terminology needed when processing a _message_ 
+during the [formatting](./formatting.md) of a _message_ at runtime.
 
+The complete formal syntax of a _message_ is described by the [ABNF](./message.abnf).
 
+### Well-formed vs. Valid Messages
 
+A _message_ is **_well-formed_** if it satisfies all the rules of the grammar.
 
+A _message_ is **_valid_** if it is _well-formed_ and **also** meets the additional content restrictions
+and semantic requirements about its structure defined below.
 
+## The Message
 
-## Messages and their Syntax
-
-### Messages
-
-A **_message_** is the complete template for a specific message formatting request.
-
-The complete syntax of a _message_ is described by the ABNF.
+A <dfn>**_message_**</dfn> is the complete template for a specific message formatting request.
 
 > **Note**
 > This syntax is designed to be embeddable into many different programming languages and formats.
@@ -148,6 +145,25 @@ A _message_ consists of two parts:
 1. an optional list of _declarations_, followed by
 2. a _body_
 
+### Declarations
+
+A **_declaration_** binds a _variable_ identifier to the value of an _expression_ within the scope of a _message_.
+This local variable can then be used in other _expressions_ within the same _message_.
+_Declarations_ are optional: many messages will not contain any _declarations_.
+
+```
+declaration = let s variable [s] "=" [s] expression
+```
+
+### Body
+
+The **_body_** of a _message_ is the part that will be formatted.
+The _body_ consists of either a _pattern_ or a _matcher_.
+
+```abnf
+body = pattern / matcher
+```
+
 All _messages_ MUST contain a _body_.
 An empty string is not a _well-formed_ _message_.
 
@@ -166,31 +182,6 @@ An empty string is not a _well-formed_ _message_.
 >let hello = new MessageFormat('{Hello, world!}')
 >hello.format()
 >```
-
-#### Well-formed vs. Valid Messages
-
-A _message_ is **_well-formed_** if it satisfies all the rules of the grammar.
-
-A _message_ is **_valid_** if it is _well-formed_ and **also** meets the additional content restrictions
-and semantic requirements about its structure defined below.
-
-## Declarations
-
-A **_declaration_** binds a _variable_ identifier to the value of an _expression_ within the scope of a _message_.
-This local variable can then be used in other _expressions_ within the same _message_.
-
-```
-declaration = let s variable [s] "=" [s] expression
-```
-
-## Body
-
-The **_body_** of a _message_ is the part that will be formatted.
-The _body_ consists of either a _pattern_ or a _matcher_.
-
-```abnf
-body = pattern / matcher
-```
 
 ## Pattern
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -2,35 +2,7 @@
 
 ## Table of Contents
 
-1. [Introduction](#introduction)
-   1. [Design Goals](#design-goals)
-   2. [Design Restrictions](#design-restrictions)
-1. [Messages and their Syntax](#messages-and-their-syntax)
-   1. [Well-formed vs. Valid Messages](#well-formed-vs-valid-messages)
-1. [The Message](#the-message)
-   1. [Declarations](#declarations)
-   2. [Body](#body)
-1. [Pattern](#pattern)
-   1. [Text](#text)
-   1. [Placeholder](#placeholder)
-1. [Matcher](#matcher)
-   1. [Selector](#selector)
-   2. [Variant](#variant)
-      1. [Key](#key)
-1. [Expressions](#expressions)
-   1. [Operand](#operand)
-   2. [Annotation](#annotation)
-      1. [Function](#function)
-         1. [Options](#options)
-      2. [Private-Use](#private-use)
-      3. [Reserved](#reserved)
-1. [Other Syntax Elements](#other-syntax-elements)
-   1. [Keywords](#keywords)
-   1. [Literals](#literals)
-   1. [Names](#names)
-   1. [Escape Sequences](#escape-sequences)
-   1. [Whitespace](#whitespace)
-1. [Complete ABNF](#complete-abnf)
+\[TBD\]
 
 ### Introduction
 
@@ -402,6 +374,9 @@ a _private-use_ or _reserved_ sequence.
 annotation = (function *(s option)) / reserved / private-use
 ```
 
+An _annotation_ can appear in an _expression_ by itself or following a single _operand_.
+When following an _operand_, the _operand_ serves as input to the _annotation_.
+
 #### Function
 
 A **_<dfn>function</dfn>_** is named functionality in an _annotation_.
@@ -416,9 +391,6 @@ what form the values of an _operand_ can take,
 what _options_ and _option_ values are valid, 
 and what outputs might result. 
 See [function registry](./) for more information.
-
-A _function_ MAY accept an _operand_.
-No other positional arguments are possible.
 
 _Functions_ can be _standalone_, or can be an _opening element_ or _closing element_.
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -567,7 +567,7 @@ reserved-char  = %x00-08        ; omit HTAB and LF
 
 ## Other Syntax Elements
 
-This section defines some of the comment elements used to construct _messages_.
+This section defines common elements used to construct _messages_.
 
 ### Keywords
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -162,6 +162,10 @@ declaration = let s variable [s] "=" [s] expression
 The **_body_** of a _message_ is the part that will be formatted.
 The _body_ consists of either a _pattern_ or a _matcher_.
 
+```abnf
+body = pattern / matcher
+```
+
 ## Pattern
 
 A **_pattern_** is a sequence of _text_ and _placeholders_ to be formatted as a unit.
@@ -241,7 +245,7 @@ satisfied:
 * The number of _keys_ on each _variant_ MUST be equal to the number of _selectors_.
 * At least one _variant_ MUST exist whose _keys_ are all equal to the "catch-all" key `*`.
 
-```
+```abnf
 matcher = match 1*(selector) 1*(variant)
 ```
 
@@ -264,7 +268,7 @@ A **_selector_** is an _expression_ that ranks or excludes the
 The combination of _selectors_ in a _matcher_ thus determines 
 which _pattern_ will be used during formatting.
 
-```
+```abnf
 selector = expression
 ```
 
@@ -302,8 +306,9 @@ and terminate with a valid _pattern_.
 The number of _keys_ in each _variant_ MUST match the number of _selectors_ in the _matcher_.
 
 _Keys_ are separated from the keyword `when` and from each other by whitespace.
+Whitespace is not required between the last _key_ and the _pattern_.
 
-```
+```abnf
 variant = when 1*(s key) [s] pattern
 key = literal / "*"
 ```
@@ -314,9 +319,8 @@ A **_key_** is a value in a _variant_ for use by a _selector_ when ranking
 or excluding _variants_ during the _matcher_ process. 
 A _key_ can be either a _literal_ value or the "catch-all" key `*`.
 
-### Catch-all Key
-
-The **_catch-all key_** is a special key that matches all values for a given _selector_.
+The **_catch-all key_** is a special key, represented by `*`,
+that matches all values for a given _selector_.
 
 ### Expression
 
@@ -328,16 +332,16 @@ and end with U+007D RIGHT CURLY BRACKET `}`.
 An _expression_ MUST NOT be empty.
 An _expression_ can contain an _operand_, 
 an _annotation_, 
-or an _operand_ followed by an _annotation_.
+or an _operand_ followed by an _annotation_;
+or it can consist of a _private-use_ or _reserved_ sequence.
 
-An _expression_ can appear as the value portion of a _declaration_,
-as a _selector_,
-or as a _placeholder_ within a _pattern_.
+A _selector_ or a _placeholder_ are both _expressions_.
+The value portion of a _declaration_ is also an expression.
 
 ```abnf
 expression = "{" [s] ((operand [s annotation]) / annotation) [s] "}"
 operand = literal / variable
-annotation = (function *(s option)) / quoted
+annotation = (function *(s option)) / private-use / reserved
 ```
 
 ### Operand

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -629,7 +629,7 @@ unquoted-start = name-start / DIGIT / "."
 
 ### Names
 
-A **_<dfn>name</dfn>_**</dfn> is an identifier for a _variable_ (prefixed with `$`),
+A **_<dfn>name</dfn>_** is an identifier for a _variable_ (prefixed with `$`),
 for a _function_ (prefixed with `:`, `+` or `-`),
 or for an _option_ (these have no prefix).
 The namespace for _names_ is based on XML's [Name](https://www.w3.org/TR/xml/#NT-Name),

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -88,6 +88,32 @@ The syntax specification takes into account the following design restrictions:
    private-use code points (U+E000 through U+F8FF, U+F0000 through U+FFFFD, and
    U+100000 through U+10FFFD), unassigned code points, and other potentially confusing content.
 
+## Core Concepts
+
+The purpose of MessageFormat is the allow content to vary at runtime.
+This variation might be due to placing a value into the content
+or it might be due to selecting a different bit of content based on some data value
+or it might be due to a combination of the two.
+
+MessageFormat calls the template for a given formatting operation a _message_.
+
+The values passed in at runtime (which are to be place into the content or used
+to select between different content items) are called _external variables_.
+The author of a _message_ can also assign _local variables_, including
+variables that modify _external variables_.
+
+Values are operated on using _functions_.
+_Functions_ described by the function registry. 
+Some functions are used for _formatting_, that is, preparing a data value for display.
+Other functions are used for _selection_, that is, choosing between different 
+content items.
+Some functions can be used for both.
+
+
+
+
+
+
 ## Messages and their Syntax
 
 ### Messages
@@ -360,9 +386,9 @@ All _expressions_ share a common syntax. The types of _expression_ are:
 > ```
 > Placeholders:
 > ```
-> {This contains an {|expression|}}
-> {This references an {$operand}}
-> {This expression calls a {$operand :function with=options}}
+> {This placeholder contains an {|expression with a literal|}}
+> {This placeholder references a {$variable}}
+> {This placeholder references a function on a variable: {$variable :function with=options}}
 > ```
 
 ### Operand

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -24,11 +24,12 @@
          1. [Options](#options)
       2. [Private-Use](#private-use)
       3. [Reserved](#reserved)
-   5. [Keywords](#keywords)
-   6. [Literals](#literals)
-   7. [Names](#names)
-   8. [Escape Sequences](#escape-sequences)
-   9. [Whitespace](#whitespace)
+1. [Other Syntax Elements](#other-syntax-elements)
+   6. [Keywords](#keywords)
+   7. [Literals](#literals)
+   8. [Names](#names)
+   9. [Escape Sequences](#escape-sequences)
+   10. [Whitespace](#whitespace)
 1. [Complete ABNF](#complete-abnf)
 
 ### Introduction
@@ -564,6 +565,9 @@ reserved-char  = %x00-08        ; omit HTAB and LF
                / %xE000-10FFFF
 ```
 
+## Other Syntax Elements
+
+This section defines some of the comment elements used to construct _messages_.
 
 ### Keywords
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -339,7 +339,7 @@ variant = when 1*(s key) [s] pattern
 key = literal / "*"
 ```
 
-## Key
+#### Key
 
 A **_key_** is a value in a _variant_ for use by a _selector_ when ranking
 or excluding _variants_ during the _matcher_ process. 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -185,7 +185,7 @@ An empty string is not a _well-formed_ _message_.
 
 ## Pattern
 
-A **_pattern_** is a sequence of _text_ and _placeholders_ to be formatted as a unit.
+A **_pattern_** contains a sequence of _text_ and _placeholders_ to be formatted as a unit.
 All _patterns_ begin with U+007B LEFT CURLY BRACKET `{` and end with U+007D RIGHT CURLY BRACKET `}`.
 Unless there is an error, resolving a _message_ always results in the formatting
 of a single _pattern_.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -20,10 +20,10 @@
 1. [Expressions](#expressions)
    1. [Operand](#operand)
    2. [Annotation](#annotation)
-   3. [Function](#function)
-      1. [Options](#options)
-      1. [Private-Use](#private-use)
-      2. [Reserved](#reserved)
+      1. [Function](#function)
+         1. [Options](#options)
+      2. [Private-Use](#private-use)
+      3. [Reserved](#reserved)
    5. [Keywords](#keywords)
    6. [Literals](#literals)
    7. [Names](#names)
@@ -401,7 +401,7 @@ a _private-use_ or _reserved_ sequence.
 annotation = (function *(s option)) / reserved / private-use
 ```
 
-### Function
+#### Function
 
 A **_<dfn>function</dfn>_** is named functionality in an _annotation_.
 _Functions_ are used to evaluate, format, select, or otherwise process data
@@ -448,7 +448,7 @@ The following sigils are used for _functions_:
 A _function_ MAY be followed by one or more _options_.
 _Options_ are not required.
 
-#### Options
+##### Options
 
 An **_<dfn>option</dfn>_** is a key-value pair containing arguments passed to a _function_.
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -184,20 +184,8 @@ A _pattern_ MAY be empty.
 > {}
 > ```
 
-A _pattern_ MAY contain an arbitrary number of _expressions_ to be evaluated 
+A _pattern_ MAY contain an arbitrary number of _placeholders_ to be evaluated 
 during the formatting process.
-
-Whitespace in a _pattern_, including tabs, spaces, and newlines is significant and MUST
-be preserved during formatting.
-Embedding a _pattern_ in curly brackets ensures that _messages_ can be embedded into
-various formats regardless of the container's whitespace trimming rules.
-
-> **Example**
-> In a Java `.properties` file, the _message_ `hello` has exactly three spaces
-> before and after the word "Hello":
-> ```properties
-> hello = {   Hello   }
-> ```
 
 ### Text
 
@@ -207,9 +195,21 @@ through U+DFFF inclusive.
 The characters `\`, `{`, and `}` MUST be escaped as `\\`, `\{`, and `\}`
 respectively.
 
-All code points in _text_ are preserved. Whitespace in _text_ is significant.
+Whitespace in _text_, including tabs, spaces, and newlines is significant and MUST
+be preserved during formatting.
+Embedding a _pattern_ in curly brackets ensures that _messages_ can be embedded into
+various formats regardless of the container's whitespace trimming rules.
 
-```
+> **Example**
+> In a Java `.properties` file, the values `hello` and `hello2` both contain
+> an identical _message_ which consists of a single _pattern_.
+> This _pattern_ consists of _text_ with exactly three spaces before and after the word "Hello":
+> ```properties
+> hello = {   Hello   }
+> hello2={   Hello   }
+> ```
+
+```abnf
 text = 1*(text-char / text-escape)
 text-char = %x0-5B         ; omit \
           / %x5D-7A        ; omit {

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -159,7 +159,7 @@ declaration = let s variable [s] "=" [s] expression
 
 ### Body
 
-The **_body</dfn>_** of a _message_ is the part that will be formatted.
+The **_<dfn>body</dfn>_** of a _message_ is the part that will be formatted.
 The _body_ consists of either a _pattern_ or a _matcher_.
 
 ```abnf

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -4,30 +4,30 @@
 
 1. [Introduction](#introduction)
    1. [Design Goals](#design-goals)
-   1. [Design Restrictions](#design-restrictions)
-1. [Overview & Examples](#overview--examples)
-   1. [Messages and Patterns](#messages-and-patterns)
-   1. [Expressions](#expression)
-   1. [Formatting Functions](#function)
-   1. [Selection](#selection)
-   1. [Local Variables](#local-variables)
-   1. [Complex Messages](#complex-messages)
-1. [Productions](#productions)
-   1. [Message](#message)
-   1. [Variable Declarations](#variable-declarations)
-   1. [Selectors](#selectors)
-   1. [Variants](#variants)
-   1. [Patterns](#patterns)
-   1. [Expressions](#expressions)
-      1. [Private-Use Sequences](#private-use)
-      2. [Reserved Sequences](#reserved)
-1. [Tokens](#tokens)
-   1. [Keywords](#keywords)
+   2. [Design Restrictions](#design-restrictions)
+1. [Messages and their Syntax](#messages-and-their-syntax)
+   1. [Well-formed vs. Valid Messages](#well-formed-vs-valid-messages)
+1. [The Message](#the-message)
+   1. [Declarations](#declarations)
+   2. [Body](#body)
+1. [Pattern](#pattern)
    1. [Text](#text)
-   1. [Literals](#literals)
-   1. [Names](#names)
-   1. [Escape Sequences](#escape-sequences)
-   1. [Whitespace](#whitespace)
+   1. [Placeholder](#placeholder)
+1. [Matcher](#matcher)
+   1. [Selector](#selector)
+   2. [Variant](#variant)
+      1. [Key](#key)
+1. [Expressions](#expressions)
+   1. [Operand](#operand)
+   2. [Annotation](#annotation)
+   3. [Function](#function)
+      1. [Private-Use](#private-use)
+      2. [Reserved](#reserved)
+   4. [Keywords](#keywords)
+   5. [Literals](#literals)
+   6. [Names](#names)
+   7. [Escape Sequences](#escape-sequences)
+   8. [Whitespace](#whitespace)
 1. [Complete ABNF](#complete-abnf)
 
 ### Introduction
@@ -402,15 +402,27 @@ annotation = (function *(s option)) / reserved / private-use
 
 ### Function
 
-A **_<dfn>function</dfn>_** is a used to evaluate, format, select, or otherwise process an _operand_,
-or, if lacking an _operand_, its _options_.
-A _function_ accepts only an _operand_ as a positional argument.
+A **_<dfn>function</dfn>_** is named functionality in an _annotation_.
+_Functions_ are used to evaluate, format, select, or otherwise process data
+values during formatting.
+
+Each _function_ is defined by the runtime's _function registry_. 
+A _function_'s entry in the _function registry_ will define 
+whether the _function_ is a _selector_ or formatter (or both),
+whether an _operand_ is required, 
+what form the values of an _operand_ can take,
+what _options_ and _option_ values are valid, 
+and what outputs might result. 
+See [function registry](./) for more information.
+
+A _function_ MAY accept an _operand_.
+No other positional arguments are possible.
 
 A _function_ consists of a prefix sigil followed by a _name_.
 The following sigils are used for _functions_:
-- `:` for standalone content
-- `+` for starting or opening _expressions_
-- `-` for ending or closing _expressions_
+- `:` for a _standalone_ function
+- `+` for an _opening element_
+- `-` for a _closing element_
 
 A _function_ MAY be followed by one or more _options_.
 _Options_ are not required.
@@ -611,7 +623,9 @@ name-char  = name-start / DIGIT / "-" / "." / ":"
 ```
 
 > **Note**
-> _External variables_ names are constrained by this namespace.
+> _External variables_ can be passed in that are not valid _names_.
+> Such variables cannot be referenced in a _message_, but are not otherwise
+> errors.
 
 ### Escape Sequences
 
@@ -646,50 +660,3 @@ s = 1*( SP / HTAB / CR / LF )
 The grammar is formally defined in [`message.abnf`](./message.abnf)
 using the ABNF notation,
 as specified by [RFC 5234](https://datatracker.ietf.org/doc/html/rfc5234).
-
-
-
-
-> Expression examples:
->
-> ```
-> {1.23}
-> ```
->
-> ```
-> {|-1.23|}
-> ```
->
-> ```
-> {1.23 :number maxFractionDigits=1}
-> ```
->
-> ```
-> {|Thu Jan 01 1970 14:37:00 GMT+0100 (CET)| :datetime weekday=long}
-> ```
->
-> ```
-> {|My Brand Name| :linkify href=|foobar.com|}
-> ```
->
-> ```
-> {$when :datetime month=2-digit}
-> ```
->
-> ```
-> {:message id=some_other_message}
-> ```
->
-> ```
-> {+ssml.emphasis level=strong}
-> ```
->
-> Message examples:
->
-> ```
-> {This is {+b}bold{-b}.}
-> ```
->
-> ```
-> {{+h1 name=above-and-beyond}Above And Beyond{-h1}}
-> ```


### PR DESCRIPTION
This is the second attempt at the specification refactoring. I started with all of our PRs merged Monday.

This is a much more significant reformulation. It is intended to be read as prose as well as specifying individual productions. 

I organized the sections "top down", with some sub-sections containing others, e.g.:

> # Message
> ## Declarations
> ## Body
> ### Pattern
> ### Matcher
> #### Selector
> #### Variant
> ##### Key

There is then a set of productions about Expressions and then finally the remaining terms, such as keywords, whitespace, and such. You might wish to view this rendered first rather than diving into the diff specifically.

---

I have followed commentary about separating "abstract" vs. "concrete" (e.g. in #440). This proposal embraces the use of ABNF constructs whose purpose is "abstract". We don't have to do this. We can define terms in the spec that do not appear in the ABNF. E.g.:

> A <dfn>**_placeholder_**</dfn> refers to any _expression_ that appears inside of a _pattern_.

(and then use `expression` in the ABNF exclusively), a la:

```abnf
pattern = "{" 1* (text / expression) "}"
```

---

This PR does not include a repaired TOC and I have not yet removed the requirements to elsewhere. I moved some examples to the end, with an intention of moving them out altogether. 

Have a read. 📚 