### PR TITLE
Allow expressions without annotations to dynamically choose a function

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -96,7 +96,7 @@ and a _function_, _private-use_, or _reserved_ _annotation_,
 the resolved value of the _expression_ is determined as follows:
 
 If the _expression_ contains a _reserved_ _annotation_,
-an `Unsupported Expression` error is emitted and a fallback value is used as its value;
+an `Unsupported Expression` error is emitted and a fallback value is used as its value.
 
 Else, if the _expression_ contains a _private-use_ _annotation_,
 its resolved value is defined according to the implementation's specification;

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -129,8 +129,8 @@ Else, if the _expression_ consists of a _literal_,
 its resolved value is defined by _literal resolution_.
 
 > **Note**
-> This means that a _literal_ value with no _annotation_ is always treated
-> as a string.
+> This means that a _literal_ value with no _annotation_
+> is always treated as a string.
 > To represent values that are not strings as a _literal_,
 > an _annotation_ needs to be provided:
 >

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -102,7 +102,7 @@ Else, if the _expression_ contains a _private-use_ _annotation_,
 its resolved value is defined according to the implementation's specification.
 
 Else, if the _expression_ contains an _annotation_,
-its resolved value is defined by _function resolution_;
+its resolved value is defined by _function resolution_.
 
 Else, the _expression_ will contain only an _operand_,
 which consists of either a _literal_ or a _variable_.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -111,10 +111,10 @@ If the _expression_ consists of a _variable_,
 its resolved value is defined by _variable resolution_.
 An implementation MAY perform additional processing
 when resolving the value of the _expression_.
-For example, it could apply _function resolution_ using a _function_
-and a set of _options_ chosen based on the value or type of the _variable_.
 
