### PR TITLE
Add content-char as common root of simple-start-char, text-char, quoted-char & reserved-char

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -28,6 +28,8 @@ annotation = (function *(s option))
            / reserved-annotation
 
 literal = quoted / unquoted
+quoted = "|" *(quoted-char / quoted-escape) "|"
+unquoted = name / number-literal
 variable = "$" name
 function = (":" / "+" / "-") identifier
 option = identifier [s] "=" [s] (literal / variable)
@@ -35,26 +37,6 @@ option = identifier [s] "=" [s] (literal / variable)
 input = %s".input"
 local = %s".local"
 match = %s".match"
-
-simple-start-char = %x0-2D         ; omit .
-                  / %x2F-5B        ; omit \
-                  / %x5D-7A        ; omit {
-                  / %x7C           ; omit }
-                  / %x7E-D7FF      ; omit surrogates
-                  / %xE000-10FFFF
-text-char = simple-start-char / "."
-
-quoted      = "|" *(quoted-char / quoted-escape) "|"
-quoted-char = %x0-5B         ; omit \
-            / %x5D-7B        ; omit |
-            / %x7D-D7FF      ; omit surrogates
-            / %xE000-10FFFF
-
-unquoted       = name
-               / number-literal
-; number-literal matches JSON number
-; https://www.rfc-editor.org/rfc/rfc8259#section-6
-number-literal = ["-"] (0 / ([1-9] *DIGIT)) ["." 1*DIGIT] [%i"e" ["-" / "+"] 1*DIGIT]
 
 ; Reserve additional .keywords for use by future versions of this specification.
 reserved-statement = reserved-keyword [s reserved-body] 1*([s] expression)
@@ -68,18 +50,15 @@ reserved-annotation = reserved-annotation-start reserved-body
 reserved-annotation-start = "!" / "@" / "#" / "%" / "*"
                           / "<" / ">" / "/" / "?" / "~"
 
-reserved-body  = *([s] 1*(reserved-char / reserved-escape / quoted))
-reserved-char  = %x00-08        ; omit HTAB and LF
-               / %x0B-0C        ; omit CR
-               / %x0E-19        ; omit SP
-               / %x21-5B        ; omit \
-               / %x5D-7A        ; omit { | }
-               / %x7E-D7FF      ; omit surrogates
-               / %xE000-10FFFF
+reserved-body = *([s] 1*(reserved-char / reserved-escape / quoted))
 
 ; Reserve sigils for private-use by implementations.
 private-use-annotation = private-start reserved-body
 private-start = "^" / "&"
+
+; number-literal matches JSON number
+; https://www.rfc-editor.org/rfc/rfc8259#section-6
+number-literal = ["-"] (0 / ([1-9] *DIGIT)) ["." 1*DIGIT] [%i"e" ["-" / "+"] 1*DIGIT]
 
 ; identifier matches https://www.w3.org/TR/REC-xml-names/#NT-QName
 ; name matches https://www.w3.org/TR/REC-xml-names/#NT-NCName
@@ -93,6 +72,19 @@ name-start = ALPHA / "_"
            / %xF900-FDCF / %xFDF0-FFFD / %x10000-EFFFF
 name-char  = name-start / DIGIT / "-" / "."
            / %xB7 / %x300-36F / %x203F-2040
+
+content-char = %x00-08        ; omit HTAB (%x09) and LF (%x0A)
+             / %x0B-0C        ; omit CR (%x0D)
+             / %x0E-19        ; omit SP (%x20)
+             / %x21-2D        ; omit . (%x2E)
+             / %x2F-5B        ; omit \ (%x5C)
+             / %x5D-7A        ; omit { | } (%x7B-7D)
+             / %x7E-D7FF      ; omit surrogates
+             / %xE000-10FFFF
+simple-start-char = content-char / s / "|"
+text-char         = content-char / s / "." / "|"
+quoted-char       = content-char / s / "." / "{" / "}"
+reserved-char     = content-char / "."
 
 text-escape     = backslash ( backslash / "{" / "}" )
 quoted-escape   = backslash ( backslash / "|" )

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -73,6 +73,10 @@ name-start = ALPHA / "_"
 name-char  = name-start / DIGIT / "-" / "."
            / %xB7 / %x300-36F / %x203F-2040
 
+simple-start-char = content-char / s / "|"
+text-char         = content-char / s / "." / "|"
+quoted-char       = content-char / s / "." / "{" / "}"
+reserved-char     = content-char / "."
 content-char = %x00-08        ; omit HTAB (%x09) and LF (%x0A)
              / %x0B-0C        ; omit CR (%x0D)
              / %x0E-19        ; omit SP (%x20)
