### PR TITLE
Limit Prettier action to selected directories & events

### DIFF
--- a/.github/workflows/prettier.yaml
+++ b/.github/workflows/prettier.yaml
@@ -1,9 +1,18 @@
 name: Apply Prettier style
 
 on:
-  push:
+  pull_request:
     paths:
-      - "**.md"
+      - "docs/**"
+      - "exploration/**"
+      - "spec/**"
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - "docs/**"
+      - "exploration/**"
+      - "spec/**"
 
 permissions:
   contents: write
@@ -19,7 +28,7 @@ jobs:
         with:
           node-version: "20.x"
       - run: npm install --no-save prettier@3
-      - run: npx prettier --write .
+      - run: npx prettier --write docs/ exploration/ spec/
       - name: git config
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
It turns out that our `main` branch is in fact protected, and that the action can't write to it.

So rather than trying to fix the styles everywhere, this limits the action to just `docs/`, `exploration/` and `spec/`.

It should also now run for `pull_request` events, in case a PR is made from a fork that isn't allowing actions.