### PR TITLE
Implementing namespacing

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -202,15 +202,16 @@ the following steps are taken:
    If the registry does not define an implementation for this _name_,
    emit an Unknown Function error
    and use a _fallback value_ for the _expression_.
-4. If the _expression_ includes _options_, resolve the _options_ to a mapping
+3. If the _expression_ includes _options_, resolve the _options_ to a mapping
    of string identifiers to values.
    For each _option_:
-   - _Resolve the name_ of the option.
-   - If its right-hand side successfully resolves to a value,
-     bind the _name_ of the _option_ to the resolved value in the mapping.
+   - _Resolve the name_ of the _option_.
+   - If the _option_'s _name-part_ already exists in the resolved mapping of _options_,
+     emit a Duplicate Option Name error.
+   - If the _option_'s right-hand side successfully resolves to a value,
+     bind the _name-part_ of the _option_'s to the resolved value in the mapping.
    - Otherwise, do not bind the _name_ of the _option_ to any value in the mapping.
-6. Call the function implementation with the following arguments:
-
+4. Call the function implementation with the following arguments:
    - The current _locale_.
    - The resolved mapping of _options_.
    - If the _expression_ includes an _operand_, its resolved value.
@@ -220,18 +221,20 @@ the following steps are taken:
    An implementation MAY pass additional arguments to the function,
    as long as reasonable precautions are taken to keep the function interface
    simple and minimal, and avoid introducing potential security vulnerabilities.
-   Implementations SHOULD use an implementation-defined _namesapce_ for
-   any additional arguments exposed to users as _options_.
 
-An implementation MAY define its own functions.
-An implementation MAY allow custom functions to be defined by users.
+   Implementations MAY expose _options_ in an implementation-defined _namespace_
+   in addition to or superceding those found in the default registry.
+
+   An implementation MAY define its own functions.
+   An implementation MAY allow custom functions to be defined by users.
+
    Function access to the _formatting context_ MUST be minimal and read-only,
    and execution time SHOULD be limited.
    Implementation-defined _functions_ SHOULD use an implementation-defined _namespace_.
    User-defined _functions_ SHOULD be permitted to define the _namespace_ to use
    in name resolution.
 
-8. If the call succeeds,
+5. If the call succeeds,
    resolve the value of the _expression_ as the result of that function call.
    If the call fails or does not return a valid value,
    emit a Resolution error and use a _fallback value_ for the _expression_.
@@ -239,10 +242,10 @@ An implementation MAY allow custom functions to be defined by users.
 ### Name Resolution
 
 <dfn title="resolve the name">**_Name resolution_**</dfn> is the determination of
-the _name_ and the _namespace_ of the name for a given _function_
+the _name-part_ and, where present, the _namespace_ of the _name_ for a given _function_
 or _option_.
 
-To determine the _name_ of an item, the following steps are taken:
+To resolve the _name_ of an item, the following steps are taken:
 
 1. Let the _name_ be the string to be processed, less any preceeding
    sigils or markers.
@@ -251,10 +254,11 @@ To determine the _name_ of an item, the following steps are taken:
 2. Determine if _name_ contains the character U+003A COLON `:`:
    - If _name_ contains a colon, let _namespace_ be the
       substring of _name_ up to (but not including)
-      the colon and _name_ be the substring of _name_ following the colon;
-   - Else let _namespace_ be an empty value (null, void, or empty string).
-4. If the _name_ is empty, return a Syntax error.
-5. Return _namespace_ and _name_.
+      the colon and _name-part_ be the substring of _name_ following the colon;
+   - Else let _namespace_ be an empty value (null, void, or empty string)
+     and _name-part_ be the _name_.
+3. If the _name-part_ is empty, return a Syntax error.
+4. Return _namespace_ and _name-part_.
 
 Implementations are not required to support the installation or resolution
 of different namespaces.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -197,14 +197,14 @@ the following steps are taken:
 
 1. If the _expression_ includes an _operand_, resolve its value.
    If this fails, use a _fallback value_ for the _expression_.
-2. _Resolve the name_ of the _function_ and, based on the starting sigil,
+2. Resolve the _identifier_ of the _function_ and, based on the starting sigil,
    find the appropriate function implementation to call.
    If the implementation cannot find the function, emit an Unknown Function error
    and use a _fallback value_ for the _expression_.
 
    An implementation MAY emit an Unknown Function error if the implementation    
-   does not support the _namespace_ of the _name_
-   or the _namespace_ does not support the _name-part_ named _function_.
+   does not support the _namespace_ of the _identifier_
+   or the _namespace_ does not support the named _function_.
 
    Implementations are not required to implement _namespaces_ or installable
    _function registries_.
@@ -212,12 +212,12 @@ the following steps are taken:
 4. If the _expression_ includes _options_, resolve the _options_ to a mapping
    of string identifiers to values.
    For each _option_:
-   - _Resolve the name_ of the _option_.
-   - If the _option_'s _name_ already exists in the resolved mapping of _options_,
+   - Resolve the _identifier_ of the _option_.
+   - If the _option_'s _identifier_ already exists in the resolved mapping of _options_,
      emit a Duplicate Option Name error.
    - If the _option_'s right-hand side successfully resolves to a value,
