### PR TITLE
Make option values optional, defaulting to true

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -202,7 +202,9 @@ the following steps are taken:
    and use a _fallback value_ for the _expression_.
 3. Resolve the _option_ values to a mapping of string identifiers to values.
    For each _option_:
-   - If its right-hand side successfully resolves to a value,
+   - If the _option_ contains no value,
+     bind the _name_ of the _option_ to the character sequence `true`.
+   - Else, if its right-hand side successfully resolves to a value,
      bind the _name_ of the _option_ to the resolved value in the mapping.
    - Otherwise, do not bind the _name_ of the _option_ to any value in the mapping.
 4. Call the function implementation with the following arguments:

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -21,7 +21,8 @@ annotation = (function *(s option)) / reserved / private-use
 literal = quoted / unquoted
 variable = "$" name
 function = (":" / "+" / "-") name
-option = name [[s] "=" [s] (literal / variable)]
+option = name [option-value]
+option-value = [s] "=" [s] (literal / variable)
 
 ; reserved keywords are always lowercase
 input = %x69.6E.70.75.74  ; "input"

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -21,7 +21,7 @@ annotation = (function *(s option)) / reserved / private-use
 literal = quoted / unquoted
 variable = "$" name
 function = (":" / "+" / "-") name
-option = name [s] "=" [s] (literal / variable)
+option = name [[s] "=" [s] (literal / variable)]
 
 ; reserved keywords are always lowercase
 input = %x69.6E.70.75.74  ; "input"

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -470,16 +470,19 @@ _Options_ are not required.
 An **_<dfn>option</dfn>_** is a key-value pair
 containing a named argument that is passed to a _function_.
 
-An _option_ has a _name_ and a _value_.
-The _name_ is separated from the _value_ by an U+003D EQUALS SIGN `=` along with
+An _option_ has a _name_ and optionally a _value_.
+An _option_ without a _value_ is taken to have the literal value `true`.
+
+If an _option_ has a _value_,
+it is separated from the _name_ by an U+003D EQUALS SIGN `=` along with
 optional whitespace.
-The value of an _option_ can be either a _literal_ or a _variable_.
+The _value_ of an _option_ can be either a _literal_ or a _variable_.
 
 Multiple _options_ are permitted in an _annotation_.
 Each _option_ is separated by whitespace.
 
 ```abnf
-option = name [s] "=" [s] (literal / variable)
+option = name [[s] "=" [s] (literal / variable)]
 ```
 
 > Examples of _functions_ with _options_
@@ -492,10 +495,11 @@ option = name [s] "=" [s] (literal / variable)
 
 > A _message_ with a `$userName` _variable_ formatted with
 > the custom `:person` _function_ capable of
-> declension (using either a fixed dictionary, algorithmic declension, ML, etc.):
+> declension (using either a fixed dictionary, algorithmic declension, ML, etc.),
+> as well as capitalization:
 >
 > ```
-> {Hello, {$userName :person case=vocative}!}
+> Hello, {$userName :person case=vocative capitalized}!
 > ```
 
 > A _message_ with a `$userObj` _variable_ formatted with

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -471,7 +471,7 @@ An **_<dfn>option</dfn>_** is a key-value pair
 containing a named argument that is passed to a _function_.
 
 An _option_ has a _name_ and optionally a _value_.
-An _option_ without a _value_ is taken to have the literal value `true`.
+An _option_ without a _value_ has the literal value `true`.
 
 If an _option_ has a _value_,
 it is separated from the _name_ by an U+003D EQUALS SIGN `=` along with


### PR DESCRIPTION
Closes #386

This allows for options without a value, which here default to a literal `true`. This replicates similar behaviour as used in HTML.

The default value is a string, as this explicitly makes `{:foo bar}`, `{:foo bar=true}` and `{:foo bar=|true|}` all indistinguishable from each other, and avoids adding boolean values as a concept.

In addition to function options, the utility of this syntax has been raised in discussions of expression attributes (#450, #458), which would also be able to use the same syntax.