### PR TITLE
Define @attributes on expressions

### DIFF
--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -95,6 +95,7 @@ interface Text {
 interface Expression {
   type: 'expression'
   body: Literal | VariableRef | FunctionRef | Unsupported
+  attributes: Option[]
 }
 ```
 
@@ -103,6 +104,9 @@ interface Expression {
 The `Literal` and `VariableRef` correspond to the the _literal_ and _variable_ syntax rules.
 When they are used as the `body` of an `Expression`,
 they represent _expression_ values with no _annotation_.
+
+The `attributes` of an `Expression` primarily represent translator hints,
+but could include ones such as `locale` that do have an impact on _message_ formatting.
 
 `Literal` represents all literal values, both _quoted_ and _unquoted_.
 The presence or absence of quotes is not preserved by the data model.

--- a/spec/data-model/message.dtd
+++ b/spec/data-model/message.dtd
@@ -9,7 +9,7 @@
 <!ATTLIST key default (true | false) "false">
 
 <!ELEMENT pattern (#PCDATA | expression)*>
-<!ELEMENT expression (literal | variable | function | unsupported)>
+<!ELEMENT expression ((literal | variable | function | unsupported),attribute*)>
 
 <!ELEMENT literal (#PCDATA)>
 <!ATTLIST literal quoted (true | false) #REQUIRED>
@@ -29,3 +29,6 @@
 <!ELEMENT unsupported (operand?,source)>
 <!ATTLIST unsupported sigil CDATA #REQUIRED>
 <!ELEMENT source (#PCDATA)>
+
+<!ELEMENT attribute (literal | variable)>
+<!ATTLIST attribute name NMTOKEN #REQUIRED>

--- a/spec/data-model/message.json
+++ b/spec/data-model/message.json
@@ -33,19 +33,20 @@
         "kind": { "enum": ["open", "close", "value"] },
         "name": { "type": "string" },
         "operand": { "$ref": "#/$defs/value" },
-        "options": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": { "type": "string" },
-              "value": { "$ref": "#/$defs/value" }
-            },
-            "required": ["name", "value"]
-          }
-        }
+        "options": { "$ref": "#/$defs/options" }
       },
       "required": ["type", "kind", "name"]
+    },
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "value": { "$ref": "#/$defs/value" }
+        },
+        "required": ["name", "value"]
+      }
     },
     "unsupported": {
       "type": "object",
@@ -79,7 +80,8 @@
             { "$ref": "#/$defs/function" },
             { "$ref": "#/$defs/unsupported" }
           ]
-        }
+        },
+        "attributes": { "$ref": "#/$defs/options" }
       },
       "required": ["type", "body"]
     },

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -105,6 +105,9 @@ one of the following is used to resolve the value of the _expression_:
 - Else, the _expression_ has a _reserved_ _annotation_,
   an Unsupported Expression error is emitted and a fallback value is used as its value.
 
+_Expression attribute resolution_ defines the handling of _expression attributes_
+that have an impact on _message_ formatting.
+
 ### Literal Resolution
 
 The resolved value of a _text_ or a _literal_ is
@@ -151,12 +154,16 @@ the following steps are taken:
    and use a _fallback value_ for the _expression_.
 3. Resolve the _option_ values to a mapping of string identifiers to values.
    For each _option_:
-     * If its right-hand side successfully resolves to a value,
-       bind the _name_ of the _option_ to the resolved value in the mapping.
-     * Otherwise, do not bind the _name_ of the _option_ to any value in the mapping.
-4. Call the function implementation with the following arguments:
+   - If its right-hand side successfully resolves to a value,
+     bind the _name_ of the _option_ to the resolved value in the mapping.
+   - Otherwise, do not bind the _name_ of the _option_ to any value in the mapping.
+4. Determine the _expression_ _locale_.
+   If the _expression_ has a valid `@locale` _expression attribute_,
+   use its resolved value as the _expression_ _locale_.
+   Otherwise, look up the _message_ _locale_ from the _formatting context_.
+5. Call the function implementation with the following arguments:
 
-   - The current _locale_.
+   - The _expression_ _locale_.
    - The resolved mapping of _options_.
    - If the _expression_ includes an _operand_, its resolved value.
 
@@ -170,7 +177,7 @@ the following steps are taken:
    their access to the _formatting context_ SHOULD be minimal and read-only,
    and their execution time SHOULD be limited.
 
-5. If the call succeeds,
+6. If the call succeeds,
    resolve the value of the _expression_ as the result of that function call.
    If the call fails or does not return a valid value,
    emit a Resolution error and use a _fallback value_ for the _expression_.
@@ -234,6 +241,24 @@ rather than the _expression_ in the _selector_ or _pattern_.
 > resolving to a _fallback value_ of `|horse|`.
 
 _Pattern selection_ is not supported for _fallback values_.
+
+### Expression Attribute Resolution
+
+The only _expression attribute_ that MUST be supported is `@locale`.
+If its value is set by a _literal_,
+it MUST be a comma-delimited sequence of IETF BCP 47 language tags.
+If its value is set by a _variable_,
+it MUST be either a single IETF BCP 47 language tag,
+or a sequence of IETF BCP 47 language tags.
+
+The resolved value of a valid `@locale` _expression attribute_
+is a sequence of IETF BCP 47 language tags.
+If a `@locale` has an invalid value,
+emit a Resolution error and ignore the _expression attribute_ in further processing.
+
+Implementations MAY ignore all other _expression attributes_ during formatting.
+Implementations MAY assign meaning during formatting to other _expression attributes_
+which use a _name_ that contains at least one U+002D HYPHEN-MINUS `-` character.
 
 ## Pattern Selection
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -244,7 +244,7 @@ _Pattern selection_ is not supported for _fallback values_.
 
 ### Expression Attribute Resolution
 
-The only _expression attribute_ that MUST be supported is `@locale`.
+Implementations MUST support the _expression attribute_ `@locale`.
 If its value is set by a _literal_,
 it MUST be a comma-delimited sequence of IETF BCP 47 language tags.
 If its value is set by a _variable_,

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -245,11 +245,11 @@ _Pattern selection_ is not supported for _fallback values_.
 ### Expression Attribute Resolution
 
 Implementations MUST support the _expression attribute_ `@locale`.
-If its value is set by a _literal_,
-it MUST be a comma-delimited sequence of IETF BCP 47 language tags.
-If its value is set by a _variable_,
-it MUST be either a single IETF BCP 47 language tag,
-or a sequence of IETF BCP 47 language tags.
+The value of `@locale` MUST be a sequence of
+one or more well-formed IETF BCP47 language tags.
+If the value is set by a _literal_,
+the _literal_ MUST consist of a comma-delimited sequence of
+well-formed IETF BCP47 language tags.
 
 The resolved value of a valid `@locale` _expression attribute_
 is a sequence of IETF BCP 47 language tags.

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -9,9 +9,11 @@ selectors = match 1*([s] expression)
 variant = when 1*(s key) [s] pattern
 key = literal / "*"
 
-expression = "{" [s] ((operand [s annotation]) / annotation) [s] "}"
+expression = "{" [s] expression-body *(s expression-attribute) [s] "}"
+expression-body = (operand [s annotation]) / annotation
 operand    = literal / variable
 annotation = (function *(s option)) / reserved / private-use
+expression-attribute = "@" option
 
 literal = quoted / unquoted
 variable = "$" name
@@ -50,13 +52,14 @@ private-start  = "^" / "&"
 ; reserve additional sigils for use by 
 ; future versions of this specification
 reserved       = reserved-start reserved-body
-reserved-start = "!" / "@" / "#" / "%" / "*" / "<" / ">" / "/" / "?" / "~"
+reserved-start = "!" / "#" / "%" / "*" / "<" / ">" / "/" / "?" / "~"
 reserved-body  = *( [s] 1*(reserved-char / reserved-escape / quoted))
 
 reserved-char  = %x00-08        ; omit HTAB and LF
                / %x0B-0C        ; omit CR
                / %x0E-19        ; omit SP
-               / %x21-5B        ; omit \
+               / %x21-3F        ; omit @
+               / %x41-5B        ; omit \
                / %x5D-7A        ; omit { | }
                / %x7E-D7FF      ; omit surrogates
                / %xE000-10FFFF
@@ -74,7 +77,7 @@ name-char  = name-start / DIGIT / "-" / "." / ":"
 
 text-escape     = backslash ( backslash / "{" / "}" )
 quoted-escape   = backslash ( backslash / "|" )
-reserved-escape = backslash ( backslash / "{" / "|" / "}" )
+reserved-escape = backslash ( backslash / "@" / "{" / "|" / "}" )
 backslash       = %x5C ; U+005C REVERSE SOLIDUS "\"
 
 s = 1*( SP / HTAB / CR / LF )

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -545,8 +545,11 @@ reserved-char  = %x00-08        ; omit HTAB and LF
 
 An **_<dfn>expression attribute</dfn>_** is a key-value pair
 containing a named argument that is attached to the _expression_ as a whole.
-They are intended to convey information about the _expression_
-that is not necessarily applicable as a _function_ _option_.
+These might be used to convey information about the _expression_
+that are not necessarily applicable as _function_ _options_,
+such as attributes related to handling during the translation process.
+They might also be used to override contextual or implementation-specific values
+used by a _function_ during formatting, such as the locale.
 For example, the `@locale` attribute overrides the locale of the _message_ for its _expression_.
 Attributes like `@can-delete` and `@translate` might not have any impact on formatting,
 acting instead as instructions to translators.
@@ -557,17 +560,16 @@ but otherwise use the same syntax as _options_.
 The _name_ of an _expression attribute_ MUST either be one of the following,
 or it MUST contain at least one U+002D HYPHEN-MINUS `-` character:
 
-- `language`: SHOULD resolve to a sequence of IETF BCP 47 language tags;
+- `locale`: a sequence of well-formed IETF BCP47 language tags
   see _expression attribute resolution_.
-- `translate`: SHOULD have a literal value of either `yes` or `no`.
+- `translate`: a literal value of either `yes` or `no`
 
 To ensure future extensibility of this specification,
 all other _expression attributes_ with a _name_ not containing `-` MUST be ignored.
 
 Multiple _expression attributes_ are permitted in an _expression_.
 Each _expression attribute_ is separated by whitespace.
-If present, _expression attributes_ MUST be the last non-whitespace content in an _expression_,
-and MUST NOT be followed by any _function_ _options_.
+If present, _expression attributes_ MUST be the last non-whitespace content in an _expression_.
 
 ```abnf
 expression-attribute = "@" option
@@ -581,15 +583,14 @@ expression-attribute = "@" option
 > {In French, "{|bonjour| @locale=fr @translate=no}" is a greeting}
 > ```
 >
-> A _message_ with a `$date` _variable_ formatted with the `:datetime` _function_
-> using the root "und" locale:
->
+> A _message_ with a `$date` _variable_ formatted using the `:datetime` _function_
+> and overriding the locale to use French formatting:
+>```
+>{The date would be displayed in French as {$date :datetime @locale=fr}.}
 > ```
-> {Today is {$date :datetime weekday=long @locale=und}.}
-> ```
 >
-> A _message_ with a `$start` _variable_ that should in translations
-> be kept as the first element of the message.
+> A _message_ with a `$start` _variable_ that should be kept in translations
+> as the first element of the message.
 >
 > ```
 > {{$start @can-reorder=no} is the beginning.}

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -321,7 +321,7 @@ during the _message_'s formatting.
 An _expression_ MUST begin with U+007B LEFT CURLY BRACKET `{`
 and end with U+007D RIGHT CURLY BRACKET `}`.
 An _expression_ MUST NOT be empty.
-An _expression_ can contain an _operand_,
+An _expression_ MUST contain an _operand_,
 an _annotation_,
 or an _operand_ followed by an _annotation_.
 This MAY be followed by one or more _expression attributes_.


### PR DESCRIPTION
Fixes #426

As discussed during today's call, we have use cases for attributes that pertain to an expression, rather than acting as function options. The examples presented in #426 refer just to the locale of an expression, but other valuable attributes include the translatability of an expression, and attributes such as `canCopy`, `canDelete`, `canOverlap`, and others defined in the [XLIFF 2.1 spec](http://docs.oasis-open.org/xliff/xliff-core/v2.1/os/xliff-core-v2.1-os.html#d0e4957). Many of these do not have an impact on message formatting, but can be very important for translation work.

This PR proposes the following syntax for this, using the examples included in the PR:

> A _message_ in English including a French _literal_ that should not be translated:
>
> ```
> {In French, "{|bonjour| @locale=fr @translate=no}" is a greeting}
> ```
>
> A _message_ with a `$date` _variable_ formatted with the `:datetime` _function_ using the root "und" locale:
>
> ```
> {Today is {$date :datetime weekday=long @locale=und}.}
> ```
>
> A _message_ with a `$start` _variable_ that should in translations be kept as the first element of the message.
>
> ```
> {{$start @can-reorder=no} is the beginning.}
> ```

Effectively, after the _function_ _options_, _expression attributes_ may be defined with the same _option_ syntax but with `@` as a prefix for each name. The following attributes are explicitly defined:
- `@locale`: a sequence of IETF BCP 47 language tags
- `@translate`: a literal value of either `yes` or `no`.

All other custom attributes must include a hyphen `-` in their name (such as `@can-reorder` above); everything else is ignored. Mismatching names can't be treated as a syntax error, because that would limit our later ability in a 2.1 spec version to define more attributes.

This PR also unreserves the `@` character and updates the data model descriptions as necessary. 