-     bind the _name_ of the _option_ to the resolved value in the mapping.
-   - Otherwise, do not bind the _name_ of the _option_ to any value in the mapping.
+     bind the _identifier_ of the _option_ to the resolved value in the mapping.
+   - Otherwise, do not bind the _identifier_ of the _option_ to any value in the mapping.
 4. Call the function implementation with the following arguments:
 
    - The current _locale_.
@@ -271,13 +271,13 @@ The _fallback value_ depends on the contents of the _expression_:
   > Example: `$user`
 
 - _expression_ with no _operand_:
-  the _function_ starting sigil followed by its _name_
+  the _function_ starting sigil followed by its _identifier_
 
   > Examples: `:platform`, `+tag`, `-tag`
 
 - Otherwise: The U+FFFD REPLACEMENT CHARACTER `�` character
 
-_Option_ names and values are not included in the _fallback value_.
+_Option_ identifiers and values are not included in the _fallback value_.
 
 When an error occurs in an _expression_ with a _variable_ _operand_
 and the _variable_ refers to a local _declaration_,
@@ -833,7 +833,7 @@ These are divided into the following categories:
     > }}
     > ```
 
-  - A **Duplicate Option Name error** occurs when the same _name_
+  - A **Duplicate Option Name error** occurs when the same _identifier_
     appears on the left-hand side
     of more than one _option_ in the same _expression_.
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -199,7 +199,9 @@ the following steps are taken:
    If this fails, use a _fallback value_ for the _expression_.
 2. Resolve the _identifier_ of the _function_ and, based on the starting sigil,
    find the appropriate function implementation to call.
-   If the implementation cannot find the function, emit an Unknown Function error
+   If the implementation cannot find the function,
+   or if the _identifier_ includes a _namespace_ that the implementation does not support,
+   emit an Unknown Function error
    and use a _fallback value_ for the _expression_.
 
    An implementation MUST emit an Unknown Function error

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -198,11 +198,17 @@ the following steps are taken:
 1. If the _expression_ includes an _operand_, resolve its value.
    If this fails, use a _fallback value_ for the _expression_.
 2. _Resolve the name_ of the _function_ and, based on the starting sigil,
-   find the appropriate function implementation from the _function registry_.
-   If the implementation does not support the _namespace_ of the _name_
-   or the _namespace_ does not support the _name-part_ named _function_,
-   emit an Unknown Function error
+   find the appropriate function implementation to call.
+   If the implementation cannot find the function, emit an Unknown Function error
    and use a _fallback value_ for the _expression_.
+
+   An implementation MAY emit an Unknown Function error if the implementation    
+   does not support the _namespace_ of the _name_
+   or the _namespace_ does not support the _name-part_ named _function_.
+
+   Implementations are not required to implement _namespaces_ or installable
+   _function registries_.
+
 4. If the _expression_ includes _options_, resolve the _options_ to a mapping
    of string identifiers to values.
    For each _option_:
@@ -226,58 +232,19 @@ the following steps are taken:
    An implementation MAY define its own functions.
    An implementation MAY allow custom functions to be defined by users.
 
+   An implementation MAY perform additional processing before calling the function.
+   For example, it can modify the _name_ of an _option_ to match the function's
+   input expectations (such as by removing the _namespace_ prefix from the _name-part_).
+
    Function access to the _formatting context_ MUST be minimal and read-only,
    and execution time SHOULD be limited.
+   
    Implementation-defined _functions_ SHOULD use an implementation-defined _namespace_.
 
-6. If the call succeeds,
+7. If the call succeeds,
    resolve the value of the _expression_ as the result of that function call.
    If the call fails or does not return a valid value,
    emit a Resolution error and use a _fallback value_ for the _expression_.
-
-### Name Resolution
-
-<dfn title="resolve the name">**_Name resolution_**</dfn> is the determination of
-the _name-part_ and, where present, the _namespace_ of the _name_ for a given _function_
-or _option_.
-
-To resolve the _name_ of an item, the following steps are taken:
-
-1. Let the _name_ be the string to be processed, less any preceeding
-   sigils or markers.
-   For example, in the _expression_ `{:function}`, the string `function`
-   is the _name_ string.
-2. Determine if _name_ contains the character U+003A COLON `:`:
-   - If _name_ contains a colon, let _namespace_ be the
-      substring of _name_ up to (but not including)
-      the colon and _name-part_ be the substring of _name_ following the colon;
-   - Else let _namespace_ be an empty value (null, void, or empty string)
-     and _name-part_ be the _name_.
-3. If the _name-part_ is empty, return a Syntax error.
-4. Return _namespace_ and _name-part_.
-
-Implementations are not required to support the installation or resolution
-of different namespaces.
-How namespaces are defined, provisioned, or handled is also implementation defined.
-The _namespace_ MAY affect which function is called.
-
-Example:
-> Suppose the ICU implementation of MessageFormat added a custom option `skeleton`
-> to the `:datetime` function.
-> Users of that implementation could invoke the datetime formatter with an
-> pattern similar to:
-> ```
-> {{Today is {$date :datetime icu:skeleton=yMMMd}.}}
-> ```
-> The `name` of the `datetime` function is resolved as:
-> * `name`     : `datetime`
-> * `namespace`: (blank)
-> * `name-part`: `datetime`
-> 
-> The `name` of the option in the expression is resolved as:
-> * `name`     : `icu:skeleton`
-> * `namespace`: `icu`
-> * `name-part`: `skeleton`
 
 
 ### Fallback Resolution

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -218,8 +218,8 @@ the following steps are taken:
      emit a Duplicate Option Name error.
    - If the _option_'s right-hand side successfully resolves to a value,
      bind the _identifier_ of the _option_ to the resolved value in the mapping.
-   - Otherwise, emit an appropriate error (e.g., an Unresolved Variable error) and
-     bind the _identifier_ of the _option_ to an unresolved value in the mapping.
+   - Otherwise, bind the _identifier_ of the _option_ to an unresolved value in the mapping.
+     (Note that an Unresolved Variable error will have been emitted.)
 4. Remove from the resolved mapping of _options_ any binding for which the value is an unresolved value.
 5. Call the function implementation with the following arguments:
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -271,7 +271,7 @@ Example:
 > Suppose the ICU implementation of MessageFormat added a custom option `skeleton`
 > to the `:datetime` function.
 > Users of that implementation could invoke the datetime formatter with an
-> expression similar to:
+> pattern similar to:
 > ```
 > {{Today is {$date :datetime icu:skeleton=yMMMd}.}}
 > ```

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -223,17 +223,12 @@ the following steps are taken:
    as long as reasonable precautions are taken to keep the function interface
    simple and minimal, and avoid introducing potential security vulnerabilities.
 
-   Implementations MAY expose _options_ in an implementation-defined _namespace_
-   in addition to or superseding those found in the default registry.
-
    An implementation MAY define its own functions.
    An implementation MAY allow custom functions to be defined by users.
 
    Function access to the _formatting context_ MUST be minimal and read-only,
    and execution time SHOULD be limited.
    Implementation-defined _functions_ SHOULD use an implementation-defined _namespace_.
-   User-defined _functions_ SHOULD be permitted to define the _namespace_ to use
-   in name resolution.
 
 6. If the call succeeds,
    resolve the value of the _expression_ as the result of that function call.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -217,8 +217,10 @@ the following steps are taken:
      emit a Duplicate Option Name error.
    - If the _option_'s right-hand side successfully resolves to a value,
      bind the _identifier_ of the _option_ to the resolved value in the mapping.
-   - Otherwise, do not bind the _identifier_ of the _option_ to any value in the mapping.
-4. Call the function implementation with the following arguments:
+   - Otherwise, emit an appropriate error (e.g., an Unresolved Variable error) and
+     bind the _identifier_ of the _option_ to an unresolved value in the mapping.
+4. Remove from the resolved mapping of _options_ any binding for which the value is an unresolved value.
+5. Call the function implementation with the following arguments:
 
    - The current _locale_.
    - The resolved mapping of _options_.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -223,7 +223,7 @@ the following steps are taken:
    simple and minimal, and avoid introducing potential security vulnerabilities.
 
    Implementations MAY expose _options_ in an implementation-defined _namespace_
-   in addition to or superceding those found in the default registry.
+   in addition to or superseding those found in the default registry.
 
    An implementation MAY define its own functions.
    An implementation MAY allow custom functions to be defined by users.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -202,10 +202,10 @@ the following steps are taken:
    If the implementation cannot find the function, emit an Unknown Function error
    and use a _fallback value_ for the _expression_.
 
-An implementation MUST emit an Unknown Function error
-if the implementation does not support _namespaces_
-or if the _namespace_ of the _identifier_ is not recognized by the implementation
-or the _namespace_ does not support the named _function_.
+   An implementation MUST emit an Unknown Function error
+   if the implementation does not support _namespaces_
+   or if the _namespace_ of the _identifier_ is not recognized by the implementation
+   or the _namespace_ does not support the named _function_.
 
    Implementations are not required to implement _namespaces_ or installable
    _function registries_.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -242,7 +242,7 @@ the following steps are taken:
    
    Implementation-defined _functions_ SHOULD use an implementation-defined _namespace_.
 
-7. If the call succeeds,
+5. If the call succeeds,
    resolve the value of the _expression_ as the result of that function call.
    If the call fails or does not return a valid value,
    emit a Resolution error and use a _fallback value_ for the _expression_.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -280,7 +280,7 @@ Example:
 > > `name`: `datetime`
 > The `name` of the option in the expression is resolved as:
 > > `namespace`: `icu`
-> > `name`: `skelelton`
+> > `name`: `skeleton`
 
 ### Fallback Resolution
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -276,11 +276,12 @@ Example:
 > {{Today is {$date :datetime icu:skeleton=yMMMd}.}}
 > ```
 > The `name` of the `datetime` function is resolved as:
-> > `namespace`: (blank)
-> > `name`: `datetime`
+> * `namespace`: (blank)
+> * `name`: `datetime`
+> 
 > The `name` of the option in the expression is resolved as:
-> > `namespace`: `icu`
-> > `name`: `skeleton`
+> * `namespace`: `icu`
+> * `name`: `skeleton`
 
 ### Fallback Resolution
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -225,7 +225,7 @@ the following steps are taken:
 
 An implementation MAY define its own functions.
 An implementation MAY allow custom functions to be defined by users.
-   Function access to the _formatting context_ SHOULD be minimal and read-only,
+   Function access to the _formatting context_ MUST be minimal and read-only,
    and execution time SHOULD be limited.
    Implementation-defined _functions_ SHOULD use an implementation-defined _namespace_.
    User-defined _functions_ SHOULD be permitted to define the _namespace_ to use

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -218,7 +218,8 @@ the following steps are taken:
    - If the _option_'s right-hand side successfully resolves to a value,
      bind the _name_ of the _option_ to the resolved value in the mapping.
    - Otherwise, do not bind the _name_ of the _option_ to any value in the mapping.
-5. Call the function implementation with the following arguments:
+4. Call the function implementation with the following arguments:
+
    - The current _locale_.
    - The resolved mapping of _options_.
    - If the _expression_ includes an _operand_, its resolved value.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -223,8 +223,8 @@ the following steps are taken:
    Implementations SHOULD use an implementation-defined _namesapce_ for
    any additional arguments exposed to users as _options_.
 
