### PR TITLE
Remove mention of stability criteria

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -73,10 +73,6 @@ A reference to a _term_ looks like this.
 > [!IMPORTANT]
 > The provisions of the stability policy are not in effect until
 > the conclusion of the technical preview and adoption of this specification.
-> Implementers should expect that changes to the specification during
-> and following the preview period will be minimal and will require compelling evidence.
-> However, the technical committee reserves the right to make necessary
-> changes to the specification until it becomes stablized.
 
 Updates to this specification will not change
 the syntactical meaning, the runtime output, or other behaviour


### PR DESCRIPTION
@macchiati [suggested](https://github.com/unicode-org/message-format-wg/pull/571#issuecomment-1861926877) we remove the additional text beyond the non-operation of the stability policy.