### PR TITLE
Drop the Literal quoted flag from the data model

### DIFF
--- a/spec/data-model.md
+++ b/spec/data-model.md
@@ -101,8 +101,9 @@ The `Literal` and `VariableRef` correspond to the the _literal_ and _variable_ s
 When they are used as the `body` of an `Expression`,
 they represent _expression_ values with no _annotation_.
 
-An _unquoted_ value is represented by a `Literal` with `quoted: false`,
-while a _quoted_ value would have `quoted: true`.
+Both _quoted_ and _unquoted_ values are represented by `Literal`,
+as the use or lack of quotation is a presentation detail
+which has no effect on the meaning of the _literal_.
 The `value` of `Literal` is the "cooked" value (i.e. escape sequences are processed).
 
 In a `VariableRef`, the `name` does not include the initial `$` of the _variable_.
@@ -110,7 +111,6 @@ In a `VariableRef`, the `name` does not include the initial `$` of the _variable
 ```ts
 interface Literal {
   type: 'literal'
-  quoted: boolean
   value: string
 }
 

--- a/spec/data-model.md
+++ b/spec/data-model.md
@@ -101,9 +101,8 @@ The `Literal` and `VariableRef` correspond to the the _literal_ and _variable_ s
 When they are used as the `body` of an `Expression`,
 they represent _expression_ values with no _annotation_.
 
-Both _quoted_ and _unquoted_ values are represented by `Literal`,
-as the use or lack of quotation is a presentation detail
-which has no effect on the meaning of the _literal_.
+`Literal` represents all literal values, both _quoted_ and _unquoted_.
+The presence or absence of quotes is not preserved by the data model.
 The `value` of `Literal` is the "cooked" value (i.e. escape sequences are processed).
 
 In a `VariableRef`, the `name` does not include the initial `$` of the _variable_.


### PR DESCRIPTION
At the moment, the data model includes a boolean `quoted` property on the `Literal` construct. This should be dropped, as it's not meant to effect anything during the runtime.

As the data model is extensible by implementations, this does allow for an implementation to add the field back in as a private extension, should it have a need to track this information.