-   An implementations MAY define its own functions or allow custom functions
-   to be defined by users.
+An implementation MAY define its own functions.
+An implementation MAY allow custom functions to be defined by users.
    Function access to the _formatting context_ SHOULD be minimal and read-only,
    and execution time SHOULD be limited.
    Implementation-defined _functions_ SHOULD use an implementation-defined _namespace_.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -204,11 +204,6 @@ the following steps are taken:
    emit an Unknown Function error
    and use a _fallback value_ for the _expression_.
 
-   An implementation MUST emit an Unknown Function error
-   if the implementation does not support _namespaces_
-   or if the _namespace_ of the _identifier_ is not recognized by the implementation
-   or the _namespace_ does not support the named _function_.
-
    Implementations are not required to implement _namespaces_ or installable
    _function registries_.
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -199,19 +199,21 @@ the following steps are taken:
    If this fails, use a _fallback value_ for the _expression_.
 2. _Resolve the name_ of the _function_ and, based on the starting sigil,
    find the appropriate function implementation from the _function registry_.
-   If the registry does not define an implementation for this _name_,
+   If the implementation does not support the _namespace_ of the _name_
+   or the _namespace_ does not support the _name-part_ named _function_
+   or the registry does not otherwise support the _name_,
    emit an Unknown Function error
    and use a _fallback value_ for the _expression_.
-3. If the _expression_ includes _options_, resolve the _options_ to a mapping
+4. If the _expression_ includes _options_, resolve the _options_ to a mapping
    of string identifiers to values.
    For each _option_:
    - _Resolve the name_ of the _option_.
-   - If the _option_'s _name-part_ already exists in the resolved mapping of _options_,
+   - If the _option_'s _name_ already exists in the resolved mapping of _options_,
      emit a Duplicate Option Name error.
    - If the _option_'s right-hand side successfully resolves to a value,
-     bind the _name-part_ of the _option_'s to the resolved value in the mapping.
+     bind the _name_ of the _option_ to the resolved value in the mapping.
    - Otherwise, do not bind the _name_ of the _option_ to any value in the mapping.
-4. Call the function implementation with the following arguments:
+5. Call the function implementation with the following arguments:
    - The current _locale_.
    - The resolved mapping of _options_.
    - If the _expression_ includes an _operand_, its resolved value.
@@ -234,7 +236,7 @@ the following steps are taken:
    User-defined _functions_ SHOULD be permitted to define the _namespace_ to use
    in name resolution.
 
-5. If the call succeeds,
+6. If the call succeeds,
    resolve the value of the _expression_ as the result of that function call.
    If the call fails or does not return a valid value,
    emit a Resolution error and use a _fallback value_ for the _expression_.
@@ -263,8 +265,6 @@ To resolve the _name_ of an item, the following steps are taken:
 Implementations are not required to support the installation or resolution
 of different namespaces.
 How namespaces are defined, provisioned, or handled is also implementation defined.
-It is important to note that the _namespace_ is not considered part of the _name_
-after resolution. 
 The _namespace_ MAY affect which function is called.
 
 Example:
