### PR TITLE
Forbid {�} as a valid expression

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -91,9 +91,9 @@ name-start = ALPHA / "_"
            / %xC0-D6 / %xD8-F6 / %xF8-2FF
            / %x370-37D / %x37F-1FFF / %x200C-200D
            / %x2070-218F / %x2C00-2FEF / %x3001-D7FF
-           / %xF900-FDCF / %xFDF0-FFFD / %x10000-EFFFF
+           / %xF900-FDCF / %xFDF0-FFFC / %x10000-EFFFF
 name-char  = name-start / DIGIT / "-" / "."
-           / %xB7 / %x300-36F / %x203F-2040
+           / %xB7 / %x300-36F / %x203F-2040 / %xFFFD
 
 text-escape     = backslash ( backslash / "{" / "}" )
 quoted-escape   = backslash ( backslash / "|" )

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -93,7 +93,7 @@ name-start = ALPHA / "_"
            / %x2070-218F / %x2C00-2FEF / %x3001-D7FF
            / %xF900-FDCF / %xFDF0-FFFC / %x10000-EFFFF
 name-char  = name-start / DIGIT / "-" / "."
-           / %xB7 / %x300-36F / %x203F-2040 / %xFFFD
+           / %xB7 / %x300-36F / %x203F-2040
 
 text-escape     = backslash ( backslash / "{" / "}" )
 quoted-escape   = backslash ( backslash / "|" )

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -793,9 +793,9 @@ name-start = ALPHA / "_"
            / %xC0-D6 / %xD8-F6 / %xF8-2FF
            / %x370-37D / %x37F-1FFF / %x200C-200D
            / %x2070-218F / %x2C00-2FEF / %x3001-D7FF
-           / %xF900-FDCF / %xFDF0-FFFD / %x10000-EFFFF
-name-char  = name-start / DIGIT / "-" / "." / ":"
-           / %xB7 / %x300-36F / %x203F-2040
+           / %xF900-FDCF / %xFDF0-FFFC / %x10000-EFFFF
+name-char  = name-start / DIGIT / "-" / "."
+           / %xB7 / %x300-36F / %x203F-2040 / %xFFFD
 ```
 
 ### Escape Sequences

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -795,7 +795,7 @@ name-start = ALPHA / "_"
            / %x2070-218F / %x2C00-2FEF / %x3001-D7FF
            / %xF900-FDCF / %xFDF0-FFFC / %x10000-EFFFF
 name-char  = name-start / DIGIT / "-" / "."
-           / %xB7 / %x300-36F / %x203F-2040 / %xFFFD
+           / %xB7 / %x300-36F / %x203F-2040
 ```
 
 ### Escape Sequences


### PR DESCRIPTION
Implementation feedback from working on updates to the JS `messageformat` library:

At the moment, the `name` rule includes U+FFFD as a valid `name-start` character. This means that `{�}` is a valid unquoted literal.

This is a potential footgun for implementations that choose to extend our "always emit something, report errors via side channel" formatting behaviour also to their stringification API. If such a stringifier is asked to stringify a data model with unsupported contents, `�` is an obvious character to use in the output, especially given how we're already using it. Currently, however, this would mean that the broken output of the stringifier would parse as valid MF2 syntax.

There is no good reason why `�` should be supported as a `name`, and broken output should not appear valid.