-> For example, given a _message_ like this:
+> For example, it could apply _function resolution_ using a _function_
+> and a set of _options_ chosen based on the value or type of the _variable_.
+> So, given a _message_ like this:
 >```
 >{Today is {$date}}
 >```

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -120,11 +120,10 @@ when resolving the value of the _expression_.
 > {Today is {$date}}
 > ```
 >
-> If the value passed in the _variable_ were a date object, such as a
-> JavaScript `Date` or a Java `java.util.Date` or `java.time.Temporal`,
+> If the value passed in the _variable_ were a date object,
+> such as a JavaScript `Date` or a Java `java.util.Date` or `java.time.Temporal`,
 > the implementation could interpret the _placeholder_ `{$date}` as if
-> the pattern included the function `:datetime` with some set of default
-> options.
+> the pattern included the function `:datetime` with some set of default options.
 
 Else, if the _expression_ consists of a _literal_,
 its resolved value is defined by _literal resolution_.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -115,10 +115,18 @@ to further perform _function resolution_.
 
 Else, if the _expression_ consists of a _literal_,
 its resolved value is defined by _literal resolution_.
-If the _literal_ appears in a _declaration_, no further resolution is permitted.
-Otherwise, an implementation MAY use the contents of the _literal_
-to choose a _function_ and _options_ to attempt to perform _function resolution_.
-If such a _function resolution_ fails, the _literal_ value MUST be the resolved value.
+
+> **Note**
+> This means that a _literal_ value with no _annotation_ is always treated
+> as a string.
+> To represent values that are not strings as a _literal_,
+> an _annotation_ needs to be provided:
+>```
+>let $aNumber = {1234 :number}
+>let $aDate = {|2023-08-30| :datetime}
+>let $aFoo = {|some foo| :foo}
+>{You have {42 :number}}
+>```
 
 ### Literal Resolution
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -113,8 +113,8 @@ An implementation MAY perform additional processing
 when resolving the value of the _expression_.
 For example, it could apply _function resolution_ using a _function_
 and a set of _options_ chosen based on the value or type of the _variable_.
-> **Example**
-> Given a _message_ like this:
+
+> For example, given a _message_ like this:
 >```
 >{Today is {$date}}
 >```

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -505,14 +505,17 @@ _Formatting_ is a mostly implementation-defined process,
 as it depends on the implementation's shape for resolved values
 and the result type of the formatting.
 
-Formatting errors MAY be emitted during _formatting_,
-as formatting is not necessarily defined on every resolved value.
-A formatter MAY provide a value to use in such a case instead of a _fallback value_.
+Formatting is not necessarily defined on every resolved value.
+An implementation SHOULD emit formatting errors during _formatting_,
+but MAY provide a value to use in such a case instead of a _falback value_.
 
-_Formatting_ MAY produce formatted messages with the following data types,
-as well as any others:
+An implementation MAY use the value of an _expression_'s _operand_
+to choose a _formatting function_ and default _options_ if no
+_annotation_ is supplied by the _expression_.
 
-- A single concatenated string.
+Implementations MAY represent the result of _formatting_ using the most
+appropriate data type or structure. Some examples of these include:
+- A single string concatenated from the resolved _pattern_ and its parts.
 - A string with associated attributes for portions of its text.
 - A flat sequence of objects corresponding to each resolved value.
 - A hierarchical structure of objects that group spans of resolved values,

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -99,7 +99,7 @@ If the _expression_ contains a _reserved_ _annotation_,
 an `Unsupported Expression` error is emitted and a fallback value is used as its value.
 
 Else, if the _expression_ contains a _private-use_ _annotation_,
-its resolved value is defined according to the implementation's specification;
+its resolved value is defined according to the implementation's specification.
 
 Else, if the _expression_ contains an _annotation_,
 its resolved value is defined by _function resolution_;

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -508,8 +508,8 @@ and the result type of the formatting.
 Resolved values cannot always be formatted by a given implementation.
 When such an error occurs during _formatting_, 
 an implementation SHOULD emit a _formatting error_ and produce a 
-_formatting fallback value_ for the _placeholder_ that produced the error.
-An implementation MAY substitute a value to use instead of a _falback value_.
+_fallback value_ for the _placeholder_ that produced the error.
+A formatting function MAY substitute a value to use instead of a _fallback value_.
 
 An implementation MAY use the value of an _expression_'s _operand_
 to choose a _formatting function_ and default _options_ if no

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -115,10 +115,12 @@ when resolving the value of the _expression_.
 > For example, it could apply _function resolution_ using a _function_
 > and a set of _options_ chosen based on the value or type of the _variable_.
 > So, given a _message_ like this:
->```
->{Today is {$date}}
->```
->If the value passed in the _variable_ were a date object, such as a
+>
+> ```
+> {Today is {$date}}
+> ```
+>
+> If the value passed in the _variable_ were a date object, such as a
 > JavaScript `Date` or a Java `java.util.Date` or `java.time.Temporal`,
 > the implementation could interpret the _placeholder_ `{$date}` as if
 > the pattern included the function `:datetime` with some set of default
@@ -132,12 +134,13 @@ its resolved value is defined by _literal resolution_.
 > as a string.
 > To represent values that are not strings as a _literal_,
 > an _annotation_ needs to be provided:
->```
->let $aNumber = {1234 :number}
->let $aDate = {|2023-08-30| :datetime}
->let $aFoo = {|some foo| :foo}
->{You have {42 :number}}
->```
+>
+> ```
+> let $aNumber = {1234 :number}
+> let $aDate = {|2023-08-30| :datetime}
+> let $aFoo = {|some foo| :foo}
+> {You have {42 :number}}
+> ```
 
 ### Literal Resolution
 
@@ -542,13 +545,14 @@ as it depends on the implementation's shape for resolved values
 and the result type of the formatting.
 
 Resolved values cannot always be formatted by a given implementation.
-When such an error occurs during _formatting_, 
-an implementation SHOULD emit a _formatting error_ and produce a 
+When such an error occurs during _formatting_,
+an implementation SHOULD emit a _formatting error_ and produce a
 _fallback value_ for the _placeholder_ that produced the error.
 A formatting function MAY substitute a value to use instead of a _fallback value_.
 
 Implementations MAY represent the result of _formatting_ using the most
 appropriate data type or structure. Some examples of these include:
+
 - A single string concatenated from the parts of the resolved _pattern_.
 - A string with associated attributes for portions of its text.
 - A flat sequence of objects corresponding to each resolved value.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -109,9 +109,20 @@ which consists of either a _literal_ or a _variable_.
 
 If the _expression_ consists of a _variable_,
 its resolved value is defined by _variable resolution_.
-An implementation MAY use the value of the _variable_ or
-its resolved value to choose a _function_ and _options_
-to further perform _function resolution_.
+An implementation MAY perform additional processing
+when resolving the value of the _expression_.
+For example, it could apply _function resolution_ using a _function_
+and a set of _options_ chosen based on the value or type of the _variable_.
+> **Example**
+> Given a _message_ like this:
+>```
+>{Today is {$date}}
+>```
+>If the value passed in the _variable_ were a date object, such as a
+> JavaScript `Date` or a Java `java.util.Date` or `java.time.Temporal`,
+> the implementation could interpret the _placeholder_ `{$date}` as if
+> the pattern included the function `:datetime` with some set of default
+> options.
 
 Else, if the _expression_ consists of a _literal_,
 its resolved value is defined by _literal resolution_.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -505,9 +505,11 @@ _Formatting_ is a mostly implementation-defined process,
 as it depends on the implementation's shape for resolved values
 and the result type of the formatting.
 
-Formatting is not necessarily defined on every resolved value.
-An implementation SHOULD emit formatting errors during _formatting_,
-but MAY provide a value to use in such a case instead of a _falback value_.
+Resolved values cannot always be formatted by a given implementation.
+When such an error occurs during _formatting_, 
+an implementation SHOULD emit a _formatting error_ and produce a 
+_formatting fallback value_ for the _placeholder_ that produced the error.
+An implementation MAY substitute a value to use instead of a _falback value_.
 
 An implementation MAY use the value of an _expression_'s _operand_
 to choose a _formatting function_ and default _options_ if no

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -528,7 +528,7 @@ A formatting function MAY substitute a value to use instead of a _fallback value
 
 Implementations MAY represent the result of _formatting_ using the most
 appropriate data type or structure. Some examples of these include:
-- A single string concatenated from the resolved _pattern_ and its parts.
+- A single string concatenated from the parts of the resolved _pattern_.
 - A string with associated attributes for portions of its text.
 - A flat sequence of objects corresponding to each resolved value.
 - A hierarchical structure of objects that group spans of resolved values,

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -70,7 +70,7 @@ _Expressions_ are used in _declarations_, _selectors_, and _patterns_.
 
 In a _declaration_, the resolved value of the _expression_ is assigned to a _variable_,
 which is available for use by later _expressions_.
-As such a _variable_ MAY then be referenced in different ways,
+Since a _variable_ can be referenced in different ways later,
 implementations SHOULD NOT immediately fully format the value for output.
 
 In _selectors_, the resolved value of an _expression_ is used for _pattern selection_.
@@ -93,17 +93,32 @@ and different implementations MAY choose to perform different levels of resoluti
 
 Depending on the presence or absence of an _operand_
 and a _function_, _private-use_, or _reserved_ _annotation_,
-one of the following is used to resolve the value of the _expression_:
+the resolved value of the _expression_ is determined as follows:
 
-- If the _expression_ contains no _annotation_,
-  its resolved value is determined by _literal resolution_ or _variable resolution_,
-  depending on the shape of the _operand_.
-- Else, if the _expression_ has a _function_ _annotation_,
-  its resolved value is defined by _function resolution_.
-- Else, if the _expression_ has a _private-use_ _annotation_,
-  its resolved value is defined according to the implementations's specification.
-- Else, the _expression_ has a _reserved_ _annotation_,
-  an Unsupported Expression error is emitted and a fallback value is used as its value.
+If the _expression_ contains a _reserved_ _annotation_,
+an `Unsupported Expression` error is emitted and a fallback value is used as its value;
+
+Else, if the _expression_ contains a _private-use_ _annotation_,
+its resolved value is defined according to the implementation's specification;
+
+Else, if the _expression_ contains an _annotation_,
+its resolved value is defined by _function resolution_;
+
+Else, the _expression_ will contain only an _operand_,
+which consists of either a _literal_ or a _variable_.
+
+If the _expression_ consists of a _variable_,
+its resolved value is defined by _variable resolution_.
+An implementation MAY use the value of the _variable_ or
+its resolved value to choose a _function_ and _options_
+to further perform _function resolution_.
+
+Else, if the _expression_ consists of a _literal_,
+its resolved value is defined by _literal resolution_.
+If the _literal_ appears in a _declaration_, no further resolution is permitted.
+Otherwise, an implementation MAY use the contents of the _literal_
+to choose a _function_ and _options_ to attempt to perform _function resolution_.
+If such a _function resolution_ fails, the _literal_ value MUST be the resolved value.
 
 ### Literal Resolution
 
@@ -510,10 +525,6 @@ When such an error occurs during _formatting_,
 an implementation SHOULD emit a _formatting error_ and produce a 
 _fallback value_ for the _placeholder_ that produced the error.
 A formatting function MAY substitute a value to use instead of a _fallback value_.
-
-An implementation MAY use the value of an _expression_'s _operand_
-to choose a _formatting function_ and default _options_ if no
-_annotation_ is supplied by the _expression_.
 
 Implementations MAY represent the result of _formatting_ using the most
 appropriate data type or structure. Some examples of these include:


### PR DESCRIPTION
Fixes #42 

Also addresses some problems with normative terms in the same text.