### PR TITLE
More Prettier action fixing

### DIFF
--- a/.github/workflows/prettier.yaml
+++ b/.github/workflows/prettier.yaml
@@ -13,6 +13,7 @@ on:
       - "docs/**"
       - "exploration/**"
       - "spec/**"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -23,7 +24,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout from push
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v3
+      - name: Checkout from PR
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - uses: actions/setup-node@v3
         with:
           node-version: "20.x"

--- a/.github/workflows/prettier.yaml
+++ b/.github/workflows/prettier.yaml
@@ -37,8 +37,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "20.x"
-      - run: npm install --no-save prettier@3
-      - run: npx prettier --write docs/ exploration/ spec/
+      - run: npm install
+      - run: npm run prettier
       - name: git config
         run: |
           git config user.name "github-actions[bot]"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "messageformat-wg",
+  "private": true,
+  "license": "Unicode-DFS-2016",
+  "dependencies": {
+    "prettier": "^3.0.1"
+  },
+  "scripts": {
+    "prettier": "prettier --write docs/ exploration/ spec/"
+  }
+}


### PR DESCRIPTION
This shouldn't be as hard as it appears to be, but alas.

In forks where it's allowed to run, the action should still "just work".

For PRs coming from branches in this repo, the `ref` is now set so that the `git push` should "just work".

For PRs coming from branches in forks, it doesn't look like there's a way to get the action to have sufficient access so that it can write to that branch from the target repo, even if a human user could. So for those cases, the explicit `repository` is set and the action will only fail on `git push` if there are any files that Prettier should be run on.

In other words, the action should now work as a CI check when it's not able to automatically fix things.

A `package.json` is added, so that `npm install && npm run prettier` can be run locally to apply the same fixes as the action would.

The `workflow_dispatch` action will also allow triggering the action manually for a given branch.

CC @ryzokuken