### PR TITLE
(Design) Default registry and MF1 compatibility matrix

### DIFF
--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -112,7 +112,7 @@ How to write an MF1 format or selector in MF2:
 | Currency | {num,number,currency} | {$num :number currency=$code} {$num :currency}              |         |
 | Plural (selector)  | {num,plural, ...}    | .match {$num :number} {$num :plural}               |         |
 | Ordinal (selector) | {num,selectordinal, ...} | .match {$num :ordinal}                         |         |
-| Ordinal (format)   | {num,ordinal} | {$num :number type=ordinal} {$num :ordinal}               |         |
+| Ordinal (format)   | {num,ordinal} |                                                           | missing |
 | Date     | {date,date}          | {$date :datetime}                                            | short date is default |
 | Date     | {date,date,short}    | {$date :datetime dateStyle=short}                            | also medium,long,full |
 | Time     | {date,time}          | {$date :datetime timeStyle=short}                            | timeStyle required    |

--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -97,18 +97,20 @@ Options:
 
 ## Compatibility Matrix
 
+How to write an MF1 format or selector in MF2:
+
 | MF1      | Syntax               | MF2                                                          | Comment |
 |----------|----------------------|--------------------------------------------------------------|---------|
 | Number   | {num,number}         | {$num :number}                                               |         |
 | Integer  | {num,number,integer} | {$num :number maximumFractionDigits=0}  {$num :integer}      |         |
-| Percent  | {num,number,percent} |                                                              | missing |
+| Percent  | {num,number,percent} | {$num :number style=percent} {$num :percent}                 |         |
 | Currency | {num,number,currency} | {$num :number currency=$code} {$num :currency}              |         |
 | Plural (selector)  | {num,plural, ...}    | .match {$num :number} {$num :plural}               |         |
 | Ordinal (selector) | {num,selectordinal, ...} | .match {$num :ordinal}                         |         |
 | Ordinal (format)   | {num,ordinal} | {$num :number type=ordinal} {$num :ordinal}               |         |
-| Date     | {date,date}          | {$date :datetime type=date}                                  |         |
+| Date     | {date,date}          | {$date :datetime}                                            | short date is default |
 | Date     | {date,date,short}    | {$date :datetime dateStyle=short}                            | also medium,long,full |
-| Time     | {date,time}          | {$date :datetime type=time}                                  |         |
+| Time     | {date,time}          | {$date :datetime timeStyle=short}                            | timeStyle required    |
 | Date     | {date,time,short}    | {$date :datetime timeStyle=short}                            | also medium,long,full |
 | Datetime | (requires picture or skeleton) | {$date :datetime dateStyle=short timeStyle=short}  | also medium,long,full |
 | Datetime | {date,time,::skeleton} | {$date :datetime weekday=short etc.}                       | supported through options bag |

--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -33,8 +33,8 @@ Aliases:
 - `:integer` (implies: `maximumFractionDigits=0`)
 - `:currency` (implies: `style=currency`)
 - `:percent` (implies: `style=percent`)
-- `:plural` (no format, implies `style=plural` which is default)
-- `:ordinal` (missing format, implies: `style=ordinal`)
+- `:plural` (no format, implies `select=plural` which is default)
+- `:ordinal` (implies: `select=ordinal`; we are missing `style=ordinal`)
 
 Operand: anyNumber
 
@@ -47,10 +47,10 @@ Options:
 - `numberingSystem` (arab arabext bali beng deva fullwide gujr guru hanidec khmr knda laoo latn 
    limb mlym mong mymr orya tamldec telu thai tibt)
 - `select` (`plural`, `ordinal`, `exact`; default: `plural`)
