### PR TITLE
Update design doc for message pattern quoting

### DIFF
--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -1,4 +1,4 @@
-# Message Parse Mode
+# Message Pattern Quoting
 
 Status: **Proposed**
 
@@ -17,7 +17,9 @@ Status: **Proposed**
 
 ## Objective
 
-Decide whether text patterns or code statements should be enclosed in MF2.
+Decide whether text patterns must always be quoted,
+or whether we allow them to be optionally quoted,
+for non-simple messages in MF2.
 
 ## Background
 

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -76,13 +76,26 @@ The [whitespace behavior for Freemarker](https://freemarker.apache.org/docs/dgui
 Other formats supporting multiple message variants tend to rely on a surrounding resource format to define variants,
 such as [Rails internationalization](https://guides.rubyonrails.org/i18n.html#pluralization) in Ruby or YAML
 and [Android String Resources](https://developer.android.com/guide/topics/resources/string-resource.html#Plurals) in XML.
-These formats rely on the resource format providing clear delineation of the beginning and end of a pattern.
+A message author will need to resolve the combination of the rules of these formats and the rules of the containing resource formats in order to achieve a clear delineation of the beginning and end of a pattern.
+For example, an Android resource string that includes leading whitespace in the message might look like
+```
+<string xml:space="preserve">"   Section 7.a. Attribute Types"</string>
+```
+In this example above, the containing XML format will collapse consecutive whitespace characters into a single space unless you provide the attribute `xml:space="preserve"`.
+After the resource file gets parsed as XML, the Android string resource format 
+[does additional whitespace collapsing and Android escaping](https://developer.android.com/guide/topics/resources/string-resource#escaping_quotes),
+requiring the entire text node string to be wrapped in double quotation marks `"..."` to preserve the initial whitespace, or the inital whitespace to use Android escaping (`\u0032 \u0032 ...`).
 
 Based on available data,
 no more than 0.3% of all messages and no more than 0.1% of messages with variants
 contain leading or trailing whitespace.
-No more than one third of this whitespace is localizable,
-and most commonly it's due to improper segmentation or other internationalization bugs.
+However, frequency of occurrence is not an indicator of the importance of leading or trailing whitespace to those authoring such messages.
+For example, sometimes such messages are authored in order to achieve a semblance of formatting in contexts that lack rich text presentation styles,
+such as operating system widgets.
+Even though such messages are usually infrequent relative to the size of all user-facing / transalatable messages,
+that is not an indicator of their significance.
+Also importantly, we cannot make assumptions about the validity of leading or trailing whitespace in a message,
+especially since their usage may be entirely unrelated to internationalization issues (ex: sentence agreement disruption by concatenation).
 
 ## Use-Cases
 

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -171,27 +171,40 @@ the extent that we make it easy to get into trouble we fail.
 Developers and translators should be able to read and write the syntax easily in a text editor.
 
 Translators (and their tools) are not software engineers, so we want our syntax
-to be as simple, robust, and non-fussy as possible.
-Multiple levels of complex nesting should be avoided,
-along with any constructs that require an excessive
-level of precision on the part of non-technical authors.
+to be as simple and robust as possible.
+
+Nesting level is not a requirement.
+People are not parsers, and don't care about nesting.
+What matters to them is their ability to recognize where a message pattern starts and where it ends.
+In the following example, localizable text is easily recognizable (especially with syntax highlighting),
+even if it occurs 3 level deep.
+
+```java
+print "{{{This is translatable}}}"
+if (foo) print "{{{This is translatable}}}" else print "{{{This is NOT translatable}}}"
+if (foo) if (bar) switch (baz) case 1: print "{{{This is translatable, deep}}}" break; default: print "{{{This is NOT translatable, deep}}}"
+```
 
 As MessageFormat 2 will be at best a secondary language to all its authors and editors,
 it should conform to user expectations and require as little learning as possible.
 
-The syntax should avoid footguns,
-in particular as it's passed through various tools during formatting.
+The syntax should avoid footguns, in particular as it's passed through various tools during formatting or stored existing file formats, databases, etc.
+Very importantly in this regard,
+we should minimize the range of characters that need to be escaped in patterns.
+
 
 ASCII-compatible syntax. While support for non-ASCII characters for variable names,
 values, literals, options, and the like are important, the syntax itself should
 be restricted to ASCII characters. This allows the message to be parsed
 visually by humans even when embedded in a syntax that requires escaping.
 
-Whitespace is forgiving.
-We _require_ the minimum amount of whitespace and allow
-authors to format or change unimportant whitespace as much as they want.
+Whitespace is forgiving, so we should be flexible with its use in the code area of message.
 This avoids the need for translators or tools to be super pedantic about
 formatting.
+However, we want WYSIWYG behavior as much as possible in patterns, meaning that there is minimal visual difference
+between the pattern and its interpolated output,
+and that there is minimal ambiguity.
+This avoids chances for unwanted surprises between the message authoring time expectations and the actual runtime formatted results.
 
 ## Constraints
 

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -8,6 +8,8 @@ Status: **Proposed**
 		<dt>Contributors</dt>
 		<dd>@eemeli</dd>
 		<dd>@aphillips</dd><!-- Seville and other inserted edits -->
+		<dd>@mihnita</dd>
+		<dd>@echeran</dd>
 		<dt>First proposed</dt>
 		<dd>2023-09-13</dd>
 		<dt>Pull Request</dt>

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -282,7 +282,7 @@ directly after code:
 >
 > This has a newline and a space at the start and a space-newline at the end
 >
->>{when *}{|
+>{when *}{|
 >|} You can quote the newlines and spaces should you desire {|
 >|}
 >```

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -66,12 +66,14 @@ Some templating libraries support both styles.
 
 When considering string formatting and templating libraries,
 it is important to keep the rules of pattern or template handling separate from and uninfluenced by the output format's rules.
-For example, many templating languages are designed around producing HTML output, for which consecutive whitespace characters within the output are collapsed into a single ASCII space.
-However, if the templating language is not strict on preserving whitespace,
+For example, many templating languages are designed around producing HTML output, for which consecutive whitespace characters within the output are collapsed into a single ASCII space by HTML renderers.
+However, if the templating language is similarly not strict on preserving whitespace,
 then it would be incapable of generating Python source code,
 for which whitespace is significant in determining block scope via the indentation (leading whitespace on a line).
 
-In fact, some HTML-oriented templating libraries preserve whitespace by default in a what-you-see-is-what-you-get (WYSIWYG) manner (Mustache, [Jinja](https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control)),
+In fact, many HTML-oriented templating libraries preserve whitespace by default in a what-you-see-is-what-you-get (WYSIWYG) manner
+([Mustache](https://mustache.github.io/mustache.5.html#Sections),
+[Jinja](https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control)),
 and some perform whitespace trimming in unspecified ways ([Handlebars](https://handlebarsjs.com/guide/expressions.html#whitespace-control)).
 The [whitespace behavior for Freemarker](https://freemarker.apache.org/docs/dgui_misc_whitespace.html), a general purpose templating library for multiple formats, is also WYSIWYG by default while allowing several optional trimming controls.
 
@@ -165,8 +167,8 @@ Translators (and their tools) are not software engineers, so we want our syntax
 to be as simple and robust as possible.
 
 Nesting level is not a requirement.
-People are not parsers, and don't care about nesting.
-What matters to them is their ability to recognize where a message pattern starts and where it ends.
+People are not parsers, and don't care about the nesting level as a primary concern when reading a message.
+What matters to them is their ability to recognize where a message's pattern starts and where it ends.
 In the following example, localizable text is easily recognizable (especially with syntax highlighting),
 even if it occurs 3 level deep.
 
@@ -205,7 +207,7 @@ The current syntax includes some plain-ascii keywords:
 `input`, `local`, `match`, and `when`.
 
 The current syntax and active proposals include some sigil + name combinations,
-such as :number, $var, |literal|, +bold, -bold, and posibly @attr.
+such as `:number`, `$var`, `|literal|`, `+bold`, `-bold`, and posibly `@attr`.
 
 The current syntax supports unquoted literal values as operands.
 

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -214,13 +214,25 @@ The current syntax includes some plain-ascii keywords:
 `input`, `local`, `match`, and `when`.
 
 The current syntax and active proposals include some sigil + name combinations,
-such as `:number`, `$var`, `|literal|`, `+bold`, and `@attr`.
+such as :number, $var, |literal|, +bold, -bold, and posibly @attr.
 
 The current syntax supports unquoted literal values as operands.
 
-Messages themselves are "simple strings" and must be considered to be a single
-line of text. In many containing formats, newlines will be represented as the local
-equivalent of `\n`.
+Messages themselves are "simple strings" and must be considered to be WYSIWYG.
+The WYSIWYG nature of representing a message pattern is independent of whether the message is a single line or contains multiple lines.
+
+There is no restriction that a message must only contain a single line (that is, not contain any newline characters),
+nor are there constraints about how newlines must be represented. As our [`spec/syntax.md`](../spec/syntax.md) states:
+
+> Any Unicode code point is allowed, except for surrogate code points U+D800 through U+DFFF inclusive.
+
+> Whitespace in _text_, including tabs, spaces, and newlines is significant and MUST be preserved during formatting.
+
+> ... Instead, we tolerate direct use of nearly all
+characters (including line breaks, control characters, etc.) and rely upon escaping
+in those outer formats to aid human comprehension (e.g., depending upon container
+format, a U+000A LINE FEED might be represented as `\n`, `\012`, `\x0A`, `\u000A`,
+`\U0000000A`, `&#xA;`, `&NewLine;`, `%0A`, `<LF>`, or something else entirely).
 
 ## Proposed Design
 

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -100,7 +100,6 @@ especially since their usage may be entirely unrelated to internationalization i
 ## Use-Cases
 
 Most messages in any localization system do not contain any expressions, statements or variants.
-These should be expressible as easily as possible.
 
 Many messages include expressions that are meant to be replaced during formatting.
 For example, a greeting like "Hello, {$username}!" would be formatted with the variable
@@ -126,9 +125,20 @@ according to its plural category
 So, in American English, the formatter might need to choose between formatting
 `You have 1 kilometer to go` and `You have 2 kilometers to go`.
 
-Rarely, messages needs to include leading or trailing whitespace due to
-e.g. how they will be concatenated with other text,
+Rarely do messages that need to include leading or trailing whitespace do so due to
+how they will be concatenated with other text,
 or as a result of being segmented from some larger volume of text.
+Based on available data,
+no more than 0.3% of all messages and no more than 0.1% of messages with variants
+contain leading or trailing whitespace.
+
+However, frequency of occurrence is not an indicator of the importance of leading or trailing whitespace to those authoring such messages.
+For example, sometimes such messages are authored in order to achieve a semblance of formatting in contexts that lack rich text presentation styles,
+such as operating system widgets.
+Even though such messages are usually infrequent relative to the size of all user-facing / transalatable messages,
+that is not an indicator of their significance.
+Also importantly, we cannot make assumptions about the validity of leading or trailing whitespace in a message,
+especially since their usage may be entirely unrelated to internationalization issues (ex: sentence agreement disruption by concatenation).
 
 ---
 

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -28,18 +28,38 @@ ICU MessageFormat and Fluent both support inline selectors
 separated from the text using `{…}` for multi-variant messages.
 ICU MessageFormat is the only known format that uses `{…}` to also delimit text.
 
-[Mustache templates](https://mustache.github.io/mustache.5.html)
-and related languages wrap "code" in `{{…}}`.
-In addition to placeholders that are replaced by their interpolated value during formatting,
-this also includes conditional blocks using `{{#…}}`/`{{/…}}` wrappers.
+Formatting and templating are distinct operations with similarities.
+Both interpolate strings by using input values,
+provided as inputs alongisde the formatting pattern string or template,
+to produce a new string.
+Formatting usually refers to smaller strings, usually no larger than a sentence,
+whereas templating are used to produce larger strings, usually for text files of various file formats, often for HTML documents.
 
-[Handlebars](https://handlebarsjs.com/guide/) extends Mustache expressions
-with operators such as `{{#if …}}` and `{{#each …}}`,
-as well as custom formatting functions that become available as e.g. `{{bold …}}`.
-
-[Jinja templates](https://jinja.palletsprojects.com/en/3.1.x/templates/) separate
-`{% statements %}` and `{{ expressions }}` from the base text.
-The former may define tests that determine the inclusion of subsequent text blocks in the output.
+There are two different styles of templating library design.
+Some languages/libraries enable the interopolation of the template substrings through programmatic expressions in "code mode" that print expressions to the output stream 
+(ex: [PHP](https://www.php.net/),
+[Freemarker](https://freemarker.apache.org/index.html)):
+```php
+<html>
+...
+	<?php
+		if (true) {
+			echo '<p>Hello World</p>';
+		}
+	?>
+...
+</html>
+```
+Some libraries separate string literal values from the programmatic expressions in "code mode" by defining a set of control flow constructs within delimiters,
+and all text outside the delimiters is printed to the output stream,
+and subject to control flow rules of their containing constructs.
+(ex: [Mustache templates](https://mustache.github.io/mustache.5.html),
+[Freemarker](https://freemarker.apache.org/index.html)).
+```
+{{#repo}}
+  <b>{{name}}</b>
+{{/repo}}
+```
 
 A cost that the message formatting and templating languages mentioned above need to rely on
 is some rule or behaviour that governs how to deal with whitespace at the beginning and end of a pattern,

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -142,9 +142,6 @@ especially since their usage may be entirely unrelated to internationalization i
 
 ---
 
-Developers editing a simple message and who wish to add an `input` or `local` annotiation
-to the message do not wish to reformat the message extensively.
-
 Developers who have messages that include leading or trailing whitespace
 want to ensure that this whitespace is included in the translatable
 text portion of the message.

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -223,7 +223,72 @@ in those outer formats to aid human comprehension (e.g., depending upon containe
 format, a U+000A LINE FEED might be represented as `\n`, `\012`, `\x0A`, `\u000A`,
 `\U0000000A`, `&#xA;`, `&NewLine;`, `%0A`, `<LF>`, or something else entirely).
 
+## Simple Messages
+
+In the Subcommittee meetings following Github discussions on Issues #493 and #499,
+the general consensus that formed for simple messages
+is that we allow them to be unquoted.
+
+("Simple messages" refers to messages consisting solely of a pattern, and thus are not complex messages.)
+
+Because the simple message pattern consists of the entire message,
+the pattern includes any leading or trailing whitespace.
+
+Given simple messages already being decided at a high level,
+the design decisions below for the proposed and alternative designs pertain specifically to complex messages.
+
 ## Proposed Design
+
+### Start in text, encapsulate message, always quote patterns
+
+Description:
+
+Since simple messages are unquoted (starting in text mode),
+complex messages must also start in text mode.
+
+Within a complex message, patterns are always quoted with `{{...}}` or other choice of delimiter.
+
+The entire complex message is also wrapped with `{{...}}` or other choice of delimiter.
+This allows interior "code mode" of message to have flexible whitespace in between tokens
+and _around_ quoted patterns.
+
+Pros
+
+* The rule about the whether leading and trailing whitespace is included is simple and unambiguous.
+* This matches the WYSIWIG behavior that simple messages preserve.
+* The patterns can be detected within the pattern more easily due to the delimiters serving as a visual anchor.
+* Requiring all patterns to be quoted minimizes the number of characters that need to be escaped within a pattern to 3:
+the 2 pattern delimiter characters and the escape character itself.
+* Because the sum of counts of declarations + `match` statement + `when` statements is always
+greater than or equal to the number of patterns,
+wrapping the entire message once yields less visual noise of repetitive code mode introducer symbols
+when there is 1+ declarations in a `match` (selection) message,
+or when there are 2+ declarations in a non-`match` complex message.
+
+Cons:
+
+* This comes at the cost of an inconsistency in the WYSIWYG patterns are quoted between simple and complex messages.
+In the case of simple messages, the containing format itself implicitly defines the beginning and end of the pattern (example: `"..."`), which is not visible at the level of MF2,
+while complex messages use the aforementioned delimiter to quote patterns (ex: `{{...}}`).
+* Another potential drawback, specifically in the case of non-`match` complex messages with exactly 1 declaration,
+is that this option adds 2 extra delimiters compared to an alternative syntax that doesn't require quoted patterns
+and is designed to minimize delimiter usage only to code mode introducers.
+
+Evaluation:
+
+The pros outweigh the cons, not just in cardinality, but far more importantly, according to the relative weight
+our value system places to the requirements met by the pro aspects compared to the con aspects. Namely:
+
+* [high] Unsurprising WYSIWYG behavior from patterns
+* [high] Easy recognition of patterns, even for non-developers
+* [high] A minimal number of characters requiring escaping
+* [high] No limitations on users with valid non-i18n concerns
+* [med] Flexible whitespace outside of patterns
+* [low] Number of characters typed (probably comparable with alternatives anyways)
+* [low] Number of "mode levels" from a parser perspective
+
+
+## Alternatives Considered
 
 ### Start in text, encapsulate code, trim around statements
 
@@ -244,8 +309,6 @@ Allow for a pattern to be `{{…}}` quoted
 such that it preserves its leading and/or trailing whitespace
 even when preceded or followed by statements.
 
-## Alternatives Considered
-
 ### Start in code, encapsulate text
 
 This approach treats messages as something like a resource format for pattern values.
@@ -261,19 +324,6 @@ so messages may appear wrapped as e.g. `"{{…}}"`.
 
 This option is not chosen due to adding an excessive
 quoting burden on all messages.
-
-### Start in text, encapsulate code, re-encapsulate text within code
-
-As in the proposed design, simple patterns are unquoted.
-Patterns in messages with statements, however,
-are required to always be surrounded by `{{…}}` or some other delimiters.
-
-This effectively means that some syntax will "enable" code mode for a message,
-and that patterns in such a message need delimiters.
-
-This option is not chosen due to adding an excessive
-quoting burden on all multi-variant messages,
-as well as introducing an unnecessary additional conceptual layer to the syntax.
 
 ### Start in text, encapsulate code, trim minimally
 
@@ -315,3 +365,7 @@ With these changes,
 all whitespace would need to be explicitly within the "code" part of the syntax,
 and patterns could never be separated from statements
 without adding whitespace to the pattern.
+
+## Scoring matrix
+
+TBD

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -86,7 +86,7 @@ For example, an Android resource string that includes leading whitespace in the 
 <string xml:space="preserve">"   Section 7.a. Attribute Types"</string>
 ```
 In this example above, the containing XML format will collapse consecutive whitespace characters into a single space unless you provide the attribute `xml:space="preserve"`.
-After the resource file gets parsed as XML, the Android string resource format 
+After the resource file gets parsed as XML, the Android resource compiler requires
 [does additional whitespace collapsing and Android escaping](https://developer.android.com/guide/topics/resources/string-resource#escaping_quotes),
 requiring the entire text node string to be wrapped in double quotation marks `"..."` to preserve the initial whitespace, or the inital whitespace to use Android escaping (`\u0032 \u0032 ...`).
 
@@ -118,20 +118,20 @@ according to its plural category
 So, in American English, the formatter might need to choose between formatting
 `You have 1 kilometer to go` and `You have 2 kilometers to go`.
 
-Rarely do messages that need to include leading or trailing whitespace do so due to
-how they will be concatenated with other text,
+Rarely, messages need to include leading or trailing whitespace due to
+e.g. how they will be concatenated with other text,
 or as a result of being segmented from some larger volume of text.
 Based on available data,
 no more than 0.3% of all messages and no more than 0.1% of messages with variants
 contain leading or trailing whitespace.
 
 However, frequency of occurrence is not an indicator of the importance of leading or trailing whitespace to those authoring such messages.
-For example, sometimes such messages are authored in order to achieve a semblance of formatting in contexts that lack rich text presentation styles,
+For example, sometimes such messages are authored in order to achieve a [semblance of formatting in contexts that lack rich text presentation styles](https://docs.oracle.com/cd/E19957-01/817-4220/images/SetupWizWelcome2.gif),
 such as operating system widgets.
 Even though such messages are usually infrequent relative to the size of all user-facing / transalatable messages,
 that is not an indicator of their significance.
-Also importantly, we cannot make assumptions about the validity of leading or trailing whitespace in a message,
-especially since their usage may be entirely unrelated to internationalization issues (ex: sentence agreement disruption by concatenation).
+There are valid use cases for leading or trailing whitespace in a message that are not internationalization bugs.
+This means that it is not MF2's concern to enforce/discourage their usage.
 
 ---
 
@@ -146,7 +146,7 @@ It should be easy to do simple things; possible to do complex things; and imposs
 
 <details>
 <blockquote>
-APIs should be easy to use and hard to misuse. It should be easy to do simple things; possible to do complex things; and impossible, or at least difficult, to do wrong things.
+APIs should be easy to use and hard to misuse. It should be easy to do simple things; possible to do complex things; and impossible, or at least difficult, to do wrong things. (per Joshua Bloch)
 
 —<a href="https://www.infoq.com/articles/API-Design-Joshua-Bloch/">Joshua Bloch, 2008</a>, author of <i>Effective Java</i>, etc.
 </blockquote>
@@ -191,7 +191,7 @@ values, literals, options, and the like are important, the syntax itself should
 be restricted to ASCII characters. This allows the message to be parsed
 visually by humans even when embedded in a syntax that requires escaping.
 
-Whitespace is forgiving, so we should be flexible with its use in the code area of message.
+We should be flexible with the use of whitespace in the code area of message.
 This avoids the need for translators or tools to be super pedantic about
 formatting.
 However, we want WYSIWYG behavior as much as possible in patterns, meaning that there is minimal visual difference
@@ -277,6 +277,7 @@ while complex messages use the aforementioned delimiter to quote patterns (ex: `
 * Another potential drawback, specifically in the case of non-`match` complex messages with exactly 1 declaration,
 is that this option adds 2 extra delimiters compared to an alternative syntax that doesn't require quoted patterns
 and is designed to minimize delimiter usage only to code mode introducers.
+* If we use curlies for patterns and for placeholders, then they serve double duty, which may make the syntax harder to understand, and also harder to make the pattern out visually.
 
 Evaluation:
 

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -86,17 +86,6 @@ After the resource file gets parsed as XML, the Android string resource format
 [does additional whitespace collapsing and Android escaping](https://developer.android.com/guide/topics/resources/string-resource#escaping_quotes),
 requiring the entire text node string to be wrapped in double quotation marks `"..."` to preserve the initial whitespace, or the inital whitespace to use Android escaping (`\u0032 \u0032 ...`).
 
-Based on available data,
-no more than 0.3% of all messages and no more than 0.1% of messages with variants
-contain leading or trailing whitespace.
-However, frequency of occurrence is not an indicator of the importance of leading or trailing whitespace to those authoring such messages.
-For example, sometimes such messages are authored in order to achieve a semblance of formatting in contexts that lack rich text presentation styles,
-such as operating system widgets.
-Even though such messages are usually infrequent relative to the size of all user-facing / transalatable messages,
-that is not an indicator of their significance.
-Also importantly, we cannot make assumptions about the validity of leading or trailing whitespace in a message,
-especially since their usage may be entirely unrelated to internationalization issues (ex: sentence agreement disruption by concatenation).
-
 ## Use-Cases
 
 Most messages in any localization system do not contain any expressions, statements or variants.

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -60,10 +60,18 @@ and subject to control flow rules of their containing constructs.
   <b>{{name}}</b>
 {{/repo}}
 ```
+Some templating libraries support both styles.
 
-A cost that the message formatting and templating languages mentioned above need to rely on
-is some rule or behaviour that governs how to deal with whitespace at the beginning and end of a pattern,
-as statements may be separated from each other by newlines or other constructs for legibility.
+When considering string formatting and templating libraries,
+it is important to keep the rules of pattern or template handling separate from and uninfluenced by the output format's rules.
+For example, many templating languages are designed around producing HTML output, for which consecutive whitespace characters within the output are collapsed into a single ASCII space.
+However, if the templating language is not strict on preserving whitespace,
+then it would be incapable of generating Python source code,
+for which whitespace is significant in determining block scope via the indentation (leading whitespace on a line).
+
+In fact, some HTML-oriented templating libraries preserve whitespace by default in a what-you-see-is-what-you-get (WYSIWYG) manner (Mustache, [Jinja](https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control)),
+and some perform whitespace trimming in unspecified ways ([Handlebars](https://handlebarsjs.com/guide/expressions.html#whitespace-control)).
+The [whitespace behavior for Freemarker](https://freemarker.apache.org/docs/dgui_misc_whitespace.html), a general purpose templating library for multiple formats, is also WYSIWYG by default while allowing several optional trimming controls.
 
 Other formats supporting multiple message variants tend to rely on a surrounding resource format to define variants,
 such as [Rails internationalization](https://guides.rubyonrails.org/i18n.html#pluralization) in Ruby or YAML

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -149,7 +149,24 @@ Which whitespace characters are displayed at runtime should not be surprising.
 
 ## Requirements
 
-Common things should be easy, uncommon things should be possible.
+It should be easy to do simple things; possible to do complex things; and impossible, or at least difficult, to do wrong things.
+
+<details>
+<blockquote>
+APIs should be easy to use and hard to misuse. It should be easy to do simple things; possible to do complex things; and impossible, or at least difficult, to do wrong things.
+
+—<a href="https://www.infoq.com/articles/API-Design-Joshua-Bloch/">Joshua Bloch, 2008</a>, author of <i>Effective Java</i>, etc.
+</blockquote>
+<blockquote>
+The Pit of Success: in stark contrast to a summit, a
+peak, or a journey across a desert to find victory through many trials and
+surprises, we want our customers to simply fall into winning practices by using
+our platform and frameworks. To
+the extent that we make it easy to get into trouble we fail.
+          
+—Rico Mariani, MS Research MindSwap Oct 2003. (<a href="https://learn.microsoft.com/en-us/archive/blogs/brada/the-pit-of-success">restated by Brad Adams</a>, MS CLR and .Net team cofounder)
+</blockquote>
+</details>
 
 Developers and translators should be able to read and write the syntax easily in a text editor.
 

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -157,6 +157,19 @@ There are five candidates for handling the boundaries between code and patterns:
 
 ### Always Quote
 
+```
+{{
+match {$var}
+when   0 {{This has no space in front of it.}}
+when one
+   {{This has no space or newline in front of it.}}
+when few
+  {{ This has one space at the start and the end. }}
+when many   {{ This also has one space start and end. }}
+when * {{You must quote all variant patterns.}}
+}}
+```
+
 Pros:
 - The boundary between pattern and code is always clear.
 - The quoting reduces the number of in-pattern escapes to the open/close sequence.

--- a/exploration/text-vs-code.md
+++ b/exploration/text-vs-code.md
@@ -19,9 +19,9 @@ Status: **Proposed**
 
 ## Objective
 
-Decide whether text patterns must always be quoted,
-or whether we allow them to be optionally quoted,
-for non-simple messages in MF2.
+Decide whether to permit _patterns_ (message text) to be unquoted
+when embedded in code. 
+Currently all _patterns_ must be quoted in non-simple messages.
 
 ## Background
 
@@ -33,11 +33,9 @@ separated from the text using `{…}` for multi-variant messages.
 ICU MessageFormat is the only known format that uses `{…}` to also delimit text.
 
 Formatting and templating are distinct operations with similarities.
-Both interpolate strings by using input values,
-provided as inputs alongisde the formatting pattern string or template,
-to produce a new string.
+Both take input values to replace portions of the pattern string or template, producing a new, formatted, string.
 Formatting usually refers to smaller strings, usually no larger than a sentence,
-whereas templating are used to produce larger strings, usually for text files of various file formats, often for HTML documents.
+whereas templating is typically used to produce larger strings (generally whole documents, such as an HTML file)
 
 There are two different styles of templating library design.
 Some languages/libraries enable the interopolation of the template substrings through programmatic expressions in "code mode" that print expressions to the output stream 
@@ -209,7 +207,7 @@ The current syntax includes some plain-ascii keywords:
 `input`, `local`, `match`, and `when`.
 
 The current syntax and active proposals include some sigil + name combinations,
-such as `:number`, `$var`, `|literal|`, `+bold`, `-bold`, and posibly `@attr`.
+such as `:number`, `$var`, `|literal|`, `+bold`, `-bold`, and possibly `@attr`.
 
 The current syntax supports unquoted literal values as operands.
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -64,7 +64,7 @@ The syntax specification takes into account the following design restrictions:
 
 ## Messages and their Syntax
 
-The purpose of MessageFormat is the allow content to vary at runtime.
+The purpose of MessageFormat is to allow content to vary at runtime.
 This variation might be due to placing a value into the content
 or it might be due to selecting a different bit of content based on some data value
 or it might be due to a combination of the two.


### PR DESCRIPTION
An update to the design doc, specifically on the topic of: "Do we allow unquoted variant patterns?"

Very much a WIP while in draft mode (not suitable for "drive-by reviews" until officially ready for review).

@mihnita please take an initial look and provide suggestions.