### PR TITLE
Re-add accidentally dropped message validity condition

### DIFF
--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -336,6 +336,8 @@ satisfied:
 
 - The number of _keys_ on each _variant_ MUST be equal to the number of _selectors_.
 - At least one _variant_ MUST exist whose _keys_ are all equal to the "catch-all" key `*`.
+- Each _selector_ MUST have an _annotation_,
+  or contain a _variable_ that directly or indirectly references a _declaration_ with an _annotation_.
 
 ```abnf
 matcher = match-statement 1*([s] variant)


### PR DESCRIPTION
As discovered in https://github.com/unicode-org/message-format-wg/pull/557#discussion_r1428727301, this was added in #431 but accidentally dropped in the #441 refactor. 