### PR TITLE
Implement code more introducer

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -1,18 +1,30 @@
-message = pattern / complex-message
+message = simple-message / complex-message
 
-complex-message = "{{" [s] *(declaration [s]) body [s] "}}"
+simple-message = [almost-keyword]
+               / ((almost-keyword not-keyword / text-start / expression) pattern)
+complex-message = *(declaration [s]) body
 
-declaration = input-declaration / local-declaration
+declaration = input-declaration / local-declaration / reserved-declaration
 input-declaration = input [s] variable-expression
 local-declaration = local s variable [s] "=" [s] expression
+reserved-declaration = "." 4*(%x61-7A) reserved-body 1*expression
+
+almost-keyword = "." *3(%x61-7A)
+not-keyword    = %x0-5B        ; omit \
+               / %x5D-60       ; omit a-z and {
+               / %x7C          ; omit }
+               / %x7E-D7FF     ; omit surrogates
+               / %xE000-10FFFF
+               / expression
 
 body = quoted-pattern
      / (selectors 1*([s] variant))
 
 quoted-pattern = "{{" pattern "}}"
 pattern = *(text / expression)
+
 selectors = match 1*([s] expression)
-variant = when 1*(s key) [s] quoted-pattern
+variant = 1*(s key) [s] quoted-pattern
 key = literal / "*"
 
 expression = literal-expression / variable-expression / function-expression
@@ -26,18 +38,19 @@ variable = "$" name
 function = (":" / "+" / "-") name
 option = name [s] "=" [s] (literal / variable)
 
-; reserved keywords are always lowercase
-input = %s"input"
-local = %s"local"
-match = %s"match"
-when  = %s"when"
+; keywords always consist of a . followed by at least four lower-case a-z letters
+input = %s".input"
+local = %s".local"
+match = %s".match"
 
 text = 1*(text-char / text-escape)
-text-char = %x0-5B         ; omit \
-          / %x5D-7A        ; omit {
-          / %x7C           ; omit }
-          / %x7E-D7FF      ; omit surrogates
-          / %xE000-10FFFF
+text-start = %x0-2D         ; omit .
+           / %x2F-5B        ; omit \
+           / %x5D-7A        ; omit {
+           / %x7C           ; omit }
+           / %x7E-D7FF      ; omit surrogates
+           / %xE000-10FFFF
+text-char  = text-start / "."
 
 quoted      = "|" *(quoted-char / quoted-escape) "|"
 quoted-char = %x0-5B         ; omit \
@@ -60,7 +73,7 @@ private-start  = "^" / "&"
 ; future versions of this specification
 reserved       = reserved-start reserved-body
 reserved-start = "!" / "@" / "#" / "%" / "*" / "<" / ">" / "/" / "?" / "~"
-reserved-body  = *( [s] 1*(reserved-char / reserved-escape / quoted))
+reserved-body  = *([s] 1*(reserved-char / reserved-escape / quoted))
 
 reserved-char  = %x00-08        ; omit HTAB and LF
                / %x0B-0C        ; omit CR
@@ -81,7 +94,7 @@ name-start = ALPHA / "_"
 name-char  = name-start / DIGIT / "-" / "." / ":"
            / %xB7 / %x300-36F / %x203F-2040
 
-text-escape     = backslash ( backslash / "{" / "}" )
+text-escape     = backslash ( backslash / "." / "{" / "}" )
 quoted-escape   = backslash ( backslash / "|" )
 reserved-escape = backslash ( backslash / "{" / "|" / "}" )
 backslash       = %x5C ; U+005C REVERSE SOLIDUS "\"

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -40,7 +40,7 @@ simple-start-char = %x0-2D         ; omit .
                   / %x7C           ; omit }
                   / %x7E-D7FF      ; omit surrogates
                   / %xE000-10FFFF
-text-char = simple-start-char-start / "."
+text-char = simple-start-char / "."
 
 quoted      = "|" *(quoted-char / quoted-escape) "|"
 quoted-char = %x0-5B         ; omit \

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -56,10 +56,11 @@ unquoted-start = name-start / DIGIT / "."
 
 
 ; Reserve additional .keywords for use by future versions of this specification.
+reserved-statement = reserved-keyword [s [reserved-body [s]]] 1*expression
 ; Note that the following expression is a simplification,
-; as this rule MUST NOT be considered to match existing keywords:
-;   (input / local / match) (s / "{")
-reserved-statement = "." reserved-body 1*expression
+; as this rule MUST NOT be considered to match existing keywords.
+; As regexp, this would be: /\.(?!input|local|match)[a-z]+/
+reserved-keyword = "." 1*(%x61-7A)
 
 ; Reserve additional sigils for use by future versions of this specification.
 reserved-annotation = reserved-annotation-start reserved-body

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -56,11 +56,11 @@ unquoted-start = name-start / DIGIT / "."
 
 
 ; Reserve additional .keywords for use by future versions of this specification.
-reserved-statement = reserved-keyword [s [reserved-body [s]]] 1*expression
+reserved-statement = reserved-keyword [s reserved-body] 1*([s] expression)
 ; Note that the following expression is a simplification,