-- `signDisplay` (`auto` `always` `exceptZero` `never`; default="auto")
-- `style` (decimal currency percent unit" default="decimal")
+- `signDisplay` (`auto` `always` `exceptZero` `never`; default=`auto`)
+- `style` (`decimal` `currency` `percent` `unit`; default=`decimal`)
 - `unit` (anything not empty)
-- `unitDisplay` (long short narrow" default="short")
+- `unitDisplay` (`long` `short` `narrow`; default=`short`)
 - `minimumIntegerDigits`, (positive integer, default: `1`)
 - `minimumFractionDigits`, (positive integer)
 - `maximumFractionDigits`, (positive integer)

--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -1,4 +1,4 @@
-# Default Registry and MF1 Compatbility
+# Default Registry and MF1 Compatibility
 
 Status: **Proposed**
 
@@ -29,7 +29,12 @@ to ensure that we don't forget something.
 
 Function name: `:number`
 
-Aliases: `:integer`, `:currency`, `:percent`
+Aliases: 
+- `:integer` (implies: `maximumFractionDigits=0`)
+- `:currency` (implies: `style=currency`)
+- `:percent` (implies: `style=percent`)
+- `:plural` (selector only, implies CLDR rules)
+- `:ordinal` (missing formats, missing selector)
 
 Operand: anyNumber
 
@@ -69,7 +74,7 @@ Options:
 - `weekday` (long short narrow)
 - `era` (long short narrow)
 - `year` (numeric, 2-digit)
-- `month` ("numeric 2-digit long short narrow)
+- `month` (numeric 2-digit long short narrow)
 - `day` (numeric 2-digit)
 - `hour` (numeric 2-digit)
 - `minute` (numeric 2-digit)
@@ -100,7 +105,7 @@ Options:
 | Currency | {num,number,currency} | {$num :number currency=$code} {$num :currency}              |         |
 | Plural (selector)  | {num,plural, ...}    | .match {$num :number} {$num :plural}               |         |
 | Ordinal (selector) | {num,selectordinal, ...} | .match {$num :ordinal}                         |         |
-| Oridnal (format)   | {num,ordinal} | {$num :number type=ordinal} {$num :ordinal}               |         |
+| Ordinal (format)   | {num,ordinal} | {$num :number type=ordinal} {$num :ordinal}               |         |
 | Date     | {date,date}          | {$date :datetime type=date}                                  |         |
 | Date     | {date,date,short}    | {$date :datetime dateStyle=short}                            | also medium,long,full |
 | Time     | {date,time}          | {$date :datetime type=time}                                  |         |

--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -63,6 +63,9 @@ Options:
 
 Function name: `:datetime`
 
+Aliases:
+- (none currently; should there be `:date` and `:time` aliases to shorthand getting particularly timeStyle?)
+
 Operand: "iso8601"
 
 Options:
@@ -91,7 +94,9 @@ Options:
 
 Function name: `:string`
 
-Operand: any string
+String is both a formatter and a selector, where it fills the role that `SelectFormat` fills in MF1.
+
+Operand: any value
 
 Options:
 (none?)
@@ -106,6 +111,8 @@ How to write an MF1 format or selector in MF2:
 
 | MF1      | Syntax               | MF2                                                          | Comment |
 |----------|----------------------|--------------------------------------------------------------|---------|
+| String   | {var}                | {$var} {$var :string}                                        |         |
+| Select   | {var,select...}      | .match {$var :string}                                        |         |
 | Number   | {num,number}         | {$num :number}                                               |         |
 | Integer  | {num,number,integer} | {$num :number maximumFractionDigits=0}  {$num :integer}      |         |
 | Percent  | {num,number,percent} | {$num :number style=percent} {$num :percent}                 |         |

--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -114,9 +114,9 @@ How to write an MF1 format or selector in MF2:
 | String   | {var}                | {$var} {$var :string}                                        |         |
 | Select   | {var,select...}      | .match {$var :string}                                        |         |
 | Number   | {num,number}         | {$num :number}                                               |         |
-| Integer  | {num,number,integer} | {$num :number maximumFractionDigits=0}  {$num :integer}      |         |
-| Percent  | {num,number,percent} | {$num :number style=percent} {$num :percent}                 |         |
-| Currency | {num,number,currency} | {$num :number currency=$code} {$num :currency}              |         |
+| Integer  | {num,number,integer} | {$num :number maximumFractionDigits=0}<br/>{$num :integer}      |         |
+| Percent  | {num,number,percent} | {$num :number style=percent}<br/>{$num :percent}                 |         |
+| Currency | {num,number,currency} | {$num :number currency=$code}<br/>{$num :currency}              |         |
 | Plural (selector)  | {num,plural, ...}    | .match {$num :number} {$num :plural}               |         |
 | Ordinal (selector) | {num,selectordinal, ...} | .match {$num :ordinal}                         |         |
 | Ordinal (format)   | {num,ordinal} |                                                           | missing |

--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -1,0 +1,112 @@
+# Default Registry and MF1 Compatbility
+
+Status: **Proposed**
+
+<details>
+	<summary>Metadata</summary>
+	<dl>
+		<dt>Contributors</dt>
+		<dd>@aphillips</dd>
+		<dt>First proposed</dt>
+		<dd>2023-12-15</dd>
+	</dl>
+</details>
+
+## Objective
+
+_What is this proposal trying to achieve?_
+
+This section contains the list of functions (both _selectors_ and _formatters_)
+proposed for the 2.0 default registry,
+along with their _operands_ and _options_.
+
+It also contains a section comparing MF1 (as embodied by ICU4J) and MF2
+to ensure that we don't forget something.
+
+## Default Registry Entries
+
+### Numbers
+
+Function name: `:number`
+
+Aliases: `:integer`, `:currency`, `:percent`
+
+Operand: anyNumber
+
+Options:
+- `compactDisplay` (`short`, `long`; default: `short`)
+- `currency` (ISO 4712 currency code)
+- `currencyDisplay` (`symbol` `narrowSymbol` `code` `name`; default: `symbol`)
+- `currencySign` (`accounting`, `standard`; default: `standard`)
+- `notation` (`standard` `scientific` `engineering` `compact`; default: `standard`)
+- `numberingSystem` (arab arabext bali beng deva fullwide gujr guru hanidec khmr knda laoo latn 
+   limb mlym mong mymr orya tamldec telu thai tibt)
+- `signDisplay` (auto always exceptZero never" default="auto")
+- `style` (decimal currency percent unit" default="decimal")
+- `unit` (anything not empty)
+- `unitDisplay` (long short narrow" default="short")
+- `minimumIntegerDigits`, (positive integer, default: `1`)
+- `minimumFractionDigits`, (positive integer)
+- `maximumFractionDigits`, (positive integer)
+- `minimumSignificantDigits`, (positive integer, default: `1`)
+- `maximumSignificantDigits`, (positive integer, default: `21`)
+
+### Dates and Times
+
+Function name: `:datetime`
+
+Operand: "iso8601"
+
+Options:
+- `dateStyle` (full long medium short)
+- `timeStyle` (full long medium short)
+- `calendar` (buddhist chinese coptic dangi ethioaa ethiopic gregory hebrew indian islamic islamic-umalqura 
+   islamic-tbla islamic-civil islamic-rgsa iso8601 japanese persian roc)
+- `numberingSystem` (arab arabext bali beng deva fullwide gujr guru hanidec khmr knda laoo latn 
+   limb mlym mong mymr orya tamldec telu thai tibt)
+- `timezone` (tzid)
+- `hourCycle` (h11 h12 h23 h24)
+- `weekday` (long short narrow)
+- `era` (long short narrow)
+- `year` (numeric, 2-digit)
+- `month` ("numeric 2-digit long short narrow)
+- `day` (numeric 2-digit)
+- `hour` (numeric 2-digit)
+- `minute` (numeric 2-digit)
+- `second` (numeric 2-digit)
+- `fractionalSecondDigits` (1, 2, 3)
+- `timeZoneName` (long short shortOffset longOffset shortGeneric longGeneric)
+
+### Strings
+
+Function name: `:string`
+
+Operand: any string
+
+Options:
+(none?)
+
+
+### Other
+
+
+## Compatibility Matrix
+
+| MF1      | Syntax               | MF2                                                          | Comment |
+|----------|----------------------|--------------------------------------------------------------|---------|
+| Number   | {num,number}         | {$num :number}                                               |         |
+| Integer  | {num,number,integer} | {$num :number maximumFractionDigits=0}  {$num :integer}      |         |
+| Percent  | {num,number,percent} |                                                              | missing |
+| Currency | {num,number,currency} | {$num :number currency=$code} {$num :currency}              |         |
+| Plural (selector)  | {num,plural, ...}    | .match {$num :number} {$num :plural}               |         |
+| Ordinal (selector) | {num,selectordinal, ...} | .match {$num :ordinal}                         |         |
+| Oridnal (format)   | {num,ordinal} | {$num :number type=ordinal} {$num :ordinal}               |         |
+| Date     | {date,date}          | {$date :datetime type=date}                                  |         |
+| Date     | {date,date,short}    | {$date :datetime dateStyle=short}                            | also medium,long,full |
+| Time     | {date,time}          | {$date :datetime type=time}                                  |         |
+| Date     | {date,time,short}    | {$date :datetime timeStyle=short}                            | also medium,long,full |
+| Datetime | (requires picture or skeleton) | {$date :datetime dateStyle=short timeStyle=short}  | also medium,long,full |
+| Datetime | {date,time,::skeleton} | {$date :datetime weekday=short etc.}                       | supported through options bag |
+| Spellout | {num,spellout}       |                                                              | missing |
+| Duration | {num,duration}       |                                                              | missing |
+| Choice   | {num,choice, ...}    |                                                              | deprecated in MF1 |

--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -33,8 +33,8 @@ Aliases:
 - `:integer` (implies: `maximumFractionDigits=0`)
 - `:currency` (implies: `style=currency`)
 - `:percent` (implies: `style=percent`)
-- `:plural` (selector only, implies CLDR rules)
-- `:ordinal` (missing formats, missing selector)
+- `:plural` (no format, implies `style=plural` which is default)
+- `:ordinal` (missing format, implies: `style=ordinal`)
 
 Operand: anyNumber
 
@@ -46,7 +46,8 @@ Options:
 - `notation` (`standard` `scientific` `engineering` `compact`; default: `standard`)
 - `numberingSystem` (arab arabext bali beng deva fullwide gujr guru hanidec khmr knda laoo latn 
    limb mlym mong mymr orya tamldec telu thai tibt)
-- `signDisplay` (auto always exceptZero never" default="auto")
+- `select` (`plural`, `ordinal`, `exact`; default: `plural`)
+- `signDisplay` (`auto` `always` `exceptZero` `never`; default="auto")
 - `style` (decimal currency percent unit" default="decimal")
 - `unit` (anything not empty)
 - `unitDisplay` (long short narrow" default="short")
@@ -56,6 +57,8 @@ Options:
 - `minimumSignificantDigits`, (positive integer, default: `1`)
 - `maximumSignificantDigits`, (positive integer, default: `21`)
 
+(When no default is given, the default depends on the locale or implementation)
+
 ### Dates and Times
 
 Function name: `:datetime`
@@ -63,24 +66,26 @@ Function name: `:datetime`
 Operand: "iso8601"
 
 Options:
-- `dateStyle` (full long medium short)
-- `timeStyle` (full long medium short)
+- `dateStyle` (`full` `long` `medium` `short`)
+- `timeStyle` (`full` `long` `medium` `short`)
 - `calendar` (buddhist chinese coptic dangi ethioaa ethiopic gregory hebrew indian islamic islamic-umalqura 
    islamic-tbla islamic-civil islamic-rgsa iso8601 japanese persian roc)
 - `numberingSystem` (arab arabext bali beng deva fullwide gujr guru hanidec khmr knda laoo latn 
    limb mlym mong mymr orya tamldec telu thai tibt)
 - `timezone` (tzid)
-- `hourCycle` (h11 h12 h23 h24)
-- `weekday` (long short narrow)
-- `era` (long short narrow)
-- `year` (numeric, 2-digit)
-- `month` (numeric 2-digit long short narrow)
-- `day` (numeric 2-digit)
-- `hour` (numeric 2-digit)
-- `minute` (numeric 2-digit)
-- `second` (numeric 2-digit)
-- `fractionalSecondDigits` (1, 2, 3)
-- `timeZoneName` (long short shortOffset longOffset shortGeneric longGeneric)
+- `hourCycle` (`h11` `h12` `h23` `h24`)
+- `weekday` (`long` `short` `narrow`)
+- `era` (`long` `short` `narrow`)
+- `year` (`numeric` `2-digit`)
+- `month` (`numeric` `2-digit` `long` `short` `narrow`)
+- `day` (`numeric` `2-digit`)
+- `hour` (`numeric` `2-digit`)
+- `minute` (`numeric` `2-digit`)
+- `second` (`numeric` `2-digit`)
+- `fractionalSecondDigits` (`1`, `2`, `3`)
+- `timeZoneName` (`long` `short` `shortOffset` `longOffset` `shortGeneric` `longGeneric`)
+
+(When no default is given, the default depends on the locale or implementation)
 
 ### Strings
 


### PR DESCRIPTION
Create a list of selectors and formatters required by the default registry as well as a matrix showing how MF1 and MF2 map functionality. 

This is an attempt to capture the current (and proposed) registry entries for the spring release. If we're missing something, it needs to get added.

🎵 _...he's making a list and checking it twice..._  🎵 