### PR TITLE
New process: design proposal template

### DIFF
--- a/exploration/0000-design-proposal-template.md
+++ b/exploration/0000-design-proposal-template.md
@@ -1,0 +1,83 @@
+# Design Proposal Template
+
+<details>
+	<summary>Metadata</summary>
+	<dl>
+		<dt>Contributors</dt>
+		<dd>@username</dd>
+		<dt>First proposed</dt>
+		<dd>1970-01-01</dd>
+		<dt>Pull Request</dt>
+		<dd>#000</dd>
+	</dl>
+</details>
+
+## Objective
+
+*What is this proposal trying to achieve?*
+
+Decide how to interpolate data in patterns, in order to be able to display dynamic information like numbers, dates, and names inside translatable messages.
+
+## Background
+
+*What context is helpful to understand this proposal?*
+
+Translatable messages need to interpolate data...
+Such data must be formatted and positioned inside translation patterns...
+There's prior art in other translation and templating solutions...
+
+## Use-Cases
+
+*What use-cases do we see? Ideally, quote concrete examples.*
+
+* Numbers representing counts, e.g. `{You have {$count} new messages}`...
+* Strings representing usernames, e.g. `{Hello, {$userName}!}`...
+* Selection based on numbers, e.g. `match {$count} when 1 {One thing} when * {Many things}`...
+
+## Requirements
+
+*What properties does the solution have to manifest to enable the use-cases above?*
+
+* Be able to use a variable more than once in a pattern...
+* Be able to use a variable in a selector...
+* Be able to reorder a variable...
+* Be able to tell what a variable refers to...
+* Make migration from ICU MF1 possible...
+
+## Constraints
+
+*What prior decisions and existing conditions limit the possible design?*
+
+* A syntactical prefix must not collide with `nmtoken`, to avoid parsing ambiguities with unquoted literals...
+
+## Proposed Design
+
+*Describe the proposed solution. Consider syntax, formatting, errors, registry, tooling, interchange.*
+
+...
+
+## Alternatives Considered
+
+*What other solutions are available?*
+*How do they compare against the requirements?*
+*What other properties they have?*
+
+### Use unnamed placeholders...
+
+For example: `{Hello, {$}!}`...
+
+* **Use more than once?** No.
+* **Use in selectors?** No.
+* **Reorder?** No.
+* **Clear what the variable refers to?** No.
+* **Migration from MF1 possible?** Yes.
+
+### Use indexed placeholders...
+
+For example: `{Hello, {$1}!}`...
+
+* **Use more than once?** Yes.
+* **Use in selectors?** Yes.
+* **Reorder?** Yes.
+* **Clear what the variable refers to?** No.
+* **Migration from MF1 possible?** Yes.


### PR DESCRIPTION
I'd like to suggest a new process for discussing and designing features and changes to MF2: document the design in a single Markdown file before implementing it *in the spec*.

Today, the scope and the specification of MF2 are concrete enough to be a good base against which incremental designs can be evaluated. MF2 is also complex enough to require a good deal of consideration of how a newly introduced change interacts with other parts of the standard.

In particular, I think such documents would be the right place to gather use-cases and requirements in a way that (a) allows us to evaluate alternative designs, and (b) can be looked up in the future to understand what problem we wanted to solve.

New proposals would be made in form of PRs adding a new file to the `exploration` directory. (The number in the file name is the PR's number, which requires a little bit of extra effort but will help with ordering and avoiding file naming conflicts.) The discussion follows in PR's review comments. When the PR is merged, it means that the proposal can be implemented in the spec. The implementation can itself result in more discussion; sometimes certain proposal will need to be reverted.

How is this different from opening new issues with a similar template to the one I propose here? There's one crucial difference: when the proposal PR is merged, the merged document represents the up-to-date consensus. With issues, the consensus is spread across multiple comments or sometimes multiple issues, making it hard to reason about some changes after time has passed. 

Not all discussions nor changes need to go through this new process. I don't know exactly what criteria to use to decide whether a change needs a design proposal doc or not. Instead I suggest a heuristic: when a reviewer says that a change would benefit from a design proposal doc, it means that it needs one :)