### PR TITLE
Define function aliases in registry, initially including `:integer`

### DIFF
--- a/spec/registry.dtd
+++ b/spec/registry.dtd
@@ -1,6 +1,6 @@
 <!ELEMENT registry (function|validationRule)*>
 
-<!ELEMENT function (description,(formatSignature|matchSignature)+)>
+<!ELEMENT function (description,(formatSignature|matchSignature|alias)+)>
 <!ATTLIST function name NMTOKEN #REQUIRED>
 
 <!ELEMENT description (#PCDATA)>
@@ -32,3 +32,15 @@
 <!ELEMENT match EMPTY>
 <!ATTLIST match values NMTOKENS #IMPLIED>
 <!ATTLIST match validationRule IDREF #IMPLIED>
+
+<!ELEMENT alias (description,setOption*)>
+<!ATTLIST alias
+    name           NMTOKEN  #REQUIRED
+    supports       (format|match|all)  "all"
+>
+
+<!ELEMENT setOption EMPTY>
+<!ATTLIST setOption
+    name           NMTOKEN #REQUIRED
+    value          CDATA #REQUIRED
+>

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -65,6 +65,11 @@ Read-only options (the `readonly` attribute) can be displayed to translators in 
 Matching-function signatures additionally include one or more `<match>` elements
 to define the keys against which they can match when used as selectors.
 
+Functions may also include `<alias>` definitions,
+which provide shorthands for commonly used option baskets.
+An _alias name_ may be used equivalently to a _function name_ in messages.
+Its `<setOption>` values are always set, and may not be overridden in message annotations.
+
 ## Example
 
 The following `registry.xml` is an example of a registry file
@@ -116,6 +121,12 @@ For the sake of brevity, only `locales="en"` is considered.
             <option name="style" readonly="true" values="decimal currency percent unit" default="decimal"/>
             <option name="currency" readonly="true" validationRule="currencyCode"/>
         </formatSignature>
+
+        <alias name="integer">
+          <description>Locale-sensitive integral number formatting</description>
+          <setOption name="maximumFractionDigits" value="0" />
+          <setOption name="style" value="decimal" />
+        </alias>
     </function>
 </registry>
 ```

--- a/spec/registry.xml
+++ b/spec/registry.xml
@@ -142,6 +142,11 @@
       <option name="maximumSignificantDigits" values="positiveInteger" default="21"/>
     </formatSignature>
 
+    <alias name="integer">
+      <description>Locale-sensitive integral number formatting</description>
+      <setOption name="maximumFractionDigits" value="0" />
+      <setOption name="style" value="decimal" />
+    </alias>
   </function>
 
 </registry>


### PR DESCRIPTION
Adds `<alias>` definitions to the registry, so that shorthands like `:integer` can be made available.