-; as this rule MUST NOT be considered to match existing keywords.
-; As regexp, this would be: /\.(?!input|local|match)[a-z]+/
-reserved-keyword = "." 1*(%x61-7A)
+; as this rule MUST NOT be considered to match existing keywords
+; (`.input`, `.local`, and `.match`).
+reserved-keyword = "." name
 
 ; Reserve additional sigils for use by future versions of this specification.
 reserved-annotation = reserved-annotation-start reserved-body

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -5,10 +5,9 @@ simple-start = simple-start-char / text-escape / expression
 pattern = *(text-char / text-escape / expression)
 
 complex-message = *(declaration [s]) complex-body [s]
-declaration = input-declaration / local-declaration / reserved-syntax
+declaration = input-declaration / local-declaration / reserved-keyword
 input-declaration = input [s] variable-expression
 local-declaration = local s variable [s] "=" [s] expression
-reserved-syntax = "." reserved-body 1*expression
 
 complex-body = quoted-pattern
              / (selectors 1*([s] variant))
@@ -22,7 +21,9 @@ expression = literal-expression / variable-expression / function-expression
 literal-expression = "{" [s] literal [s annotation] [s] "}"
 variable-expression = "{" [s] variable [s annotation] [s] "}"
 function-expression = "{" [s] annotation [s] "}"
-annotation = (function *(s option)) / reserved / private-use
+annotation = (function *(s option))
+           / reserved-annotation
+           / private-use-annotation
 
 literal = quoted / unquoted
 variable = "$" name
@@ -54,16 +55,18 @@ unquoted-start = name-start / DIGIT / "."
                / %xB7 / %x300-36F / %x203F-2040
 
 
-; reserve sigils for private-use by implementations
-private-use    = private-start reserved-body
-private-start  = "^" / "&"
+; Reserve additional .keywords for use by future versions of this specification.
+; Note that the following expression is a simplification,
+; as this rule MUST NOT be considered to match existing keywords:
+;   (input / local / match) (s / "{")
+reserved-keyword = "." reserved-body 1*expression
 
-; reserve additional sigils for use by 
-; future versions of this specification
-reserved       = reserved-start reserved-body
-reserved-start = "!" / "@" / "#" / "%" / "*" / "<" / ">" / "/" / "?" / "~"
+; Reserve additional sigils for use by future versions of this specification.
+reserved-annotation = reserved-annotation-start reserved-body
+reserved-annotation-start = "!" / "@" / "#" / "%" / "*"
+                          / "<" / ">" / "/" / "?" / "~"
+
 reserved-body  = *([s] 1*(reserved-char / reserved-escape / quoted))
-
 reserved-char  = %x00-08        ; omit HTAB and LF
                / %x0B-0C        ; omit CR
                / %x0E-19        ; omit SP
@@ -71,6 +74,10 @@ reserved-char  = %x00-08        ; omit HTAB and LF
                / %x5D-7A        ; omit { | }
                / %x7E-D7FF      ; omit surrogates
                / %xE000-10FFFF
+
+; Reserve sigils for private-use by implementations.
+private-use-annotation = private-start reserved-body
+private-start  = "^" / "&"
 
 ; based on https://www.w3.org/TR/xml/#NT-Name,
 ; but cannot start with U+003A COLON ":"

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -5,7 +5,7 @@ simple-start = simple-start-char / text-escape / expression
 pattern = *(text-char / text-escape / expression)
 
 complex-message = *(declaration [s]) complex-body [s]
-declaration = input-declaration / local-declaration / reserved-keyword
+declaration = input-declaration / local-declaration / reserved-statement
 input-declaration = input [s] variable-expression
 local-declaration = local s variable [s] "=" [s] expression
 
@@ -59,7 +59,7 @@ unquoted-start = name-start / DIGIT / "."
 ; Note that the following expression is a simplification,
 ; as this rule MUST NOT be considered to match existing keywords:
 ;   (input / local / match) (s / "{")
-reserved-keyword = "." reserved-body 1*expression
+reserved-statement = "." reserved-body 1*expression
 
 ; Reserve additional sigils for use by future versions of this specification.
 reserved-annotation = reserved-annotation-start reserved-body

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -4,13 +4,13 @@ simple-message = [simple-start pattern]
 simple-start = simple-start-char / text-escape / expression
 pattern = *(text-char / text-escape / expression)
 
-complex-message = *(declaration [s]) complex-body [s]
+complex-message = *(declaration [s]) complex-body
 declaration = input-declaration / local-declaration / reserved-statement
 input-declaration = input [s] variable-expression
 local-declaration = local s variable [s] "=" [s] expression
 
 complex-body = quoted-pattern
-             / (selectors 1*([s] variant))
+             / ((selectors / reserved-statement) 1*([s] variant))
 quoted-pattern = "{{" pattern "}}"
 
 selectors = match 1*([s] expression)

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -1,27 +1,19 @@
 message = simple-message / complex-message
 
