### PR TITLE
Clarify declaration immutability

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -758,7 +758,7 @@ These are divided into the following categories:
     contains a _selector_ that does not have an _annotation_,
     or contains a _variable_ that does not directly or indirectly reference a _declaration_ with an _annotation_.
 
-    > Example invalid messages resulting in a _Missing Selector Annotation error_:
+    > Examples of invalid messages resulting in a _Missing Selector Annotation error_:
     >
     > ```
     > {{
@@ -786,11 +786,32 @@ These are divided into the following categories:
     > }}
     > ```
 
+  - **Duplicate Declaration errors** occur when a _variable_ appears in two _declarations_.
+    This includes when an _input-declaration_ binds a _variable_ that appears in a previous _declaration_,
+    when a _local-declaration_ binds a _variable_ that appears in a previous _declaration_,
+    or when a _local-declaration_ refers to its _variable_ in its _expression_.
+
+    > Examples of invalid messages resulting in a Duplicate Declaration error:
+    >
+    > ```
+    > {{
+    >    input {$var :number maxFractionDigits=0}
+    >    input {$var :number minFractionDigits=0}
+    >    {{Redeclaration of the same variable}}
+    > }}
+    > {{
+    >    local $var = {$ext :someFunction}
+    >    local $var = {$error}
+    >    local $var2 = {$var2 :error}
+    >    {{{$var} cannot be redefined. {$var2} cannot refer to itself}}
+    > }}
+    > ```
+
   - **Duplicate Option Name errors** occur when the same _name_
     appears on the left-hand side
     of more than one _option_ in the same _expression_.
 
-    > Example invalid messages resulting in a Duplicate Option Name error:
+    > Examples of invalid messages resulting in a Duplicate Option Name error:
     >
     > ```
     > Value is {42 :number style=percent style=decimal}

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -800,6 +800,16 @@ These are divided into the following categories:
     >    {{Redeclaration of the same variable}}
     > }}
     > {{
+    >    local $var = {$ext :number maxFractionDigits=0}
+    >    input {$var :number minFractionDigits=0}
+    >    {{Redeclaration of a local variable}}
+    > }}
+    > {{
+    >    input {$var :number minFractionDigits=0}
+    >    local $var = {$ext :number maxFractionDigits=0}
+    >    {{Redeclaration of an input variable}}
+    > }}
+    > {{
     >    local $var = {$ext :someFunction}
     >    local $var = {$error}
     >    local $var2 = {$var2 :error}

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -786,7 +786,7 @@ These are divided into the following categories:
     > }}
     > ```
 
-  - **Duplicate Declaration errors** occur when a _variable_ appears in two _declarations_.
+  - A **Duplicate Declaration error** occurs when a _variable_ appears in two _declarations_.
     This includes when an _input-declaration_ binds a _variable_ that appears in a previous _declaration_,
     when a _local-declaration_ binds a _variable_ that appears in a previous _declaration_,
     or when a _local-declaration_ refers to its _variable_ in its _expression_.
@@ -807,7 +807,7 @@ These are divided into the following categories:
     > }}
     > ```
 
-  - **Duplicate Option Name errors** occur when the same _name_
+  - A **Duplicate Option Name error** occurs when the same _name_
     appears on the left-hand side
     of more than one _option_ in the same _expression_.
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -789,7 +789,7 @@ These are divided into the following categories:
   - A **Duplicate Declaration error** occurs when a _variable_ appears in two _declarations_.
     This includes when an _input-declaration_ binds a _variable_ that appears in a previous _declaration_,
     when a _local-declaration_ binds a _variable_ that appears in a previous _declaration_,
-    or when a _local-declaration_ refers to its _variable_ in its _expression_.
+    or when a _local-declaration_ refers to its bound _variable_ in its _expression_.
 
     > Examples of invalid messages resulting in a Duplicate Declaration error:
     >

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -163,21 +163,6 @@ Duplicate Declaration error during formatting:
   _declaration_.
 - A _local-declaration_ MUST NOT bind a _variable_ that appears in its _expression_.
 
-> Examples of invalid messages:
-> ```
-> {{
->    input {$var :number maxFractionDigits=0}
->    input {$var :number minFractionDigits=0}
->    {{Redeclaration of the same variable}}
-> }}
-> {{
->    local $var = {$ext :someFunction}
->    local $var = {$error}
->    local $var2 = {$var2 :error}
->    {{{$var} cannot be redefined. {$var2} cannot refer to itself}}
-> }}
-> ```
-
 > [!Note]
 > These restrictions only apply to _declarations_.
 > A _placeholder_ or _selector_ MAY override the annotation provided in a _declaration_.
@@ -190,6 +175,7 @@ Duplicate Declaration error during formatting:
 >    when * {{This pattern can re-annotate {$var :number maxFractionDigits=3}}}
 > }}
 > ```