@@ -276,12 +276,15 @@ Example:
 > {{Today is {$date :datetime icu:skeleton=yMMMd}.}}
 > ```
 > The `name` of the `datetime` function is resolved as:
+> * `name`     : `datetime`
 > * `namespace`: (blank)
-> * `name`: `datetime`
+> * `name-part`: `datetime`
 > 
 > The `name` of the option in the expression is resolved as:
+> * `name`     : `icu:skeleton`
 > * `namespace`: `icu`
-> * `name`: `skeleton`
+> * `name-part`: `skeleton`
+
 
 ### Fallback Resolution
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -233,10 +233,6 @@ the following steps are taken:
    An implementation MAY define its own functions.
    An implementation MAY allow custom functions to be defined by users.
 
-   An implementation MAY perform additional processing before calling the function.
-   For example, it can modify the _name_ of an _option_ to match the function's
-   input expectations (such as by removing the _namespace_ prefix from the _name-part_).
-
    Function access to the _formatting context_ MUST be minimal and read-only,
    and execution time SHOULD be limited.
    

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -200,8 +200,7 @@ the following steps are taken:
 2. _Resolve the name_ of the _function_ and, based on the starting sigil,
    find the appropriate function implementation from the _function registry_.
    If the implementation does not support the _namespace_ of the _name_
-   or the _namespace_ does not support the _name-part_ named _function_
-   or the registry does not otherwise support the _name_,
+   or the _namespace_ does not support the _name-part_ named _function_,
    emit an Unknown Function error
    and use a _fallback value_ for the _expression_.
 4. If the _expression_ includes _options_, resolve the _options_ to a mapping

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -202,15 +202,16 @@ the following steps are taken:
    If the implementation cannot find the function, emit an Unknown Function error
    and use a _fallback value_ for the _expression_.
 
-   An implementation MAY emit an Unknown Function error if the implementation    
-   does not support the _namespace_ of the _identifier_
-   or the _namespace_ does not support the named _function_.
+An implementation MUST emit an Unknown Function error
+if the implementation does not support _namespaces_
+or if the _namespace_ of the _identifier_ is not recognized by the implementation
+or the _namespace_ does not support the named _function_.
 
    Implementations are not required to implement _namespaces_ or installable
    _function registries_.
 
-4. If the _expression_ includes _options_, resolve the _options_ to a mapping
-   of string identifiers to values.
+3. Resolve the _options_ to a mapping of string identifiers to values.
+   If _options_ is missing, the mapping will be empty.
    For each _option_:
    - Resolve the _identifier_ of the _option_.
    - If the _option_'s _identifier_ already exists in the resolved mapping of _options_,

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -47,6 +47,7 @@ quoted-char = %x0-5B         ; omit \
 
 unquoted       = unquoted-start *name-char
 unquoted-start = name-start / DIGIT / "."
+               / %xB7 / %x300-36F / %x203F-2040
 
 ; reserve sigils for private-use by implementations
 private-use    = private-start reserved-body

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -22,7 +22,7 @@ function-expression = "{" [s] annotation [s] "}"
 annotation = (function *(s option)) / reserved / private-use
 
 literal = quoted / unquoted
-variable = "$" name-body
+variable = "$" name-part
 function = (":" / "+" / "-") name
 option = name [s] "=" [s] (literal / variable)
 
@@ -71,10 +71,9 @@ reserved-char  = %x00-08        ; omit HTAB and LF
                / %xE000-10FFFF
 
 ; based on https://www.w3.org/TR/REC-xml-names/#NT-QName
-name      = [namespace] name-body
-namespace = name-start *name-char namespace-sep
-namespace-sep = ":"
-name-body = name-start *name-char
+name       = [namespace ":"] name-body
+namespace  = name-part
+name-part  = name-start *name-char
 name-start = ALPHA / "_"
            / %xC0-D6 / %xD8-F6 / %xF8-2FF
            / %x370-37D / %x37F-1FFF / %x200C-200D

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -79,7 +79,7 @@ name-start = ALPHA / "_"
            / %x370-37D / %x37F-1FFF / %x200C-200D
            / %x2070-218F / %x2C00-2FEF / %x3001-D7FF
            / %xF900-FDCF / %xFDF0-FFFD / %x10000-EFFFF
-name-char  = name-start / DIGIT / "-" / "." / ":"
+name-char  = name-start / DIGIT / "-" / "."
            / %xB7 / %x300-36F / %x203F-2040
 
 text-escape     = backslash ( backslash / "{" / "}" )

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -71,7 +71,7 @@ reserved-char  = %x00-08        ; omit HTAB and LF
                / %xE000-10FFFF
 
 ; based on https://www.w3.org/TR/REC-xml-names/#NT-QName
-name       = [namespace ":"] name-body
+name       = [namespace ":"] name-part
 namespace  = name-part
 name-part  = name-start *name-char
 name-start = ALPHA / "_"

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -22,7 +22,7 @@ function-expression = "{" [s] annotation [s] "}"
 annotation = (function *(s option)) / reserved / private-use
 
 literal = quoted / unquoted
-variable = "$" name
+variable = "$" name-body
 function = (":" / "+" / "-") name
 option = name [s] "=" [s] (literal / variable)
 
@@ -70,9 +70,11 @@ reserved-char  = %x00-08        ; omit HTAB and LF
                / %x7E-D7FF      ; omit surrogates
                / %xE000-10FFFF
 
-; based on https://www.w3.org/TR/xml/#NT-Name,
-; but cannot start with U+003A COLON ":"
-name = name-start *name-char
+; based on https://www.w3.org/TR/REC-xml-names/#NT-QName
+name      = [namespace] name-body
+namespace = name-start *name-char namespace-sep
+namespace-sep = ":"
+name-body = name-start *name-char
 name-start = ALPHA / "_"
            / %xC0-D6 / %xD8-F6 / %xF8-2FF
            / %x370-37D / %x37F-1FFF / %x200C-200D

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -45,12 +45,8 @@ quoted-char = %x0-5B         ; omit \
             / %x7D-D7FF      ; omit surrogates
             / %xE000-10FFFF
 
-; based on https://www.w3.org/TR/xml/#NT-Nmtoken,
-; but cannot start with U+002D HYPHEN-MINUS or U+003A COLON ":"
-unquoted = unquoted-start *name-char
+unquoted       = unquoted-start *name-char
 unquoted-start = name-start / DIGIT / "."
-               / %xB7 / %x300-36F / %x203F-2040
-
 
 ; reserve sigils for private-use by implementations
 private-use    = private-start reserved-body

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -67,7 +67,8 @@ reserved-char  = %x00-08        ; omit HTAB and LF
                / %x7E-D7FF      ; omit surrogates
                / %xE000-10FFFF
 
-; based on https://www.w3.org/TR/REC-xml-names/#NT-QName
+; identifier matches https://www.w3.org/TR/REC-xml-names/#NT-QName
+; name matches https://www.w3.org/TR/REC-xml-names/#NT-NCName
 identifier = [namespace ":"] name
 namespace  = name
 name       = name-start *name-char

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -22,9 +22,9 @@ function-expression = "{" [s] annotation [s] "}"
 annotation = (function *(s option)) / reserved / private-use
 
 literal = quoted / unquoted
-variable = "$" name-part
-function = (":" / "+" / "-") name
-option = name [s] "=" [s] (literal / variable)
+variable = "$" name
+function = (":" / "+" / "-") identifier
+option = identifier [s] "=" [s] (literal / variable)
 
 ; reserved keywords are always lowercase
 input = %s"input"
@@ -71,9 +71,9 @@ reserved-char  = %x00-08        ; omit HTAB and LF
                / %xE000-10FFFF
 
 ; based on https://www.w3.org/TR/REC-xml-names/#NT-QName
-name       = [namespace ":"] name-part
-namespace  = name-part
-name-part  = name-start *name-char
+identifier = [namespace ":"] name
+namespace  = name
+name       = name-start *name-char
 name-start = ALPHA / "_"
            / %xC0-D6 / %xD8-F6 / %xF8-2FF
            / %x370-37D / %x37F-1FFF / %x200C-200D

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -45,7 +45,7 @@ quoted-char = %x0-5B         ; omit \
             / %x7D-D7FF      ; omit surrogates
             / %xE000-10FFFF
 
-unquoted       = unquoted-start *name-char
+unquoted       = unquoted-start *(name-char / ":")
 unquoted-start = name-start / DIGIT / "."
                / %xB7 / %x300-36F / %x203F-2040
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -683,9 +683,11 @@ This is different from XML's [Name](https://www.w3.org/TR/xml/#NT-Name)
 in that it MUST NOT contain a U+003A COLON `:`.
 Otherwise, the set of characters allowed in names is large.
 
-_Functions_ and _options_ MAY be preceded by a _namespace_ identifier
-which is separated from the body of the _name_ by a U+003A COLON `:`.
-Built-in _functions_ and _options_ do not have a _namespace_ identifier.
+A **_<dfn>name</dfn>_** is a character sequence that is used as
+an identifier for _functions_ and _options_.
+This MAY include a non-empty _namespace_ identifier at its start
+which is separated from the rest of the _name_ by a U+003A COLON `:`.
+Built-in _functions_ and their _options_ do not have a _namespace_ identifier.
 
 > [!NOTE]
 > _External variables_ can be passed in that are not valid _names_.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -677,7 +677,7 @@ unquoted-start = name-start / DIGIT / "."
 A **_<dfn>name</dfn>_** is an identifier for a _variable_ (prefixed with `$`),
 for a _function_ (prefixed with `:`, `+` or `-`),
 or for an _option_ (these have no prefix).
-The namespace for _names_ is based on Namespaces in XML 1.0's 
+The namespace for _names_ is based on <cite>Namespaces in XML 1.0</cite>'s 
 [NCName](https://www.w3.org/TR/xml-names/#NT-NCName).
 This is different from XML's [Name](https://www.w3.org/TR/xml/#NT-Name)
 in that it MUST NOT start with `:`.
@@ -709,13 +709,12 @@ Support for _namespaces_ and their interpretation is implementation-defined
 in this release.
 
 ```abnf
