### PR TITLE
Add proposed/accepted status to design docs

### DIFF
--- a/exploration/0000-design-proposal-template.md
+++ b/exploration/0000-design-proposal-template.md
@@ -2,7 +2,9 @@
 
 Status: **Accepted**
 
-_Use either **Proposed** or **Accepted** as the status._
+_Use the status **Proposed** when creating a design proposal._
+_The status will be changed to **Accepted** when the design proposal is accepted as working group consensus._
+_The status will be changed to **Rejected** if the design proposal ultimately is not adopted by the working group._
 _This is intended to allow new design documents to be first proposed and then iterated over time,_
 _rather than needing to have all their details agreed in a single PR._
 

--- a/exploration/0000-design-proposal-template.md
+++ b/exploration/0000-design-proposal-template.md
@@ -1,5 +1,11 @@
 # Design Proposal Template
 
+Status: **Accepted**
+
+_Use either **Proposed** or **Accepted** as the status._
+_This is intended to allow new design documents to be first proposed and then iterated over time,_
+_rather than needing to have all their details agreed in a single PR._
+
 <details>
 	<summary>Metadata</summary>
 	<dl>


### PR DESCRIPTION
We should track and signal the status of a design document, so that we can iterate on them across multiple PRs. To keep it simple, we probably don't need more than two statuses to start with, "proposed" and "accepted".

CC @ryzokuken, who also has a design doc PR in flight.