### PR TITLE
(Design) Document the open questions around standalone markup

### DIFF
--- a/exploration/open-close-expressions.md
+++ b/exploration/open-close-expressions.md
@@ -181,7 +181,7 @@ This is similar to [Mustache](http://mustache.github.io/mustache.5.html)'s contr
 This is {#strong}bold{/strong} and this is {#img alt=|an image|}.
 ```
 
-Markup names are _namespaced_ by their use of the pound sign `#` and the forward slash `/` sigils.
+Markup names are _namespaced_ by their use of the U+0023 NUMBER SIGN `#` and the U+002F SOLIDUS `/` sigils.
 They are distinct from `$variables`, `:functions`, and `|literals|`.
 
 This allows for placeholders like `{#b}`, and `{#a title=|Link tooltip|}`.
@@ -191,7 +191,7 @@ Markup is not valid in _declarations_ or _selectors_.
 
 #### Pros
 
-* Leverages the familiarity of the forward slash `/` used for closing spans.
+* Leverages the familiarity of the forward slash (U+002F SOLIDUS `/`) for closing spans.
 
 * Doesn't conflict with any other placeholder expressions.
 
@@ -199,7 +199,7 @@ Markup is not valid in _declarations_ or _selectors_.
 
 #### Cons
 
-* Introduces two new sigils, the pound sign `#` and the forward slash `/`.
+* Introduces two new sigils, U+0023 NUMBER SIGN `#` and the U+002F SOLIDUS `/`.
 
 * In Mustache, the `{{#foo}}`...`{{/foo}}` syntax is used for *control flow* statements rather than printable data.
 
@@ -455,10 +455,10 @@ This is [html:strong]bold[/html:strong] and this is [html:img alt=|an image|/].
 
 * Concise and less noisy than the alternatives.
 
-* Doesn't add new sigils except for the forward slash `/`,
+* Doesn't add new sigils except for the forward slash (U+002F SOLIDUS `/`),
   which is universally known thanks to the wide-spread use of HTML.
 
-* Leverages the familiarity of the forward slash `/` used for closing spans.
+* Leverages the familiarity of the forward slash (U+002F SOLIDUS `/`) used for closing spans.
 
 * Makes it clear that `{42}` and `[foo]` are different concepts:
   one is a standalone placeholder and the other is an open-span element.

--- a/exploration/open-close-expressions.md
+++ b/exploration/open-close-expressions.md
@@ -150,7 +150,8 @@ Following previously established consensus,
 the resolution of the value of an _expression_ may only depend on its own contents,
 without access to the other parts of the selected pattern.
 
-Any information stored in the registry is not available on runtime,
+Any information stored in the registry is not available at runtime
+unless reflected in the implementation's behaviour,
 and may be unavailable in tooling.
 
 ## Proposed Design

--- a/exploration/open-close-placeholders.md
+++ b/exploration/open-close-placeholders.md
@@ -185,7 +185,7 @@ This is {#strong}bold{/strong} and this is {#img alt=|an image|}.
 Markup names are _namespaced_ by their use of the U+0023 NUMBER SIGN `#` and the U+002F SOLIDUS `/` sigils.
 They are distinct from `$variables`, `:functions`, and `|literals|`.
 
-This allows for placeholders like `{#b}`, and `{#a title=|Link tooltip|}`.
+This allows for placeholders like `{#b}`, `{#img}`, and `{#a title=|Link tooltip|}`.
 Unlike annotations, markup _placeholders_ may not have operands.
 
 Markup is not valid in _declarations_ or _selectors_.
@@ -201,6 +201,9 @@ Markup is not valid in _declarations_ or _selectors_.
 #### Cons
 
 * Introduces two new sigils, U+0023 NUMBER SIGN `#` and the U+002F SOLIDUS `/`.
+
+* As in HTML, differentiating "open" and "standalone" placeholders requires
+  additional information not encoded in the bare syntax.
 
 * In Mustache, the `{{#foo}}`...`{{/foo}}` syntax is used for *control flow* statements rather than printable data.
 


### PR DESCRIPTION
See https://github.com/unicode-org/message-format-wg/pull/535#issuecomment-1831867288.

Right now, the doc recognizes that standalone elements are still an open question, but the documented proposal goes one step further: it suggests to use the registry to encode the standalone aspect.

In this PR, I list all previously suggested alternatives on an equal level, since no decision has been made about them yet.