@@ -81,10 +85,6 @@ content-char = %x00-08        ; omit HTAB (%x09) and LF (%x0A)
              / %x5D-7A        ; omit { | } (%x7B-7D)
              / %x7E-D7FF      ; omit surrogates
              / %xE000-10FFFF
-simple-start-char = content-char / s / "|"
-text-char         = content-char / s / "." / "|"
-quoted-char       = content-char / s / "." / "{" / "}"
-reserved-char     = content-char / "."
 
 text-escape     = backslash ( backslash / "{" / "}" )
 quoted-escape   = backslash ( backslash / "|" )

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -286,6 +286,8 @@ Whitespace in _text_, including tabs, spaces, and newlines is significant and MU
 be preserved during formatting.
 
 ```abnf
+simple-start-char = content-char / s / "|"
+text-char         = content-char / s / "." / "|"
 content-char = %x00-08        ; omit HTAB (%x09) and LF (%x0A)
              / %x0B-0C        ; omit CR (%x0D)
              / %x0E-19        ; omit SP (%x20)
@@ -294,8 +296,6 @@ content-char = %x00-08        ; omit HTAB (%x09) and LF (%x0A)
              / %x5D-7A        ; omit { | } (%x7B-7D)
              / %x7E-D7FF      ; omit surrogates
              / %xE000-10FFFF
-simple-start-char = content-char / s / "|"
-text-char = content-char / s / "." / "|"
 ```
 
 When a _pattern_ is quoted by embedding the _pattern_ in curly brackets, the

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -280,6 +280,7 @@ In the ABNF, _text_ is represented by non-empty sequences of
 `simple-start-char`, `text-char`, and `text-escape`.
 The first of these is used at the start of a _simple message_,
 and matches `text-char` except for not allowing U+002E FULL STOP `.`.
+The ABNF uses `content-char` as a shared base for _text_ and _quoted literal_ characters.
 
 Whitespace in _text_, including tabs, spaces, and newlines is significant and MUST
 be preserved during formatting.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -285,13 +285,16 @@ Whitespace in _text_, including tabs, spaces, and newlines is significant and MU
 be preserved during formatting.
 
 ```abnf
-simple-start-char = %x0-2D         ; omit .
-                  / %x2F-5B        ; omit \
-                  / %x5D-7A        ; omit {
-                  / %x7C           ; omit }
-                  / %x7E-D7FF      ; omit surrogates
-                  / %xE000-10FFFF
-text-char = simple-start-char / "."
+content-char = %x00-08        ; omit HTAB (%x09) and LF (%x0A)
+             / %x0B-0C        ; omit CR (%x0D)
+             / %x0E-19        ; omit SP (%x20)
+             / %x21-2D        ; omit . (%x2E)
+             / %x2F-5B        ; omit \ (%x5C)
+             / %x5D-7A        ; omit { | } (%x7B-7D)
+             / %x7E-D7FF      ; omit surrogates
+             / %xE000-10FFFF
+simple-start-char = content-char / s / "|"
+text-char = content-char / s / "." / "|"
 ```
 
 When a _pattern_ is quoted by embedding the _pattern_ in curly brackets, the
@@ -658,13 +661,7 @@ reserved-annotation-start = "!" / "@" / "#" / "%" / "*"
                           / "<" / ">" / "/" / "?" / "~"
 
 reserved-body = *([s] 1*(reserved-char / reserved-escape / quoted))
-reserved-char = %x00-08        ; omit HTAB and LF
-              / %x0B-0C        ; omit CR
-              / %x0E-19        ; omit SP
-              / %x21-5B        ; omit \
-              / %x5D-7A        ; omit { | }
-              / %x7E-D7FF      ; omit surrogates
-              / %xE000-10FFFF
+reserved-char = content-char / "."
 ```
 
 ## Other Syntax Elements
@@ -717,10 +714,7 @@ of number values in _operands_ or _options_, or as _keys_ for _variants_.
 literal = quoted / unquoted
 
 quoted         = "|" *(quoted-char / quoted-escape) "|"
-quoted-char    = %x0-5B         ; omit \
-               / %x5D-7B        ; omit |
-               / %x7D-D7FF      ; omit surrogates
-               / %xE000-10FFFF
+quoted-char    = content-char / s / "." / "{" / "}"
 
 unquoted       = name
                / number-literal


### PR DESCRIPTION
This change does not change the syntax in any way, and only introduces a `content-char` rule as a common base for other character classes.

At the moment, we have multiple explicit character range definitions in the ABNF, and it's not easy to see that they are very nearly the same as each other, and how exactly they differ. By introducing their overlap as `content-char`, this becomes more obvious to a reader.