### PR TITLE
Reformat `registry.dtd` to not repeat `<!ATTLIST>` & align attribute definitions

### DIFF
--- a/spec/registry.dtd
+++ b/spec/registry.dtd
@@ -1,34 +1,48 @@
 <!ELEMENT registry (function|validationRule)*>
 
 <!ELEMENT function (description,(formatSignature|matchSignature)+)>
-<!ATTLIST function name NMTOKEN #REQUIRED>
+<!ATTLIST function
+    name           NMTOKEN  #REQUIRED
+>
 
 <!ELEMENT description (#PCDATA)>
 
 <!ELEMENT validationRule EMPTY>
-<!ATTLIST validationRule id ID #REQUIRED>
-<!ATTLIST validationRule regex CDATA #REQUIRED>
+<!ATTLIST validationRule
+    id             ID     #REQUIRED
+    regex          CDATA  #REQUIRED
+>
 
 <!ELEMENT formatSignature (input?,option*)>
-<!ATTLIST formatSignature position (open|close|standalone) "standalone">
-<!ATTLIST formatSignature locales NMTOKENS #IMPLIED>
+<!ATTLIST formatSignature
+    position       (open|close|standalone)  "standalone"
+    locales        NMTOKENS                 #IMPLIED
+>
 
 <!ELEMENT matchSignature (input?,option*,match*)>
-<!ATTLIST matchSignature locales NMTOKENS #IMPLIED>
+<!ATTLIST matchSignature
+    locales        NMTOKENS  #IMPLIED
+>
 
 <!ELEMENT input EMPTY>
-<!ATTLIST input values NMTOKENS #IMPLIED>
-<!ATTLIST input validationRule IDREF #IMPLIED>
-<!ATTLIST input readonly (true|false) "false">
+<!ATTLIST input
+    values         NMTOKENS      #IMPLIED
+    validationRule IDREF         #IMPLIED
+    readonly       (true|false)  "false"
+>
 
 <!ELEMENT option EMPTY>
-<!ATTLIST option name NMTOKEN #REQUIRED>
-<!ATTLIST option values NMTOKENS #IMPLIED>
-<!ATTLIST option default NMTOKEN #IMPLIED>
-<!ATTLIST option validationRule IDREF #IMPLIED>
-<!ATTLIST option required (true|false) "false">
-<!ATTLIST option readonly (true|false) "false">
+<!ATTLIST option
+    name           NMTOKEN       #REQUIRED
+    values         NMTOKENS      #IMPLIED
+    default        NMTOKEN       #IMPLIED
+    validationRule IDREF         #IMPLIED
+    required       (true|false)  "false"
+    readonly       (true|false)  "false"
+>
 
 <!ELEMENT match EMPTY>
-<!ATTLIST match values NMTOKENS #IMPLIED>
-<!ATTLIST match validationRule IDREF #IMPLIED>
+<!ATTLIST match
+    values         NMTOKENS  #IMPLIED
+    validationRule IDREF     #IMPLIED
+>


### PR DESCRIPTION
This is a purely editorial change, so asking for fast-tracking.

This makes the `registry.dtd` align with commonly used conventions on its formatting.