+> (See [Error Handling](./formatting.md#error-handling) for examples of invalid messages)
 
 ### Body
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -163,9 +163,13 @@ Duplicate Declaration error during formatting:
   _declaration_.
 - A _local-declaration_ MUST NOT bind a _variable_ that appears in its _expression_.
 
+A _local-declaration_ MAY overwrite an external input value as long as the
+external input value does not appear in a _declaration_.
+
 > [!Note]
 > These restrictions only apply to _declarations_.
-> A _placeholder_ or _selector_ MAY override the annotation provided in a _declaration_.
+> A _placeholder_ or _selector_ MAY supply a different annotation than one
+> provided in a _declaration_ for the same _variable_.
 > For example, this message is _valid_:
 > ```
 > {{

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -168,15 +168,15 @@ external input value does not appear in a _declaration_.
 
 > [!Note]
 > These restrictions only apply to _declarations_.
-> A _placeholder_ or _selector_ MAY supply a different annotation than one
-> provided in a _declaration_ for the same _variable_.
+> A _placeholder_ or _selector_ can apply a different annotation to a _variable_
+> than one applied to the same _variable_ name in a _declaration_.
 > For example, this message is _valid_:
 > ```
 > {{
 >    input {$var :number maxFractionDigits=0}
 >    match {$var :plural maxFractionDigits=2}
->    when 0 {{The selector can re-annotate {$var}}}
->    when * {{This pattern can re-annotate {$var :number maxFractionDigits=3}}}
+>    when 0 {{The selector can apply a different annotation to {$var} for the purposes of selection}}
+>    when * {{A placeholder in a pattern can apply a different annotation to {$var :number maxFractionDigits=3}}}
 > }}
 > ```
 > (See [Error Handling](./formatting.md#error-handling) for examples of invalid messages)

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -148,18 +148,48 @@ MAY include an _annotation_ that is applied to the external value.
 
 A **_<dfn>local-declaration</dfn>_** binds a _variable_ to the resolved value of an _expression_.
 
-Declared _variables_ MUST NOT be used before their _declaration_,
-and their values MUST NOT be self-referential;
-otherwise, a _message_ is not considered _valid_.
-
-Multiple _declarations_ MUST NOT bind a value to the same _variable_;
-otherwise, a _message_ is not considered _valid_.
-
 ```abnf
 declaration = input-declaration / local-declaration
 input-declaration = input [s] variable-expression
 local-declaration = local s variable [s] "=" [s] expression
 ```
+
+_Variables_, once declared, MUST NOT be redeclared. 
+A _message_ that does any of the following is not _valid_ and will produce a 
+Duplicate Declaration error during formatting:
+- An _input-declaration_ MUST NOT bind a _variable_ that appears as a _variable_ in a previous 
+  _declaration_.
+- A _local-declaration_ MUST NOT bind a _variable_ that appears as a _variable_ in a previous
+  _declaration_.
+- A _local-declaration_ MUST NOT bind a _variable_ that appears in its _expression_.
+
+> Examples of invalid messages:
+> ```
+> {{
+>    input {$var :number maxFractionDigits=0}
+>    input {$var :number minFractionDigits=0}
+>    {{Redeclaration of the same variable}}
+> }}
+> {{
+>    local $var = {$ext :someFunction}
+>    local $var = {$error}
+>    local $var2 = {$var2 :error}
+>    {{{$var} cannot be redefined. {$var2} cannot refer to itself}}
+> }}
+> ```
+
+> [!Note]
+> These restrictions only apply to _declarations_.
+> A _placeholder_ or _selector_ MAY override the annotation provided in a _declaration_.
+> For example, this message is _valid_:
+> ```
+> {{
+>    input {$var :number maxFractionDigits=0}
+>    match {$var :plural maxFractionDigits=2}
+>    when 0 {{The selector can re-annotate {$var}}}
+>    when * {{This pattern can re-annotate {$var :number maxFractionDigits=3}}}
+> }}
+> ```
 
 ### Body
 


### PR DESCRIPTION
Having reviewed @catamorphism's previous text and looking at our current text, these are proposed **_editorial_** changes to make variable immutability clearer in the spec. The previous text's "a _messages_ is not considered valid" doesn't read as proper English. We also lack an error for this (we have one for duplicate options), so I added one.