### PR TITLE
Clarify that Reserved may also represent private-use in data model

### DIFF
--- a/spec/data-model.md
+++ b/spec/data-model.md
@@ -145,16 +145,21 @@ interface Option {
 }
 ```
 
-A `Reserved` represents an _expression_ with a _reserved_ _annotation_.
-The `sigil` corresponds to the starting sigil of the _reserved_.
+A `Reserved` represents an _expression_ with a _reserved_ or _private-use_ _annotation_.
+The `sigil` corresponds to the starting sigil of the _annotation_.
 The `source` is the "raw" value (i.e. escape sequences are not processed)
-and includes the starting `sigil`.
+and does not include the starting `sigil`.
 
 Implementations MUST NOT rely on the set of `sigil` values remaining constant,
 as future versions of this specification MAY assign other meanings to such sigils.
 
 If the _expression_ includes a _literal_ or _variable_ before the _annotation_,
 it is included as the `operand`.
+
+When parsing the syntax of a _message_ that includes a _private-use_ _annotation_
+supported by the implementation,
+the implemenation MAY represent it in the data model using a different interface
+as appropriate for the semantics and meaning that it attaches to that _annotation_.
 
 ```ts
 interface Reserved {

--- a/spec/data-model.md
+++ b/spec/data-model.md
@@ -150,8 +150,10 @@ The `sigil` corresponds to the starting sigil of the _annotation_.
 The `source` is the "raw" value (i.e. escape sequences are not processed)
 and does not include the starting `sigil`.
 
-Implementations MUST NOT rely on the set of `sigil` values remaining constant,
-as future versions of this specification MAY assign other meanings to such sigils.
+> **Note**
+> Implementers should be aware that future versions of this specification
+> might assign meaning to _reserved_ `sigil` values
+> and add new interfaces to this data model.
 
 If the _expression_ includes a _literal_ or _variable_ before the _annotation_,
 it is included as the `operand`.

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -80,8 +80,7 @@ The `value` of `Text` is the "cooked" value (i.e. escape sequences are processed
 
 Implementations MUST NOT rely on the set of `Expression` `body` values being exhaustive,
 as future versions of this specification MAY define additional expressions.
-If encountering a `body` with an unrecognised value,
-an implementation SHOULD treat it as it would an `Unsupported` value.
+A `body` with an unrecognized value SHOULD be treated as an `Unsupported` value.
 
 ```ts
 interface Pattern {

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -81,7 +81,7 @@ The `value` of `Text` is the "cooked" value (i.e. escape sequences are processed
 Implementations MUST NOT rely on the set of `Expression` `body` values being exhaustive,
 as future versions of this specification MAY define additional expressions.
 If encountering a `body` with an unrecognised value,
-an implementation SHOULD treat it as it would a `Reserved` value.
+an implementation SHOULD treat it as it would an `Unsupported` value.
 
 ```ts
 interface Pattern {
@@ -95,7 +95,7 @@ interface Text {
 
 interface Expression {
   type: 'expression'
-  body: Literal | VariableRef | FunctionRef | Reserved
+  body: Literal | VariableRef | FunctionRef | Unsupported
 }
 ```
 
@@ -148,7 +148,7 @@ interface Option {
 }
 ```
 
-A `Reserved` represents an _expression_ with a _reserved_ or _private-use_ _annotation_.
+An `Unsupported` represents an _expression_ with a _reserved_ or _private-use_ _annotation_.
 The `sigil` corresponds to the starting sigil of the _annotation_.
 The `source` is the "raw" value (i.e. escape sequences are not processed)
 and does not include the starting `sigil`.
@@ -167,8 +167,8 @@ the implemenation MAY represent it in the data model using a different interface
 as appropriate for the semantics and meaning that it attaches to that _annotation_.
 
 ```ts
-interface Reserved {
-  type: 'reserved'
+interface Unsupported {
+  type: 'unsupported'
   sigil: '!' | '@' | '#' | '%' | '^' | '&' | '*' | '<' | '>' | '/' | '?' | '~'
   source: string
   operand?: Literal | VariableRef

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -148,23 +148,27 @@ interface Option {
 }
 ```
 
-An `Unsupported` represents an _expression_ with a _reserved_ or _private-use_ _annotation_.
+An `Unsupported` represents an _expression_ with a
+_reserved_ _annotation_ or a _private-use_ _annotation_ not supported
+by the implementation.
 The `sigil` corresponds to the starting sigil of the _annotation_.
 The `source` is the "raw" value (i.e. escape sequences are not processed)
 and does not include the starting `sigil`.
 
 > **Note**
-> Implementers should be aware that future versions of this specification
-> might assign meaning to _reserved_ `sigil` values
-> and add new interfaces to this data model.
+> Be aware that future versions of this specification
+> might assign meaning to _reserved_ `sigil` values.
+> This would result in new interfaces being added to
+> this data model.
 
 If the _expression_ includes a _literal_ or _variable_ before the _annotation_,
 it is included as the `operand`.
 
 When parsing the syntax of a _message_ that includes a _private-use_ _annotation_
 supported by the implementation,
-the implemenation MAY represent it in the data model using a different interface
-as appropriate for the semantics and meaning that it attaches to that _annotation_.
+the implementation SHOULD represent it in the data model
+using an interface appropriate for the semantics and meaning
+that the implementation attaches to that _annotation_.
 
 ```ts
 interface Unsupported {

--- a/spec/data-model/message.dtd
+++ b/spec/data-model/message.dtd
@@ -9,7 +9,7 @@
 <!ATTLIST key default (true | false) "false">
 
 <!ELEMENT pattern (#PCDATA | expression)*>
-<!ELEMENT expression (literal | variable | function | reserved)>
+<!ELEMENT expression (literal | variable | function | unsupported)>
 
 <!ELEMENT literal (#PCDATA)>
 <!ATTLIST literal quoted (true | false) #REQUIRED>
@@ -26,6 +26,6 @@
 <!ELEMENT option (literal | variable)>
 <!ATTLIST option name NMTOKEN #REQUIRED>
 
-<!ELEMENT reserved (operand?,source)>
-<!ATTLIST reserved sigil CDATA #REQUIRED>
+<!ELEMENT unsupported (operand?,source)>
+<!ATTLIST unsupported sigil CDATA #REQUIRED>
 <!ELEMENT source (#PCDATA)>

--- a/spec/data-model/message.json
+++ b/spec/data-model/message.json
@@ -47,10 +47,10 @@
       },
       "required": ["type", "kind", "name"]
     },
-    "reserved": {
+    "unsupported": {
       "type": "object",
       "properties": {
-        "type": { "const": "reserved" },
+        "type": { "const": "unsupported" },
         "sigil": {
           "enum": ["!", "@", "#", "%", "^", "&", "*", "<", ">", "?", "~"]
         },
@@ -77,7 +77,7 @@
             { "$ref": "#/$defs/literal" },
             { "$ref": "#/$defs/variable" },
             { "$ref": "#/$defs/function" },
-            { "$ref": "#/$defs/reserved" }
+            { "$ref": "#/$defs/unsupported" }
           ]
         }
       },


### PR DESCRIPTION
The data model `Reserved` interface may also be used for private-use annotations that are not supported by the implementation. This PR adds text clarifying that to be the case, and explicitly mentions that private-use syntax that is supported by the implementation may use a different interface.

The `source` definition is also corrected to _not_ include the starting sigil. This was the only point in the data model where a part of the syntax was showing up twice, without a really good reason why.