### PR TITLE
Fix stability policy

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -95,6 +95,8 @@ Additional options or option values MAY be defined.
 > the functions for date formatting, number formatting and so on
 > will change their results over time.
 
+Later specification versions MAY make previously invalid messages valid.
+
 Updates to this specification will not introduce message syntax that,
 when parsed according to earlier versions of this specification,
 would produce syntax or data model errors.

--- a/spec/README.md
+++ b/spec/README.md
@@ -70,26 +70,24 @@ A reference to a _term_ looks like this.
 
 ### Stability Policy
 
-Updates to this specification MUST NOT change
+Updates to this specification will not change
 the syntactical meaning, the runtime output, or other behaviour
 of valid messages written for earlier versions of this specification
 that only use functions and expression attributes defined in this specification.
-Updates to this specification will not remove any syntax provided
-in this version. Future versions MAY add additional structure or meaning
-to existing syntax.
+Updates to this specification will not remove any syntax provided in this version.
+Future versions MAY add additional structure or meaning to existing syntax.
 
-Updates to this specification will not remove any reserved keywords
-or sigils.
+Updates to this specification will not remove any reserved keywords or sigils.
 
-> Note: future versions may defined new keywords
+> Note: future versions may define new keywords.
 
-Updates to this specification will not reserve or assign meaning to any
-character "sigils" except for those in the `reserved` production.
+Updates to this specification will not reserve or assign meaning to
+any character "sigils" except for those in the `reserved` production.
 
-Updates to this specification will not remove any functions
-defined in the default registry nor will they remove any options
-or option values. Additional options or option values MAY be
-defined.
+Updates to this specification
+will not remove any functions defined in the default registry nor
+will they remove any options or option values.
+Additional options or option values MAY be defined.
 
 > [!NOTE]
 > This does not guarantee that the results of formatting will never change.
@@ -97,7 +95,7 @@ defined.
 > the functions for date formatting, number formatting and so on
 > will change their results over time.
 
-Updates to this specification MUST NOT introduce message syntax that,
+Updates to this specification will not introduce message syntax that,
 when parsed according to earlier versions of this specification,
 would produce syntax or data model errors.
 Such messages MAY produce errors when formatted


### PR DESCRIPTION
When #472 was merged, it ended up including changes suggested by @aphillips in https://github.com/unicode-org/message-format-wg/pull/472#discussion_r1327996351 that had not been fully reviewed. This PR is about fixing issues related to that late addition.

Right now this is mostly editorial, and re-introducing a phrase that was dropped on merge:
> Later specification versions MAY make previously invalid messages valid.

However, we should also decide here what to do about this indented note that was included in the change:
> > Note: future versions may define new keywords.

For this to be valid, we need to find a way to make it play nice with this other bit of policy:
> Updates to this specification will not introduce message syntax that,
> when parsed according to earlier versions of this specification,
> would produce syntax or data model errors.

In other words, we need to come up with a syntax that allows for space for keywords to be _reserved_, so that a current parser won't syntax-error with them. At least thus far, each of our keywords associates with one of more subsequent _expressions_ or _patterns_.

This is problematic with a syntax like our current one, which uses `{` at the top level as both an _expression_ and _pattern_ start, depending on the context. Essentially, it's not possible to determine if `keyword {foo|bar}` is valid without knowing if it's meant to be processed as an expression or a pattern.

With a syntax as proposed in [this alternative](https://github.com/unicode-org/message-format-wg/blob/text-vs-code/exploration/0474-text-vs-code.md#start-in-text-encapsulate-code), this problem becomes at least tractable.

This note should not be left as is; either it needs to be dropped, or it needs to be made explicitly normative.