### PR TITLE
Formatting: Don't remove unresolved options from the map passed to the function

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -216,6 +216,7 @@ the following steps are taken:
    - If the _option_'s right-hand side successfully resolves to a value,
      bind the _identifier_ of the _option_ to the resolved value in the mapping.
    - Otherwise, bind the _identifier_ of the _option_ to an unresolved value in the mapping.
+     Implementations MAY later remove this value before calling the _function_.
      (Note that an Unresolved Variable error will have been emitted.)
 
 4. Call the function implementation with the following arguments:

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -217,8 +217,8 @@ the following steps are taken:
      bind the _identifier_ of the _option_ to the resolved value in the mapping.
    - Otherwise, bind the _identifier_ of the _option_ to an unresolved value in the mapping.
      (Note that an Unresolved Variable error will have been emitted.)
-4. Remove from the resolved mapping of _options_ any binding for which the value is an unresolved value.
-5. Call the function implementation with the following arguments:
+
+4. Call the function implementation with the following arguments:
 
    - The current _locale_.
    - The resolved mapping of _options_.


### PR DESCRIPTION
A follow-up to https://github.com/unicode-org/message-format-wg/pull/524#discussion_r1409411240:

@stasm:

> I see that this step was added yesterday in a suggestion from @gibson042. What is the purpose of it? Why wouldn't we want functions to see unresolved options?

@eemeli:

> This is a small fix unrelated to namespacing that's bundled in here to ensure that if
> 
> ```
> {:foo opt=$none opt=bar}
> ```
> 
> is formatted with `$none` not resolving, not only will that cause an Unresolved Variable error to be emitted, but that a Duplicate Option Name error will also be emitted -- the latter was previously skipped.
> 
> The behaviour around options with errors is unchanged from the previous; it's just expressed a bit differently. If you think that ought to be changed, then that should go in a different PR as this is scope-creepy enough already.

Perhaps I'm missing something, but my reading of the current step 3 is that both errors would be emitted. I don't really see how step 4, which I remove in this PR, helps.
