### PR TITLE
Update affiliations

### DIFF
--- a/delegates.md
+++ b/delegates.md
@@ -21,7 +21,7 @@ Please include your primary affiliation (e.g., the company you represent or wher
 
 ### Current
 
-- Addison Phillips - Amazon.com (APS)
+- Addison Phillips - Unicode (APP)
 - Dan Chiba - Oracle (DCA)
 - Eemeli Aro - Mozilla & OpenJSF (EAO)
 - Elango Cheran - Google (ECH)

--- a/delegates.md
+++ b/delegates.md
@@ -23,7 +23,7 @@ Please include your primary affiliation (e.g., the company you represent or wher
 
 - Addison Phillips - Amazon.com (APS)
 - Dan Chiba - Oracle (DCA)
-- Eemeli Aro - OpenJSF & Vincit (EAO)
+- Eemeli Aro - Mozilla & OpenJSF (EAO)
 - Elango Cheran - Google (ECH)
 - George Rhoten - Apple (GWR)
 - Jan Mühlemann - Locize (JMU)
@@ -42,7 +42,7 @@ Please include your primary affiliation (e.g., the company you represent or wher
 - Robert Chu - Amazon.com (RCU)
 - Romulo Cintra - CaixaBank (RCA)
 - Shane Carr - Google (SFC)
-- Staś Małolepszy - Mozilla (STA)
+- Staś Małolepszy - Google (STA)
 - Steven R. Loomis - IBM (SRL)
 - Zibi Braniecki - Amazon Alexa (ZBI)
 


### PR DESCRIPTION
I happened to notice that we maintain a list of named "delegates" and their affiliations, and that it's at least somewhat out of date. I updated the Mozilla entries to start, as I joined a few years ago and @stasm is now at Google.

There are probably other out-of-date entries here as well, and as we rely on the mailing list + GitHub tracking for the places where "membership" of the group is relevant, we could also just remove this whole file as misleading.

This could also be fast-tracked.