### PR TITLE
Clarify that Duplicate Option Name is a data model error

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -214,8 +214,6 @@ the following steps are taken:
    If _options_ is missing, the mapping will be empty.
    For each _option_:
    - Resolve the _identifier_ of the _option_.
-   - If the _option_'s _identifier_ already exists in the resolved mapping of _options_,
-     emit a Duplicate Option Name error.
    - If the _option_'s right-hand side successfully resolves to a value,
      bind the _identifier_ of the _option_ to the resolved value in the mapping.
    - Otherwise, bind the _identifier_ of the _option_ to an unresolved value in the mapping.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -89,7 +89,8 @@ Attempting to parse a _message_ that is not _well-formed_ will result in a _Synt
 
 A _message_ is **_<dfn>valid</dfn>_** if it is _well-formed_ and
 **also** meets the additional content restrictions
-and semantic requirements about its structure defined below.
+and semantic requirements about its structure defined below for
+_declarations_, _matcher_ and _options_.
 Attempting to parse a _message_ that is not _valid_ will result in a _Data Model Error_.
 
 ## The Message
@@ -553,6 +554,9 @@ The value of an _option_ can be either a _literal_ or a _variable_.
 
 Multiple _options_ are permitted in an _annotation_.
 Each _option_ is separated by whitespace.
+
+The _option_ _identifiers_ MUST be unique within each _expression_.
+Otherwise, the _message_ is not considered _valid_.
 
 ```abnf
 option = identifier [s] "=" [s] (literal / variable)

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -553,7 +553,7 @@ optional whitespace.
 The value of an _option_ can be either a _literal_ or a _variable_.
 
 Multiple _options_ are permitted in an _annotation_.
-_Options_ are separated from other parts of the _annotation_
+_Options_ are separated from the preceding _function_ _identifier_
 and from each other by whitespace.
 Each _option_'s _identifier_ MUST be unique within the _annotation_: 
 an _annotation_ with duplicate _option_ _identifiers_ is not valid.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -553,10 +553,10 @@ optional whitespace.
 The value of an _option_ can be either a _literal_ or a _variable_.
 
 Multiple _options_ are permitted in an _annotation_.
-Each _option_ is separated by whitespace.
-
-The _option_ _identifiers_ MUST be unique within each _expression_.
-Otherwise, the _message_ is not considered _valid_.
+_Options_ are separated from other parts of the _annotation_
+and from each other by whitespace.
+Each _option_'s _identifier_ MUST be unique within the _annotation_: 
+an _annotation_ with duplicate _option_ _identifiers_ is not valid.
 
 ```abnf
 option = identifier [s] "=" [s] (literal / variable)


### PR DESCRIPTION
I noticed during implementation that even though we define Duplicate Option Name as a data model error, we handle it as a formatting error. This should be clarified.