-variable = "$" name-body
+variable = "$" name-part
 function = (":" / "+" / "-") name
 
-name      = [namespace] name-body
-namespace = name-start *name-char namespace-sep
-namespace-sep = ":"
-name-body = name-start *name-char
+name       = [namespace ":"] name-part
+namespace  = name-part
+name-part  = name-start *name-char
 name-start = ALPHA / "_"
            / %xC0-D6 / %xD8-F6 / %xF8-2FF
            / %x370-37D / %x37F-1FFF / %x200C-200D

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -677,16 +677,45 @@ unquoted-start = name-start / DIGIT / "."
 A **_<dfn>name</dfn>_** is an identifier for a _variable_ (prefixed with `$`),
 for a _function_ (prefixed with `:`, `+` or `-`),
 or for an _option_ (these have no prefix).
-The namespace for _names_ is based on XML's [Name](https://www.w3.org/TR/xml/#NT-Name),
-with the restriction that it MUST NOT start with `:`,
-as that would conflict with the _function_ start character.
+The namespace for _names_ is based on Namespaces in XML 1.0's 
+[NCName](https://www.w3.org/TR/xml-names/#NT-NCName).
+This is different from XML's [Name](https://www.w3.org/TR/xml/#NT-Name)
+in that it MUST NOT start with `:`.
 Otherwise, the set of characters allowed in names is large.
 
+_Functions_ and _options_ may be preceded by a _namespace_ identifier
+which is separated from the body of the _name_ by a `: U+003A COLON`.
+Built-in _functions_ and _options_ do not have a _namespace_ identifier.
+
+Examples:
+> A variable:
+>```
+>This has a {$variable}
+>```
+>A function:
+> ```
+> This has a {:function}
+> ```
+> An add-on function from the `icu` namespace:
+> ```
+> This has a {:icu:function}
+> ```
+> An option and an add-on option:
+> ```
+> This has {:options option=value icu:option=add_on}
+> ```
+
+Support for _namespaces_ and their interpretation is implementation-defined
+in this release.
+
 ```abnf
-variable = "$" name
+variable = "$" name-body
 function = (":" / "+" / "-") name
 
-name = name-start *name-char
+name      = [namespace] name-body
+namespace = name-start *name-char namespace-sep
+namespace-sep = ":"
+name-body = name-start *name-char
 name-start = ALPHA / "_"
            / %xC0-D6 / %xD8-F6 / %xF8-2FF
            / %x370-37D / %x37F-1FFF / %x200C-200D

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -687,6 +687,11 @@ _Functions_ and _options_ MAY be preceded by a _namespace_ identifier
 which is separated from the body of the _name_ by a U+003A COLON `:`.
 Built-in _functions_ and _options_ do not have a _namespace_ identifier.
 
+> [!NOTE]
+> _External variables_ can be passed in that are not valid _names_.
+> Such variables cannot be referenced in a _message_,
+> but are not otherwise errors.
+
 Examples:
 > A variable:
 >```
@@ -724,10 +729,48 @@ name-char  = name-start / DIGIT / "-" / "." / ":"
            / %xB7 / %x300-36F / %x203F-2040
 ```
 
-> [!NOTE]
-> _External variables_ can be passed in that are not valid _names_.
-> Such variables cannot be referenced in a _message_,
-> but are not otherwise errors.
+#### Name resolution
+
+<dfn title="resolve the name">**_Resolve the name_**</dfn> means the determination of
+the _name-part_ and, where present, the _namespace_ of the _name_ for a given _function_
+or _option_.
+
+To resolve the _name_ of an item, the following steps are taken:
+
+1. Let the _name_ be the string to be processed, less any preceeding
+   sigils or markers.
+   For example, in the _expression_ `{:function}`, the string `function`
+   is the _name_ string.
+2. Determine if _name_ contains the character U+003A COLON `:`:
+   - If _name_ contains a colon, let _namespace_ be the
+      substring of _name_ up to (but not including)
+      the colon and _name-part_ be the substring of _name_ following the colon;
+   - Else let _namespace_ be an empty value (null, void, or empty string)
+     and _name-part_ be the _name_.
+3. Return _namespace_ and _name-part_.
+
+Implementations are not required to support the installation or resolution
+of different namespaces.
+How namespaces are defined, provisioned, or handled is also implementation defined.
+
+Example:
+> Suppose the ICU implementation of MessageFormat added a custom option `skeleton`
+> to the `:datetime` function.
+> Users of that implementation could invoke the datetime formatter with an
+> pattern similar to:
+> ```
+> {{Today is {$date :datetime icu:skeleton=yMMMd}.}}
+> ```
+> The `name` of the `datetime` function is resolved as:
+> * `name`     : `datetime`
+> * `namespace`: (blank)
+> * `name-part`: `datetime`
+> 
+> The `name` of the option in the expression is resolved as:
+> * `name`     : `icu:skeleton`
+> * `namespace`: `icu`
+> * `name-part`: `skeleton`
+
 
 ### Escape Sequences
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -728,7 +728,7 @@ variable = "$" name
 function = (":" / "+" / "-") identifier
 option = identifier [s] "=" [s] (literal / variable)
 
-identifier = [namespace ":"] name-part
+identifier = [namespace ":"] name
 namespace  = name
 name       = name-start *name-char
 name-start = ALPHA / "_"

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -169,7 +169,7 @@ external input value does not appear in a _declaration_.
 > [!Note]
 > These restrictions only apply to _declarations_.
 > A _placeholder_ or _selector_ can apply a different annotation to a _variable_
-> than one applied to the same _variable_ name in a _declaration_.
+> than one applied to the same _variable_ named in a _declaration_.
 > For example, this message is _valid_:
 > ```
 > {{
@@ -482,7 +482,7 @@ and vice versa.
 > {+button}Submit{-button} or {+link}cancel{-link}.
 > ```
 
-A _function_ consists of a prefix sigil followed by a _name_.
+A _function_ consists of a prefix sigil followed by an _identifier_.
 The following sigils are used for _functions_:
 
 - `:` for a _standalone_ function
@@ -497,8 +497,8 @@ _Options_ are not required.
 An **_<dfn>option</dfn>_** is a key-value pair
 containing a named argument that is passed to a _function_.
 
-An _option_ has a _name_ and a _value_.
-The _name_ is separated from the _value_ by an U+003D EQUALS SIGN `=` along with
+An _option_ has an _identifier_ and a _value_.
+The _identifier_ is separated from the _value_ by an U+003D EQUALS SIGN `=` along with
 optional whitespace.
 The value of an _option_ can be either a _literal_ or a _variable_.
 
@@ -506,7 +506,7 @@ Multiple _options_ are permitted in an _annotation_.
 Each _option_ is separated by whitespace.
 
 ```abnf
-option = name [s] "=" [s] (literal / variable)
+option = identifier [s] "=" [s] (literal / variable)
 ```
 
 > Examples of _functions_ with _options_
@@ -672,22 +672,30 @@ unquoted-start = name-start / DIGIT / "."
                / %xB7 / %x300-36F / %x203F-2040
 ```
 
-### Names
+### Names and Identifiers
 
-A **_<dfn>name</dfn>_** is an identifier for a _variable_ (prefixed with `$`),
+An **_<dfn>identifier</dfn>_** is a character sequence that
+identifies a _function_ or _option_.
+Each _identifier_ consists of a _name_ optionally preceeded by
+a _namespace_. 
+When present, the _namespace_ is separated from the _name_ by a
+U+003A COLON `:`.
+Built-in _functions_ and their _options_ do not have a _namespace_ identifier.
+
+_Function_ _identifiers_ are prefixed with `:`, `+`, or `-`.
+_Option_ _identifiers_ have no prefix.
+
+A **_<dfn>name</dfn>_** is a character sequence used in an _identifier_ 
+or as the name for for a _variable_.
+
+_Variable_ names are prefixed with `$`.
 for a _function_ (prefixed with `:`, `+` or `-`),
-or for an _option_ (these have no prefix).
-The namespace for _names_ is based on <cite>Namespaces in XML 1.0</cite>'s 
+
+Valid content for _names_ is based on <cite>Namespaces in XML 1.0</cite>'s 
 [NCName](https://www.w3.org/TR/xml-names/#NT-NCName).
 This is different from XML's [Name](https://www.w3.org/TR/xml/#NT-Name)
 in that it MUST NOT contain a U+003A COLON `:`.
-Otherwise, the set of characters allowed in names is large.
-
-A **_<dfn>name</dfn>_** is a character sequence that is used as
-an identifier for _functions_ and _options_.
-This MAY include a non-empty _namespace_ identifier at its start
-which is separated from the rest of the _name_ by a U+003A COLON `:`.
-Built-in _functions_ and their _options_ do not have a _namespace_ identifier.
+Otherwise, the set of characters allowed in a _name_ is large.
 
 > [!NOTE]
 > _External variables_ can be passed in that are not valid _names_.
@@ -716,12 +724,13 @@ Support for _namespaces_ and their interpretation is implementation-defined
 in this release.
 
 ```abnf
-variable = "$" name-part
-function = (":" / "+" / "-") name
+variable = "$" name
+function = (":" / "+" / "-") identifier
+option = identifier [s] "=" [s] (literal / variable)
 
-name       = [namespace ":"] name-part
-namespace  = name-part
-name-part  = name-start *name-char
+identifier = [namespace ":"] name-part
+namespace  = name
+name       = name-start *name-char
 name-start = ALPHA / "_"
            / %xC0-D6 / %xD8-F6 / %xF8-2FF
            / %x370-37D / %x37F-1FFF / %x200C-200D
@@ -730,49 +739,6 @@ name-start = ALPHA / "_"
 name-char  = name-start / DIGIT / "-" / "." / ":"
            / %xB7 / %x300-36F / %x203F-2040
 ```
-
-#### Name resolution
-
-<dfn title="resolve the name">**_Resolve the name_**</dfn> means the determination of
-the _name-part_ and, where present, the _namespace_ of the _name_ for a given _function_
-or _option_.
-
-To resolve the _name_ of an item, the following steps are taken:
-
-1. Let the _name_ be the string to be processed, less any preceeding
-   sigils or markers.
-   For example, in the _expression_ `{:function}`, the string `function`
-   is the _name_ string.
-2. Determine if _name_ contains the character U+003A COLON `:`:
-   - If _name_ contains a colon, let _namespace_ be the
-      substring of _name_ up to (but not including)
-      the colon and _name-part_ be the substring of _name_ following the colon;
-   - Else let _namespace_ be an empty value (null, void, or empty string)
-     and _name-part_ be the _name_.
-3. Return _namespace_ and _name-part_.
-
-Implementations are not required to support the installation or resolution
-of different namespaces.
-How namespaces are defined, provisioned, or handled is also implementation defined.
-
-Example:
-> Suppose the ICU implementation of MessageFormat added a custom option `skeleton`
-> to the `:datetime` function.
-> Users of that implementation could invoke the datetime formatter with an
-> pattern similar to:
-> ```
-> {{Today is {$date :datetime icu:skeleton=yMMMd}.}}
-> ```
-> The `name` of the `datetime` function is resolved as:
-> * `name`     : `datetime`
-> * `namespace`: (blank)
-> * `name-part`: `datetime`
-> 
-> The `name` of the option in the expression is resolved as:
-> * `name`     : `icu:skeleton`
-> * `namespace`: `icu`
-> * `name-part`: `skeleton`
-
 
 ### Escape Sequences
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -683,8 +683,8 @@ This is different from XML's [Name](https://www.w3.org/TR/xml/#NT-Name)
 in that it MUST NOT start with `:`.
 Otherwise, the set of characters allowed in names is large.
 
-_Functions_ and _options_ may be preceded by a _namespace_ identifier
-which is separated from the body of the _name_ by a `: U+003A COLON`.
+_Functions_ and _options_ MAY be preceded by a _namespace_ identifier
+which is separated from the body of the _name_ by a U+003A COLON `:`.
 Built-in _functions_ and _options_ do not have a _namespace_ identifier.
 
 Examples:

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -680,7 +680,7 @@ or for an _option_ (these have no prefix).
 The namespace for _names_ is based on <cite>Namespaces in XML 1.0</cite>'s 
 [NCName](https://www.w3.org/TR/xml-names/#NT-NCName).
 This is different from XML's [Name](https://www.w3.org/TR/xml/#NT-Name)
-in that it MUST NOT start with `:`.
+in that it MUST NOT contain a U+003A COLON `:`.
 Otherwise, the set of characters allowed in names is large.
 
 _Functions_ and _options_ MAY be preceded by a _namespace_ identifier


### PR DESCRIPTION
Initial implementation of namespacing design into the spec.

This version makes the following pair of options parallel to one another (i.e. they are not duplicates):

```
{$foo :function option=value ns:option=value2}
```