-simple-message = [almost-keyword]
-               / ((almost-keyword not-keyword / text-start / expression) pattern)
-complex-message = *(declaration [s]) body
+simple-message = [simple-start pattern]
+simple-start = text-start / text-escape / expression
 
+pattern = *(text / expression)
+
+complex-message = *(declaration [s]) complex-body
 declaration = input-declaration / local-declaration / reserved-declaration
 input-declaration = input [s] variable-expression
 local-declaration = local s variable [s] "=" [s] expression
-reserved-declaration = "." 4*(%x61-7A) reserved-body 1*expression
+reserved-declaration = "." reserved-body 1*expression
 
-almost-keyword = "." *3(%x61-7A)
-not-keyword    = %x0-5B        ; omit \
-               / %x5D-60       ; omit a-z and {
-               / %x7C          ; omit }
-               / %x7E-D7FF     ; omit surrogates
-               / %xE000-10FFFF
-               / expression
-
-body = quoted-pattern
-     / (selectors 1*([s] variant))
-
+complex-body = quoted-pattern
+             / (selectors 1*([s] variant))
 quoted-pattern = "{{" pattern "}}"
-pattern = *(text / expression)
 
 selectors = match 1*([s] expression)
 variant = 1*(s key) [s] quoted-pattern
@@ -38,7 +30,7 @@ variable = "$" name
 function = (":" / "+" / "-") name
 option = name [s] "=" [s] (literal / variable)
 
-; keywords always consist of a . followed by at least four lower-case a-z letters
+; keywords always consist of a . followed by lower-case a-z letters
 input = %s".input"
 local = %s".local"
 match = %s".match"

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -90,7 +90,7 @@ name-start = ALPHA / "_"
 name-char  = name-start / DIGIT / "-" / "." / ":"
            / %xB7 / %x300-36F / %x203F-2040
 
-text-escape     = backslash ( backslash / "." / "{" / "}" )
+text-escape     = backslash ( backslash / "{" / "}" )
 quoted-escape   = backslash ( backslash / "|" )
 reserved-escape = backslash ( backslash / "{" / "|" / "}" )
 backslash       = %x5C ; U+005C REVERSE SOLIDUS "\"

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -1,11 +1,10 @@
 message = simple-message / complex-message
 
 simple-message = [simple-start pattern]
-simple-start = text-start / text-escape / expression
+simple-start = simple-start-char / text-escape / expression
+pattern = *(text-char / text-escape / expression)
 
-pattern = *(text / expression)
-
-complex-message = *(declaration [s]) complex-body
+complex-message = *(declaration [s]) complex-body [s]
 declaration = input-declaration / local-declaration / reserved-declaration
 input-declaration = input [s] variable-expression
 local-declaration = local s variable [s] "=" [s] expression
@@ -16,7 +15,7 @@ complex-body = quoted-pattern
 quoted-pattern = "{{" pattern "}}"
 
 selectors = match 1*([s] expression)
-variant = 1*(s key) [s] quoted-pattern
+variant = key *(s key) [s] quoted-pattern
 key = literal / "*"
 
 expression = literal-expression / variable-expression / function-expression
@@ -30,19 +29,17 @@ variable = "$" name
 function = (":" / "+" / "-") name
 option = name [s] "=" [s] (literal / variable)
 
-; keywords always consist of a . followed by lower-case a-z letters
 input = %s".input"
 local = %s".local"
 match = %s".match"
 
-text = 1*(text-char / text-escape)
-text-start = %x0-2D         ; omit .
-           / %x2F-5B        ; omit \
-           / %x5D-7A        ; omit {
-           / %x7C           ; omit }
-           / %x7E-D7FF      ; omit surrogates
-           / %xE000-10FFFF
-text-char  = text-start / "."
+simple-start-char = %x0-2D         ; omit .
+                  / %x2F-5B        ; omit \
+                  / %x5D-7A        ; omit {
+                  / %x7C           ; omit }
+                  / %x7E-D7FF      ; omit surrogates
+                  / %xE000-10FFFF
+text-char = simple-start-char-start / "."
 
 quoted      = "|" *(quoted-char / quoted-escape) "|"
 quoted-char = %x0-5B         ; omit \

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -5,10 +5,10 @@ simple-start = simple-start-char / text-escape / expression
 pattern = *(text-char / text-escape / expression)
 
 complex-message = *(declaration [s]) complex-body [s]
-declaration = input-declaration / local-declaration / reserved-declaration
+declaration = input-declaration / local-declaration / reserved-syntax
 input-declaration = input [s] variable-expression
 local-declaration = local s variable [s] "=" [s] expression
-reserved-declaration = "." reserved-body 1*expression
+reserved-syntax = "." reserved-body 1*expression
 
 complex-body = quoted-pattern
              / (selectors 1*([s] variant))


### PR DESCRIPTION
This starts implementing the changes for the [code mode introducer](https://github.com/unicode-org/message-format-wg/blob/main/exploration/code-mode-introducer.md) (#521, #526), including dropping `when`.

Before I get any further, it might be best for us to align on the exact ABNF changes. See line comments for a few specific questions.