### PR TITLE
Add `<when>` to help select the right `<match>`

### DIFF
--- a/spec/registry.dtd
+++ b/spec/registry.dtd
@@ -18,7 +18,7 @@
     position       (open|close|standalone)  "standalone"
 >
 
-<!ELEMENT matchSignature (input?,option*,override*,when*,match*)>
+<!ELEMENT matchSignature (input?,option*,override*,when*,matches?)>
 
 <!ELEMENT input EMPTY>
 <!ATTLIST input
@@ -37,14 +37,19 @@
     readonly       (true|false)  "false"
 >
 
+<!ELEMENT matches (match*)>
+<!ATTLIST matches
+    href           CDATA  #IMPLIED
+    validationRule IDREF  #IMPLIED
+>
+
 <!ELEMENT match EMPTY>
 <!ATTLIST match
     locales        NMTOKENS  #IMPLIED
     values         NMTOKENS  #IMPLIED
-    validationRule IDREF     #IMPLIED
 >
 
-<!ELEMENT when (when*,match*)>
+<!ELEMENT when (when*,matches?)>
 <!ATTLIST when
     option         NMTOKEN   #REQUIRED
     values         NMTOKENS  #REQUIRED

--- a/spec/registry.dtd
+++ b/spec/registry.dtd
@@ -18,7 +18,7 @@
     position       (open|close|standalone)  "standalone"
 >
 
-<!ELEMENT matchSignature (input?,option*,match*,override*)>
+<!ELEMENT matchSignature (input?,option*,override*,when*,match*)>
 
 <!ELEMENT input EMPTY>
 <!ATTLIST input
@@ -42,6 +42,12 @@
     locales        NMTOKENS  #IMPLIED
     values         NMTOKENS  #IMPLIED
     validationRule IDREF     #IMPLIED
+>
+
+<!ELEMENT when (when*,match*)>
+<!ATTLIST when
+    option         NMTOKEN   #REQUIRED
+    values         NMTOKENS  #REQUIRED
 >
 
 <!ELEMENT override (input?,option*)>

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -66,21 +66,33 @@ the corresponding input and options rules.
 If multiple `<override>` elements would match the current locale,
 only the first one is used.
 
