### PR TITLE
Allow options on closing markup placeholders

### DIFF
--- a/exploration/open-close-placeholders.md
+++ b/exploration/open-close-placeholders.md
@@ -151,9 +151,6 @@ in pairs: `Click {#a id=a1}here{/a ref=a1} to {#a id=a2}continue{/a ref=a2}`.
 > Many markup systems do not use or permit options on close values.
 such as `Click <a title="Link tooltip">here</a> to continue`.
 
-Open, close and standalone markup may have non-localisable options,
-such as `Click {#a id=a1}here{/a ref=a1} to {#a id=a2}continue{/a ref=a2}`.
-
 As with function options,
 markup options should be defined in a registry so that they can be validated.
 

--- a/exploration/open-close-placeholders.md
+++ b/exploration/open-close-placeholders.md
@@ -101,6 +101,8 @@ _What context is helpful to understand this proposal?_
 
 - As a CAT tool, I want to use the concepts of open, close, and standalone that I am already familiar with, to provide certain functionalities above.
 
+- As a CAT tool, I want to pair open and close markup even when there are multiple elements of the same type and even when they overlap each other.
+
 - As a developer, I want to connect message markup with existing element instances in the UI.
 
 - As a developer, I want to sanitize translations without removing the markup important to the message.
@@ -135,8 +137,11 @@ a non-empty sequence of pattern parts (text, placeholders).
 Markup spans may be nested,
 as in `<b>Bold and <i>also italic</i></b>`.
 
-Markup may have localisable options,
+Open and standalone markup may have localisable options,
 such as `Click <a title="Link tooltip">here</a> to continue`.
+
+Open, close and standalone markup may have non-localisable options,
+such as `Click {#a id=a1}here{/a ref=a1} to {#a id=a2}continue{/a ref=a2}`.
 
 As with function options,
 markup options should be defined in a registry so that they can be validated.
@@ -173,7 +178,7 @@ placeholder = expression / markup
 markup       = "{" [s] markup-open [s] ["/"] "}"
              / "{" [s] markup-close [s] "}"
 markup-open  = "#" name *(s option)
-markup-close = "/" name
+markup-close = "/" name *(s option)
 ```
 
 This is similar to [Mustache](http://mustache.github.io/mustache.5.html)'s control flow syntax.

--- a/exploration/open-close-placeholders.md
+++ b/exploration/open-close-placeholders.md
@@ -137,7 +137,18 @@ a non-empty sequence of pattern parts (text, placeholders).
 Markup spans may be nested,
 as in `<b>Bold and <i>also italic</i></b>`.
 
-Open and standalone markup may have localisable options,
+Markup placeholders can contain options.
+
+Some option values might require translation themselves. 
+For example, `Click <a title="Link tooltip">here</a> to continue.`
+
+The meaning of markup options is externally defined.
+Some uses might require specific values
+such as when used by tools to associate markup values
+in pairs: `Click {#a id=a1}here{/a ref=a1} to {#a id=a2}continue{/a ref=a2}`.
+
+> [!NOTE]
+> Many markup systems do not use or permit options on close values.
 such as `Click <a title="Link tooltip">here</a> to continue`.
 
 Open, close and standalone markup may have non-localisable options,


### PR DESCRIPTION
As a follow-up to https://github.com/unicode-org/message-format-wg/pull/541#pullrequestreview-1787622004, we'd like to allow options on "close" markup placeholders.

The main use-case is tooling and XLIFF interchange. See also #450 which proposes a different mechanism for this (but hasn't yet been accepted).