### PR TITLE
Add markup as designed

### DIFF
--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -110,13 +110,16 @@ interface CatchallKey {
 ## Patterns
 
 Each `Pattern` represents a linear sequence, without selectors.
-Each element of the `body` array MUST either be a non-empty string or an `Expression` or `Markup` object.
-String values represent literal _text_,
-while `Expression` and `Markup` wrap each of the potential _expression_ and _markup_ shapes.
+Each element of the `body` array MUST be a non-empty string, an `Expression` or a `Markup` object.
+String values represent literal _text_.
+`Expression` wraps each of the potential _expression_ shapes.
+`Markup` wraps each of the potential _markup_ shapes.
 The `body` strings are the "cooked" _text_ values, i.e. escape sequences are processed.
 
-Implementations MUST NOT rely on the set of `Expression` and `Markup` interfaces being exhaustive,
-as future versions of this specification MAY define additional expressions.
+Implementations MUST NOT rely on the set of `Expression` and 
+`Markup` interfaces defined in this document being exhaustive.
+Future versions of this specification might define additional
+types of expression or markup.
 
 ```ts
 interface Pattern {
@@ -224,8 +227,9 @@ interface UnsupportedAnnotation {
 
 ## Markup
 
-Each of _markup-open_, _markup-close_, and _markup-standalone_ are represented
-by the corresponding `MarkupOpen`, `MarkupStandalone`, and `MarkupClose`.
+Each of the markup interfaces `MarkupOpen`, `MarkupStandalone`,
+and `MarkupClose` represent the _markup_ `type` of the corresponding
+`kind`.
 The `name` in these does not include the starting sigils `#` and `/`.
 The optional `options` for open and standalone markup use the same `Option`
 as `FunctionAnnotation`.

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -227,9 +227,8 @@ interface UnsupportedAnnotation {
 
 ## Markup
 
-Each of the markup interfaces `MarkupOpen`, `MarkupStandalone`,
-and `MarkupClose` represent the _markup_ `type` of the corresponding
-`kind`.
+A `Markup` object is either `MarkupOpen`, `MarkupStandalone`, or `MarkupClose`,
+which are differentiated by `kind`.
 The `name` in these does not include the starting sigils `#` and `/`.
 The optional `options` for open and standalone markup use the same `Option`
 as `FunctionAnnotation`.

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -110,38 +110,45 @@ interface CatchallKey {
 ## Patterns
 
 Each `Pattern` represents a linear sequence, without selectors.
-Each element of the `body` array MUST either be a non-empty string or an `Expression` object.
+Each element of the `body` array MUST either be a non-empty string or an `Expression` or `Markup` object.
 String values represent literal _text_,
-while `Expression` wraps each of the potential _expression_ shapes.
+while `Expression` and `Markup` wrap each of the potential _expression_ and _markup_ shapes.
 The `body` strings are the "cooked" _text_ values, i.e. escape sequences are processed.
 
-Implementations MUST NOT rely on the set of `Expression` interfaces being exhaustive,
+Implementations MUST NOT rely on the set of `Expression` and `Markup` interfaces being exhaustive,
 as future versions of this specification MAY define additional expressions.
 
 ```ts
 interface Pattern {
-  body: Array<string | Expression>;
+  body: Array<string | Expression | Markup>;
 }
 
-type Expression = LiteralExpression | VariableExpression | FunctionExpression |
-                  UnsupportedExpression;
+type Expression =
+  | LiteralExpression
+  | VariableExpression
+  | FunctionExpression
+  | UnsupportedExpression;
 
 interface LiteralExpression {
+  type: "expression";
   arg: Literal;
   annotation?: FunctionAnnotation | UnsupportedAnnotation;
 }
 
 interface VariableExpression {
+  type: "expression";
   arg: VariableRef;
   annotation?: FunctionAnnotation | UnsupportedAnnotation;
 }
 
 interface FunctionExpression {
+  type: "expression";
   arg?: never;
   annotation: FunctionAnnotation;
 }
 
 interface UnsupportedExpression {
+  type: "expression";
   arg?: never;
   annotation: UnsupportedAnnotation;
 }
@@ -172,17 +179,13 @@ interface VariableRef {
 ```
 
 A `FunctionAnnotation` represents a _function_ _annotation_.
-In a `FunctionAnnotation`,
-the `kind` corresponds to the starting sigil of a _function_:
-`'open'` for `+`, `'close'` for `-`, and `'value'` for `:`.
-The `name` does not include this starting sigil.
+The `name` does not include the `:` starting sigil.
 
 Each _option_ is represented by an `Option`.
 
 ```ts
 interface FunctionAnnotation {
   type: "function";
-  kind: "open" | "close" | "value";
   name: string;
   options?: Option[];
 }
@@ -214,8 +217,40 @@ that the implementation attaches to that _annotation_.
 ```ts
 interface UnsupportedAnnotation {
   type: "unsupported-annotation";
-  sigil: "!" | "@" | "#" | "%" | "^" | "&" | "*" | "<" | ">" | "/" | "?" | "~";
+  sigil: "!" | "@" | "%" | "^" | "&" | "*" | "+" | "<" | ">" | "?" | "~";
   source: string;
+}
+```
+
+## Markup
+
+Each of _markup-open_, _markup-close_, and _markup-standalone_ are represented
+by the corresponding `MarkupOpen`, `MarkupStandalone`, and `MarkupClose`.
+The `name` in these does not include the starting sigils `#` and `/`.
+The optional `options` for open and standalone markup use the same `Option`
+as `FunctionAnnotation`.
+
+```ts
+type Markup = MarkupOpen | MarkupStandalone | MarkupClose;
+
+interface MarkupOpen {
+  type: "markup";
+  kind: "open";
+  name: string;
+  options?: Option[];
+}
+
+interface MarkupStandalone {
+  type: "markup";
+  kind: "standalone";
+  name: string;
+  options?: Option[];
+}
+
+interface MarkupClose {
+  type: "markup";
+  kind: "close";
+  name: string;
 }
 ```
 

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -110,7 +110,7 @@ interface CatchallKey {
 ## Patterns
 
 Each `Pattern` represents a linear sequence, without selectors.
-Each element of the `body` array MUST be a non-empty string, an `Expression` or a `Markup` object.
+Each element of the `body` array MUST be a non-empty string, an `Expression`, or a `Markup` object.
 String values represent literal _text_.
 `Expression` wraps each of the potential _expression_ shapes.
 `Markup` wraps each of the potential _markup_ shapes.
@@ -119,7 +119,7 @@ The `body` strings are the "cooked" _text_ values, i.e. escape sequences are pro
 Implementations MUST NOT rely on the set of `Expression` and 
 `Markup` interfaces defined in this document being exhaustive.
 Future versions of this specification might define additional
-types of expression or markup.
+expressions or markup.
 
 ```ts
 interface Pattern {
@@ -229,7 +229,8 @@ interface UnsupportedAnnotation {
 
 A `Markup` object is either `MarkupOpen`, `MarkupStandalone`, or `MarkupClose`,
 which are differentiated by `kind`.
-The `name` in these does not include the starting sigils `#` and `/`.
+The `name` in these does not include the starting sigils `#` and `/` 
+or the ending sigil `/`.
 The optional `options` for open and standalone markup use the same `Option`
 as `FunctionAnnotation`.
 

--- a/spec/data-model/message.dtd
+++ b/spec/data-model/message.dtd
@@ -21,7 +21,7 @@
 <!ELEMENT key (#PCDATA)>
 <!ATTLIST key default (true | false) "false">
 
-<!ELEMENT pattern (#PCDATA | expression)*>
+<!ELEMENT pattern (#PCDATA | expression | markup)*>
 
 <!ELEMENT expression (
   ((literal | variable), (functionAnnotation | unsupportedAnnotation)?) |
@@ -35,12 +35,17 @@
 <!ATTLIST variable name NMTOKEN #REQUIRED>
 
 <!ELEMENT functionAnnotation (option)*>
-<!ATTLIST functionAnnotation
-  kind (open | close | value) #REQUIRED
-  name NMTOKEN #REQUIRED
->
+<!ATTLIST functionAnnotation name NMTOKEN #REQUIRED>
+
 <!ELEMENT option (literal | variable)>
 <!ATTLIST option name NMTOKEN #REQUIRED>
 
 <!ELEMENT unsupportedAnnotation (#PCDATA)>
 <!ATTLIST unsupportedAnnotation sigil CDATA #REQUIRED>
+
+<!-- A <markup kind="close"> MUST NOT contain any <option> elements -->
+<!ELEMENT markup (option)*>
+<!ATTLIST markup
+  kind (open | standalone | close) #REQUIRED
+  name NMTOKEN #REQUIRED
+>

--- a/spec/data-model/message.json
+++ b/spec/data-model/message.json
@@ -113,7 +113,17 @@
       "type": "object",
       "properties": {
         "type": { "const": "markup" },
-        "kind": { "enum": ["open", "standalone"] },
+        "kind": { "const": "open" },
+        "name": { "type": "string" },
+        "options": { "$ref": "#/$defs/options" }
+      },
+      "required": ["type", "kind", "name"]
+    },
+    "markup-standalone": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "markup" },
+        "kind": { "const": "standalone" },
         "name": { "type": "string" },
         "options": { "$ref": "#/$defs/options" }
       },
@@ -131,6 +141,7 @@
     "markup": {
       "oneOf": [
         { "$ref": "#/$defs/markup-open" },
+        { "$ref": "#/$defs/markup-standalone" },
         { "$ref": "#/$defs/markup-close" }
       ]
     },

--- a/spec/data-model/message.json
+++ b/spec/data-model/message.json
@@ -22,27 +22,29 @@
       },
       "required": ["type", "name"]
     },
-    "option": {
-      "type": "object",
-      "properties": {
-        "name": { "type": "string" },
-        "value": {
-          "oneOf": [{ "$ref": "#/$defs/literal" }, { "$ref": "#/$defs/variable" }]
-        }
-      },
-      "required": ["name", "value"]
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "value": {
+            "oneOf": [
+              { "$ref": "#/$defs/literal" },
+              { "$ref": "#/$defs/variable" }
+            ]
+          }
+        },
+        "required": ["name", "value"]
+      }
     },
 
     "function-annotation": {
       "type": "object",
       "properties": {
         "type": { "const": "function" },
-        "kind": { "enum": ["open", "close", "value"] },
         "name": { "type": "string" },
-        "options": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/option" }
-        }
+        "options": { "$ref": "#/$defs/options" }
       },
       "required": ["type", "kind", "name"]
     },
@@ -67,32 +69,36 @@
     "literal-expression": {
       "type": "object",
       "properties": {
+        "type": { "const": "expression" },
         "arg": { "$ref": "#/$defs/literal" },
         "annotation": { "$ref": "#/$defs/annotation" }
       },
-      "required": ["arg"]
+      "required": ["type", "arg"]
     },
     "variable-expression": {
       "type": "object",
       "properties": {
+        "type": { "const": "expression" },
         "arg": { "$ref": "#/$defs/variable" },
         "annotation": { "$ref": "#/$defs/annotation" }
       },
-      "required": ["arg"]
+      "required": ["type", "arg"]
     },
     "function-expression": {
       "type": "object",
       "properties": {
+        "type": { "const": "expression" },
         "annotation": { "$ref": "#/$defs/function-annotation" }
       },
-      "required": ["annotation"]
+      "required": ["type", "annotation"]
     },
     "unsupported-expression": {
       "type": "object",
       "properties": {
+        "type": { "const": "expression" },
         "annotation": { "$ref": "#/$defs/unsupported-annotation" }
       },
-      "required": ["annotation"]
+      "required": ["type", "annotation"]
     },
     "expression": {
       "oneOf": [
@@ -103,13 +109,43 @@
       ]
     },
 
+    "markup-open": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "markup" },
+        "kind": { "enum": ["open", "standalone"] },
+        "name": { "type": "string" },
+        "options": { "$ref": "#/$defs/options" }
+      },
+      "required": ["type", "kind", "name"]
+    },
+    "markup-close": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "markup" },
+        "kind": { "const": "close" },
+        "name": { "type": "string" }
+      },
+      "required": ["type", "kind", "name"]
+    },
+    "markup": {
+      "oneOf": [
+        { "$ref": "#/$defs/markup-open" },
+        { "$ref": "#/$defs/markup-close" }
+      ]
+    },
+
     "pattern": {
       "type": "object",
       "properties": {
         "body": {
           "type": "array",
           "items": {
-            "oneOf": [{ "type": "string" }, { "$ref": "#/$defs/expression" }]
+            "oneOf": [
+              { "type": "string" },
+              { "$ref": "#/$defs/expression" },
+              { "$ref": "#/$defs/markup" }
+            ]
           }
         }
       },

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -264,7 +264,7 @@ Unlike _functions_, the resolution of _markup_ is not customizable.
 The resolved value of _markup_ includes the following fields:
 
 - The type of the markup: open, standalone, or close
-- The _name_ of the _markup_
+- The _identifier_ of the _markup_
 - For _markup-open_ and _markup_standalone_,
   the resolved _options_ values after _option resolution_.
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -99,7 +99,7 @@ but also the _variable_ to which the resolved value of the _variable-expression_
 
 In _selectors_, the resolved value of an _expression_ is used for _pattern selection_.
 
-In a _pattern_, the resolved value of _expressions_ and _markup_ is used in their _formatting_.
+In a _pattern_, the resolved value of an _expression_ or _markup_ is used in its _formatting_.
 
 The shapes of resolved values are implementation-dependent,
 and different implementations MAY choose to perform different levels of resolution.

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -3,7 +3,7 @@ message = simple-message / complex-message
 simple-message = [simple-start pattern]
 simple-start = simple-start-char / text-escape / placeholder
 pattern = *(text-char / text-escape / placeholder)
-placeholder = expression
+placeholder = expression / markup
 
 complex-message = *(declaration [s]) complex-body
 declaration = input-declaration / local-declaration / reserved-statement
@@ -23,13 +23,18 @@ expression = literal-expression / variable-expression / annotation-expression
 literal-expression = "{" [s] literal [s annotation] [s] "}"
 variable-expression = "{" [s] variable [s annotation] [s] "}"
 annotation-expression = "{" [s] annotation [s] "}"
-annotation = (function *(s option))
+annotation = function
            / private-use-annotation
            / reserved-annotation
 
+markup       = "{" [s] markup-open [s] ["/"] "}"
+             / "{" [s] markup-close [s] "}"
+markup-open  = "#" identifier *(s option)
+markup-close = "/" identifier
+
 literal = quoted / unquoted
 variable = "$" name
-function = (":" / "+" / "-") identifier
+function = ":" identifier *(s option)
 option = identifier [s] "=" [s] (literal / variable)
 
 input = %s".input"
@@ -65,8 +70,8 @@ reserved-keyword = "." name
 
 ; Reserve additional sigils for use by future versions of this specification.
 reserved-annotation = reserved-annotation-start reserved-body
-reserved-annotation-start = "!" / "@" / "#" / "%" / "*"
-                          / "<" / ">" / "/" / "?" / "~"
+reserved-annotation-start = "!" / "@" / "%" / "*" / "+"
+                          / "<" / ">" / "?" / "~"
 
 reserved-body  = *([s] 1*(reserved-char / reserved-escape / quoted))
 reserved-char  = %x00-08        ; omit HTAB and LF

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -685,11 +685,11 @@ markup-close = "/" identifier
 > {#button}Submit{/button} or {#img alt=|Cancel| /}.}
 > ```
 
-_Markup-open_ and _markup-close_ parts MAY be paired,
-but this is not a requirement.
-A _markup-open_ MAY be present in a message without
-a corresponding _markup-close_, and vice versa.
-_Markup-standalone_ parts are not paired.
+A _markup-open_ can appear without a corresponding _markup-close_.
+A _markup-close_ can appear without a corresponding _markup-open_.
+_Markup_ _placeholders_ can appear in any order without making the _message_ invalid.
+However, specifications or implementations defining _markup_ might impose requirements
+on the pairing, ordering, or contents of _markup_ during _formatting_.
 
 ## Other Syntax Elements
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -311,11 +311,11 @@ Otherwise, care must be taken to ensure that pattern-significant whitespace is p
 
 ### Placeholder
 
-A **_<dfn>placeholder</dfn>_** is an _expression_ that appears inside of a _pattern_
+A **_<dfn>placeholder</dfn>_** is an _expression_ or _markup_ that appears inside of a _pattern_
 and which will be replaced during the formatting of a _message_.
 
 ```abnf
-placeholder = expression
+placeholder = expression / markup
 ```
 
 ## Matcher
@@ -448,7 +448,7 @@ All _expressions_ share a common syntax. The types of _expression_ are:
 
 1. The value of a _local-declaration_
 2. A _selector_
-3. A _placeholder_ in a _pattern_
+3. A kind of _placeholder_ in a _pattern_
 
 Additionally, an _input-declaration_ can contain a _variable-expression_.
 
@@ -483,7 +483,7 @@ a _function_ together with its associated _options_, or
 a _private-use annotation_ or a _reserved annotation_.
 
 ```abnf
-annotation = (function *(s option))
+annotation = function
            / private-use-annotation
            / reserved-annotation
 ```
@@ -509,37 +509,19 @@ what _options_ and _option_ values are valid,
 and what outputs might result.
 See [function registry](./) for more information.
 
-_Functions_ can be _standalone_, or can be an _opening element_ or _closing element_.
-
-A **_<dfn>standalone</dfn>_** _function_ is not expected to be paired with another _function_.
-An **_<dfn>opening element</dfn>_** is a _function_ that SHOULD be paired with a _closing element_.
-A **_<dfn>closing element</dfn>_** is a _function_ that SHOULD be paired with an _opening element_.
-
-An _opening element_ MAY be present in a message without a corresponding _closing element_,
-and vice versa.
-
-> A _message_ with a _standalone_ _function_ operating on the _variable_ `$now`:
->
-> ```
-> {$now :datetime}
-> ```
->
-> A _message_ with two markup-like _functions_, `button` and `link`,
-> which the runtime can use to construct a document tree structure for a UI framework:
->
-> ```
-> {+button}Submit{-button} or {+link}cancel{-link}.
-> ```
-
-A _function_ consists of a prefix sigil followed by an _identifier_.
-The following sigils are used for _functions_:
-
-- `:` for a _standalone_ function
-- `+` for an _opening element_
-- `-` for a _closing element_
-
-A _function_ MAY be followed by one or more _options_.
+A _function_ starts with a prefix sigil `:` followed by an _identifier_.
+The _name_ MAY be followed by one or more _options_.
 _Options_ are not required.
+
+```abnf
+function = ":" identifier *(s option)
+```
+
+> A _message_ with a _function_ operating on the _variable_ `$now`:
+>
+> ```
+> It is now {$now :datetime}
+> ```
 
 ##### Options
 
@@ -656,8 +638,8 @@ unrecognized _reserved-annotations_ or _private-use-annotations_ have no meaning
 
 ```abnf
 reserved-annotation = reserved-annotation-start reserved-body
-reserved-annotation-start = "!" / "@" / "#" / "%" / "*"
-                          / "<" / ">" / "/" / "?" / "~"
+reserved-annotation-start = "!" / "@" / "%" / "*" / "+"
+                          / "<" / ">" / "?" / "~"
 
 reserved-body = *([s] 1*(reserved-char / reserved-escape / quoted))
 reserved-char = %x00-08        ; omit HTAB and LF
@@ -668,6 +650,45 @@ reserved-char = %x00-08        ; omit HTAB and LF
               / %x7E-D7FF      ; omit surrogates
               / %xE000-10FFFF
 ```
+
+## Markup
+
+**_<dfn>Markup</dfn>_** _placeholders_ are _pattern_ parts
+that can be used to represent non-language parts of a _message_,
+such as inline elements or styling that should apply to a span of parts.
+Markup comes in three forms:
+
+**_<dfn>Markup-open</dfn>_** starts with `#` and
+is a _pattern_ part starting a span.
+It MAY include _options_, but these are not required.
+
+If a _markup-open_ includes a `/` immediately before its closing `}`,
+it is a self-closing **_<dfn>markup-standalone</dfn>_** part
+representing a standalone element within a message,
+such as an inline image or any other opaque content.
+
+**_<dfn>Markup-close</dfn>_** starts with `/` and
+is a _pattern_ part ending a span.
+Unlike the other forms, it does not include _options_.
+
+```abnf
+markup       = "{" [s] markup-open [s] ["/"] "}"
+             / "{" [s] markup-close [s] "}"
+markup-open  = "#" identifier *(s option)
+markup-close = "/" identifier
+```
+
+> A _message_ with one `button` markup span and a standalone `img` markup element.
+>
+> ```
+> {#button}Submit{/button} or {#img alt=|Cancel| /}.}
+> ```
+
+_Markup-open_ and _markup-close_ parts SHOULD be paired,
+but this is not a requirement.
+A _markup-open_ MAY be present in a message without
+a corresponding _markup-close_, and vice versa.
+_Markup-standalone_ parts are not paired.
 
 ## Other Syntax Elements
 
@@ -732,14 +753,15 @@ number-literal = ["-"] (0 / ([1-9] *DIGIT)) ["." 1*DIGIT] [%i"e" ["-" / "+"] 1*D
 ### Names and Identifiers
 
 An **_<dfn>identifier</dfn>_** is a character sequence that
-identifies a _function_ or _option_.
+identifies a _function_, _markup_, or _option_.
 Each _identifier_ consists of a _name_ optionally preceeded by
 a _namespace_. 
 When present, the _namespace_ is separated from the _name_ by a
 U+003A COLON `:`.
 Built-in _functions_ and their _options_ do not have a _namespace_ identifier.
 
-_Function_ _identifiers_ are prefixed with `:`, `+`, or `-`.
+_Function_ _identifiers_ are prefixed with `:`.
+_Markup_ _identifiers_ are prefixed with `#` or `/`.
 _Option_ _identifiers_ have no prefix.
 
 A **_<dfn>name</dfn>_** is a character sequence used in an _identifier_ 
@@ -747,7 +769,6 @@ or as the name for a _variable_
 or the value of an _unquoted_ _literal_.
 
 _Variable_ names are prefixed with `$`.
-_Function_ names are prefixed with `:`, `+` or `-`.
 
 Valid content for _names_ is based on <cite>Namespaces in XML 1.0</cite>'s 
 [NCName](https://www.w3.org/TR/xml-names/#NT-NCName).
@@ -783,7 +804,6 @@ in this release.
 
 ```abnf
 variable = "$" name
-function = (":" / "+" / "-") identifier
 option = identifier [s] "=" [s] (literal / variable)
 
 identifier = [namespace ":"] name

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -510,7 +510,7 @@ and what outputs might result.
 See [function registry](./) for more information.
 
 A _function_ starts with a prefix sigil `:` followed by an _identifier_.
-The _name_ MAY be followed by one or more _options_.
+The _identifier_ MAY be followed by one or more _options_.
 _Options_ are not required.
 
 ```abnf

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -658,16 +658,17 @@ that can be used to represent non-language parts of a _message_,
 such as inline elements or styling that should apply to a span of parts.
 Markup comes in three forms:
 
-**_<dfn>Markup-open</dfn>_** starts with `#` and
-is a _pattern_ part starting a span.
-It MAY include _options_, but these are not required.
+**_<dfn>Markup-open</dfn>_** starts with U+0023 NUMBER SIGN `#` and
+represents an opening element within the _message_,
+such as markup used to start a span.
+It MAY include _options_.
 
-If a _markup-open_ includes a `/` immediately before its closing `}`,
-it is a self-closing **_<dfn>markup-standalone</dfn>_** part
-representing a standalone element within a message,
-such as an inline image or any other opaque content.
+**_<dfn>Markup-standalone</dfn>_** starts with U+0023 NUMBER SIGN `#`
+and has a U+002F SOLIDUS `/` immediately before its closing `}`
+representing a self-closing or standalone element within the _message_.
+It MAY include _options_.
 
-**_<dfn>Markup-close</dfn>_** starts with `/` and
+**_<dfn>Markup-close</dfn>_** starts with U+002F SOLIDUS `/` and
 is a _pattern_ part ending a span.
 Unlike the other forms, it does not include _options_.
 
@@ -684,7 +685,7 @@ markup-close = "/" identifier
 > {#button}Submit{/button} or {#img alt=|Cancel| /}.}
 > ```
 
-_Markup-open_ and _markup-close_ parts SHOULD be paired,
+_Markup-open_ and _markup-close_ parts MAY be paired,
 but this is not a requirement.
 A _markup-open_ MAY be present in a message without
 a corresponding _markup-close_, and vice versa.


### PR DESCRIPTION
This implements markup [as designed](https://github.com/unicode-org/message-format-wg/blob/main/exploration/open-close-placeholders.md), including syntax, data model, and formatting changes.

The open/close/value "kind" concept is removed from functions, which now only ever use `:` as a prefix. The `+` is added to `reserved-annotation-start`, but `-` is not.

Resolution and formatting to a string is defined for markup, but formatting to parts is not, given that we don't define parts.

Noting for @gibson042 in particular: In the data model, I did need to add a `type: "expression"` on the expressions, so that they could be differentiated from the `type: "markup"` elements that a pattern may now also hold.