-Matching-function signatures additionally include one or more `<match>` elements
-to define the keys against which they can match when used as selectors.
+### Variant Key Matches
+
+Matching-function signatures can include `<matches>` and `<when>` elements
+defining the variant keys matched by the selector.
+
+Each `<matches>` MAY contain either one or more `<match>` elements, or an `href` attribute.
+If an `href` attribute is set, its URL value MUST resolve to an XML document
+with a root `<matches>` element with no `href` attribute,
+which will then replace the current `<matches>` element for all later processing.
+If `<matches>` contains any child elements, its `href` attribute is ignored.
+Otherwise, if `<matches>` contains an `href` attribute, its `validationRule` attribute is ignored.
+
 The `<match>` element whose `locales` best matches the current locale
 using resource item [lookup](https://unicode.org/reports/tr35/#Lookup) from LDML is used.
 An element with no `locales` attribute is the default
 (and is considered equivalent to the `root` locale).
 
 As the available keys may depend on option values,
-`<when>` elements can be used to select an appropriate set of `<match>` elements for selection.
+`<when>` elements can be used to select an appropriate `<matches>` element for selection.
 If the resolved or default value of a selector option
 corresponding to the `<when>` `option` attribute
 is included in its list of `values`,
-its contents are considered before any and all later `<when>` and `<match>` elements.
-If a `<match>` element within a `<when>` matches the current locale,
-later `<match>` elements outside that `<when>` are not considered.
+its contents are considered before any and all later `<when>` and `<matches>` elements.
+If a `<matches>` element within a `<when>` has a `<match>` for the current locale,
+later `<matches>` elements outside that `<when>` are not considered.
+
+### Function Aliases
 
 Functions may also include `<alias>` definitions,
 which provide shorthands for commonly used option baskets.
@@ -124,12 +136,18 @@ For the sake of brevity, only `locales="en"` is considered.
             <option name="minimumSignificantDigits" validationRule="positiveInteger"/>
             <option name="maximumSignificantDigits" validationRule="positiveInteger"/>
             <when option="select" values="plural">
-                <match locales="en" values="one other" validationRule="anyNumber"/>
+                <matches validationRule="anyNumber">
+                    <match locales="en" values="one other"/>
+                </matches>
             </when>
             <when option="select" values="ordinal">
-                <match locales="en" values="one two few other" validationRule="anyNumber"/>
+                <matches validationRule="anyNumber">
+                    <match locales="en" values="one two few other"/>
+                </matches>
             </when>
-            <match values="zero one two few many other" validationRule="anyNumber"/>
+            <matches validationRule="anyNumber">
+                <match values="zero one two few many other"/>
+            </matches>
         </matchSignature>
 
         <formatSignature>
@@ -161,16 +179,16 @@ Given the above description, the `:number` function is defined to work both in a
 ```
 
 Furthermore,
-`:number`'s `<matchSignature>` contains multiple `<match>` and `<when>` elements
+`:number`'s `<matchSignature>` contains multiple `<matches>` and `<when>` elements
 which allow the validation of variant keys.
 
-- `<when option="select" values="plural"><match locales="en" values="one other" ... />`
+- `<when option="select" values="plural"><matches><match locales="en" values="one other" ... />`
   can be used in locales like `en` and `en-GB` if the selection type is known to be plural
   to validate that only `one`, `other` or numeric keys are used for variants.
-- `<when option="select" values="ordinal"><match locales="en" values="one two few other" ... />`
+- `<when option="select" values="ordinal"><matches><match locales="en" values="one two few other" ... />`
   can be used in locales like `en` and `en-GB` if the selection type is known to be ordinal
   to validate that only `one`, `two`, `few`, `other` or numeric keys are used for variants.
-- `<match values="zero one two few many other" validationRule="anyNumber"/>` can be used
+- `<matches validationRule="anyNumber"><match values="zero one two few many other"/>` can be used
   for all locales and selection types, validating that variant keys are either numeric
   or use one of the plural category identifiers.
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -71,7 +71,7 @@ only the first one is used.
 Matching-function signatures can include `<matches>` and `<when>` elements
 defining the variant keys matched by the selector.
 
-Each `<matches>` MAY contain either one or more `<match>` elements, or an `href` attribute.
+Each `<matches>` contains either a (possibly empty) set of `<match>` elements or an `href` attribute.
 If `<matches>` contains both an `href` attribute and child elements
 the `href` attribute is ignored.
 If `<matches>` contains only an `href` attribute, any `validationRule` attributes are ignored. 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -89,8 +89,8 @@ If the resolved or default value of a selector option
 corresponding to the `<when>` `option` attribute
 is included in its list of `values`,
 its contents are considered before any and all later `<when>` and `<matches>` elements.
-If a `<matches>` element within a `<when>` has a `<match>` for the current locale,
-later `<matches>` elements outside that `<when>` are not considered.
+If a `<matches>` element within a matching `<when>` has a `<match>` for the current locale,
+later `<matches>` outside that `<when>` are not considered.
 
 ### Function Aliases
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -68,7 +68,7 @@ only the first one is used.
 
 ### Variant Key Matches
 
-Matching-function signatures can include `<matches>` and `<when>` elements
+Selector signatures can include `<matches>` and `<when>` elements
 defining the variant keys matched by the selector.
 
 Each `<matches>` contains either a (possibly empty) set of `<match>` elements or an `href` attribute.

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -68,6 +68,10 @@ only the first one is used.
 
 Matching-function signatures additionally include one or more `<match>` elements
 to define the keys against which they can match when used as selectors.
+The `<match>` element whose `locales` best matches the current locale
+using resource item [lookup](https://unicode.org/reports/tr35/#Lookup) from LDML is used.
+An element with no `locales` attribute is the default
+(and is considered equivalent to the `root` locale).
 
 Functions may also include `<alias>` definitions,
 which provide shorthands for commonly used option baskets.
@@ -146,10 +150,6 @@ Given the above description, the `:number` function is defined to work both in a
 Furthermore,
 `:number`'s `<matchSignature>` contains two `<match>` elements
 which allow the validation of variant keys.
-The element whose `locales` best matches the current locale
-using resource item [lookup](https://unicode.org/reports/tr35/#Lookup) from LDML is used.
-An element with no `locales` attribute is the default
-(and is considered equivalent to the `root` locale).
 
 - `<match locales="en" values="one two few other" .../>` can be used in locales like `en` and `en-GB`
   to validate the `when other` variant by verifying that the `other` key is present

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -72,18 +72,18 @@ Matching-function signatures can include `<matches>` and `<when>` elements
 defining the variant keys matched by the selector.
 
 Each `<matches>` MAY contain either one or more `<match>` elements, or an `href` attribute.
-If an `href` attribute is set, its URL value MUST resolve to an XML document
-with a root `<matches>` element with no `href` attribute,
-which will then replace the current `<matches>` element for all later processing.
-If `<matches>` contains any child elements, its `href` attribute is ignored.
-Otherwise, if `<matches>` contains an `href` attribute, its `validationRule` attribute is ignored.
+If `<matches>` contains both an `href` attribute and child elements
+the `href` attribute is ignored.
+If `<matches>` contains only an `href` attribute, any `validationRule` attributes are ignored. 
+The `href` attribute MUST resolve to an XML document whose root element is `<matches>`.
+The contents of the resolved XML document replaces the current `matches` element for all later processing.
 
 The `<match>` element whose `locales` best matches the current locale
 using resource item [lookup](https://unicode.org/reports/tr35/#Lookup) from LDML is used.
 An element with no `locales` attribute is the default
 (and is considered equivalent to the `root` locale).
 
-As the available keys may depend on option values,
+In situations where the available keys depend on option values,
 `<when>` elements can be used to select an appropriate `<matches>` element for selection.
 If the resolved or default value of a selector option
 corresponding to the `<when>` `option` attribute

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -73,6 +73,15 @@ using resource item [lookup](https://unicode.org/reports/tr35/#Lookup) from LDML
 An element with no `locales` attribute is the default
 (and is considered equivalent to the `root` locale).
 
+As the available keys may depend on option values,
+`<when>` elements can be used to select an appropriate set of `<match>` elements for selection.
+If the resolved or default value of a selector option
+corresponding to the `<when>` `option` attribute
+is included in its list of `values`,
+its contents are considered before any and all later `<when>` and `<match>` elements.
+If a `<match>` element within a `<when>` matches the current locale,
+later `<match>` elements outside that `<when>` are not considered.
+
 Functions may also include `<alias>` definitions,
 which provide shorthands for commonly used option baskets.
 An _alias name_ may be used equivalently to a _function name_ in messages.
@@ -108,14 +117,18 @@ For the sake of brevity, only `locales="en"` is considered.
 
         <matchSignature>
             <input validationRule="anyNumber"/>
-            <option name="type" values="cardinal ordinal"/>
+            <option name="select" values="plural ordinal" default="plural"/>
             <option name="minimumIntegerDigits" validationRule="positiveInteger"/>
             <option name="minimumFractionDigits" validationRule="positiveInteger"/>
             <option name="maximumFractionDigits" validationRule="positiveInteger"/>
             <option name="minimumSignificantDigits" validationRule="positiveInteger"/>
             <option name="maximumSignificantDigits" validationRule="positiveInteger"/>
-            <!-- Since this applies to both cardinal and ordinal, all plural options are valid. -->
-            <match locales="en" values="one two few other" validationRule="anyNumber"/>
+            <when option="select" values="plural">
+                <match locales="en" values="one other" validationRule="anyNumber"/>
+            </when>
+            <when option="select" values="ordinal">
+                <match locales="en" values="one two few other" validationRule="anyNumber"/>
+            </when>
             <match values="zero one two few many other" validationRule="anyNumber"/>
         </matchSignature>
 
@@ -148,14 +161,18 @@ Given the above description, the `:number` function is defined to work both in a
 ```
 
 Furthermore,
-`:number`'s `<matchSignature>` contains two `<match>` elements
+`:number`'s `<matchSignature>` contains multiple `<match>` and `<when>` elements
 which allow the validation of variant keys.
 
-- `<match locales="en" values="one two few other" .../>` can be used in locales like `en` and `en-GB`
-  to validate the `when other` variant by verifying that the `other` key is present
-  in the list of enumarated values: `one other`.
-- `<match ... validationRule="anyNumber"/>` can be used to valide the `when 1` variant
-  by testing the `1` key against the `anyNumber` regular expression defined in the registry file.
+- `<when option="select" values="plural"><match locales="en" values="one other" ... />`
+  can be used in locales like `en` and `en-GB` if the selection type is known to be plural
+  to validate that only `one`, `other` or numeric keys are used for variants.
+- `<when option="select" values="ordinal"><match locales="en" values="one two few other" ... />`
+  can be used in locales like `en` and `en-GB` if the selection type is known to be ordinal
+  to validate that only `one`, `two`, `few`, `other` or numeric keys are used for variants.
+- `<match values="zero one two few many other" validationRule="anyNumber"/>` can be used
+  for all locales and selection types, validating that variant keys are either numeric
+  or use one of the plural category identifiers.
 
 ---
 


### PR DESCRIPTION
As noted by @macchiati in https://github.com/unicode-org/message-format-wg/pull/471#issuecomment-1848074823:
> One note: we might not want to treat `:integer` as simply an alias for `:number`. There is one difference in handling:
> 
> When you have a match, for translation the **when** clauses are expanded (or contracted) depending on the locale. There are some locales that have a plural category that is only present when the number is fractional, and in those locales you can limit the expansion by not including that category if the numeric value is known to be integral.

Thinking about this myself, I think we need a mechanism for picking the right set of keys based on multiple option values. Polish is a decent example here:
- plural selection on integers uses `one`, `few`, and `many`
- plural selection on all numbers uses `one`, `few`, `many` and `other`
- ordinal selection uses only `other`

The way we have aliases set up, they set option values like `maximumFractionDigits: 0` for their parent function, so if we start solving this via aliases, then we're likely to end up in a place where `:integer` and `:number maximumFractionDigits=0` have different behaviour.

So here I propose adding `<when>` elements to the `<matchSignature>` as a way of resolving that. Continuing with the above example, they work like this:
```xml
<function name="number">
  ...
  <matchSignature>
    ...
    <option name="select" values="plural ordinal" default="plural" />
    ...
    <when option="select" values="ordinal">
      <match locales="en" values="one two few other" validationRule="anyNumber" />
      <match locales="pl" values="other" validationRule="anyNumber" />
    </when>
    <when option="select" values="plural">
      <when option="maximumFractionDigits" values="0">
        <match locales="pl" values="one few many" validationRule="anyNumber" />
      </when>
      <match locales="en" values="one other" validationRule="anyNumber" />
      <match locales="pl" values="one few many other" validationRule="anyNumber" />
    </when>
    <match values="zero one two few many other" validationRule="anyNumber" />
  </matchSignature>
  ...
  <alias name="integer">
    <setOption name="maximumFractionDigits" value="0" />
  </alias>
</function>
```

The way that should be used is that the `option`/`values` combo of each `<when>` is tested in order to pick a first set of `<match>` to check against the current locale, and that's repeated until one of the sets provides a match.

So if we start with a selector expression `{$x :integer}`, its resolved options are:
```js
{ maximumFractionDigits: '0', select: 'plural' }
```
Let's consider what happens with a few different locales `en`, `pl`, and `fr` (standing in for "any other locale"):
- First, `<when option="select" values="ordinal">` does not match, so its contents are ignored.
- As `<when option="select" values="plural">` does match, let's consider its contents:
  - The inner `<when option="maximumFractionDigits" values="0">` also matches:
    - For `pl`,  its set of `<match>` elements does provide a Lookup match, so we use that and don't consider any later ones.
    - For `en` and `fr`, its set of `<match>` elements does not provide a Lookup match.
  - Continuing for `en` and `fr` with the next set `<match locales="en" ... />`, `<match locales="pl" ... />`:
    - For `en` we do find a Lookup match, and use that.
    - For `fr`, no match at this level.
- For `fr`, we ultimately fall back to the last `<match>` without a `locales` which implicitly matches.

So we end up with these sets of category keys to use for the selector:
- `en`: `one other`
- `pl`: `one few many`
- `fr`: `zero one two few many other` (due to fallback)

Please note that while the example here does perform selection on `:number` and that's still being discussed in #471, this approach would be equally valid on a non-alias selector like `:plural`, for which being able to account for integral input values would be just as useful.