### PR TITLE
Add stability policy

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -76,6 +76,12 @@ of valid messages written for earlier versions of this specification
 that only use functions and expression attributes defined in this specification.
 Later specification versions MAY make previously invalid messages valid.
 
+> [!NOTE]
+> This does not guarantee that the results of formatting will never change.
+> Even when the specification doesn't change,
+> the functions for date formatting, number formatting and so on
+> will change their results over time.
+
 Updates to this specification MUST NOT introduce message syntax that,
 when parsed according to earlier versions of this specification,
 would produce syntax or data model errors.

--- a/spec/README.md
+++ b/spec/README.md
@@ -82,7 +82,12 @@ would produce syntax or data model errors.
 Such messages MAY produce errors when formatted
 according to an earlier version of this specification.
 
-Later versions of this specification MAY define new function names,
+From version 2.0, MessageFormat will only reserve, define, or require
+function names,
+function option names,
+or expression attribute names 
+consisting of characters in the ranges a-z, A-Z, and 0-9.
+All other names in these categories are reserved for the use of implementations or users.
 function option names, and expression attribute names with new meanings.
 Such names defined in this specification MUST consist only of
 characters in the ranges a-z, A-Z, and 0-9.

--- a/spec/README.md
+++ b/spec/README.md
@@ -71,7 +71,7 @@ A reference to a _term_ looks like this.
 ### Stability Policy
 
 Updates to this specification MUST NOT change
-the syntactical meaning, the formatting, or other behaviour
+the syntactical meaning, the runtime output, or other behaviour
 of valid messages written for earlier versions of this specification
 that only use functions and expression attributes defined in this specification.
 Later specification versions MAY make previously invalid messages valid.

--- a/spec/README.md
+++ b/spec/README.md
@@ -79,7 +79,7 @@ in this version. Future versions MAY add additional structure or meaning
 to existing syntax.
 
 Updates to this specification will not remove any reserved keywords
-or sigils. 
+or sigils.
 
 > Note: future versions may defined new keywords
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -74,7 +74,22 @@ Updates to this specification MUST NOT change
 the syntactical meaning, the runtime output, or other behaviour
 of valid messages written for earlier versions of this specification
 that only use functions and expression attributes defined in this specification.
-Later specification versions MAY make previously invalid messages valid.
+Updates to this specification will not remove any syntax provided
+in this version. Future versions MAY add additional structure or meaning
+to existing syntax.
+
+Updates to this specification will not remove any reserved keywords
+or sigils. 
+
+> Note: future versions may defined new keywords
+
+Updates to this specification will not reserve or assign meaning to any
+character "sigils" except for those in the `reserved` production.
+
+Updates to this specification will not remove any functions
+defined in the default registry nor will they remove any options
+or option values. Additional options or option values MAY be
+defined.
 
 > [!NOTE]
 > This does not guarantee that the results of formatting will never change.

--- a/spec/README.md
+++ b/spec/README.md
@@ -83,14 +83,9 @@ Such messages MAY produce errors when formatted
 according to an earlier version of this specification.
 
 From version 2.0, MessageFormat will only reserve, define, or require
-function names,
-function option names,
-or expression attribute names
+function names or function option names
 consisting of characters in the ranges a-z, A-Z, and 0-9.
 All other names in these categories are reserved for the use of implementations or users.
-function option names, and expression attribute names with new meanings.
-Such names defined in this specification MUST consist only of
-characters in the ranges a-z, A-Z, and 0-9.
 
 > [!NOTE]
 > Users defining custom names SHOULD include at least one character outside these ranges

--- a/spec/README.md
+++ b/spec/README.md
@@ -85,7 +85,7 @@ according to an earlier version of this specification.
 From version 2.0, MessageFormat will only reserve, define, or require
 function names,
 function option names,
-or expression attribute names 
+or expression attribute names
 consisting of characters in the ranges a-z, A-Z, and 0-9.
 All other names in these categories are reserved for the use of implementations or users.
 function option names, and expression attribute names with new meanings.

--- a/spec/README.md
+++ b/spec/README.md
@@ -85,5 +85,7 @@ Later versions of this specification MAY define new function names,
 function option names, and expression attribute names with new meanings.
 Such names defined in this specification MUST consist only of
 characters in the ranges a-z, A-Z, and 0-9.
-Users defining custom names SHOULD include at least one character outside these ranges
-to ensure that they will be compatible with future versions of this specification.
+
+> [!NOTE]
+> Users defining custom names SHOULD include at least one character outside these ranges
+> to ensure that they will be compatible with future versions of this specification.

--- a/spec/README.md
+++ b/spec/README.md
@@ -70,7 +70,8 @@ A reference to a _term_ looks like this.
 
 ### Stability Policy
 
-Updates to this specification MUST NOT change the formatting or other behaviour
+Updates to this specification MUST NOT change
+the syntactical meaning, the formatting, or other behaviour
 of valid messages written for earlier versions of this specification
 that only use functions and expression attributes defined in this specification.
 Later specification versions MAY make previously invalid messages valid.

--- a/spec/README.md
+++ b/spec/README.md
@@ -5,6 +5,7 @@
 1. [Introduction](#introduction)
    1. [Conformance](#conformance)
    1. [Terminology and Conventions](#terminology-and-conventions)
+   1. [Stability Policy](#stability-policy)
 1. [Syntax](syntax.md)
    1. [Productions](syntax.md#productions)
    1. [Tokens](syntax.md#tokens)
@@ -66,3 +67,23 @@ A **_term_** looks like this when it is defined in this specification.
 A reference to a _term_ looks like this.
 
 > Examples are non-normative and styled like this.
+
+### Stability Policy
+
+Updates to this specification MUST NOT change the formatting or other behaviour
+of valid messages written for earlier versions of this specification
+that only use functions and expression attributes defined in this specification.
+Later specification versions MAY make previously invalid messages valid.
+
+Updates to this specification MUST NOT introduce message syntax that,
+when parsed according to earlier versions of this specification,
+would produce syntax or data model errors.
+Such messages MAY produce errors when formatted
+according to an earlier version of this specification.
+
+Later versions of this specification MAY define new function names,
+function option names, and expression attribute names with new meanings.
+Such names defined in this specification MUST consist only of
+characters in the ranges a-z, A-Z, and 0-9.
+Users defining custom names SHOULD include at least one character outside these ranges
+to ensure that they will be compatible with future versions of this specification.


### PR DESCRIPTION
As discussed face-to-face yesterday.

The first two paragraphs state that future changes won't break your old MF2 messages, and that future messages will not use syntax that an older parser will consider as errors -- this is why we've _reserved_ some parts of the spec.

The last paragraph is about soft-reserving namespace for future spec versions.