### PR TITLE
Flatten JSON & TS data model Pattern element

### DIFF
--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -109,11 +109,14 @@ interface CatchallKey {
 
 ## Patterns
 
-Each `Pattern` represents a linear sequence, without selectors.
+Each `Pattern` is a standalone linear sequence of text and placeholders
+that represents the output of a message.
+
 Each element of the `Pattern` MUST either be a non-empty string or an `Expression` object.
-String values represent literal _text_,
-while `Expression` wraps each of the potential _expression_ shapes.
-The `Pattern` strings are the "cooked" _text_ values, i.e. escape sequences are processed.
+String values represent literal _text_.
+String values include all processing of the underlying _text_ values,
+including escape sequence processing.
+`Expression` values wrap each of the _expression_ shapes.
 
 Implementations MUST NOT rely on the set of `Expression` interfaces being exhaustive,
 as future versions of this specification MAY define additional expressions.

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -110,18 +110,16 @@ interface CatchallKey {
 ## Patterns
 
 Each `Pattern` represents a linear sequence, without selectors.
-Each element of the `body` array MUST either be a non-empty string or an `Expression` object.
+Each element of the `Pattern` MUST either be a non-empty string or an `Expression` object.
 String values represent literal _text_,
 while `Expression` wraps each of the potential _expression_ shapes.
-The `body` strings are the "cooked" _text_ values, i.e. escape sequences are processed.
+The `Pattern` strings are the "cooked" _text_ values, i.e. escape sequences are processed.
 
 Implementations MUST NOT rely on the set of `Expression` interfaces being exhaustive,
 as future versions of this specification MAY define additional expressions.
 
 ```ts
-interface Pattern {
-  body: Array<string | Expression>;
-}
+type Pattern = Array<string | Expression>;
 
 type Expression = LiteralExpression | VariableExpression | FunctionExpression |
                   UnsupportedExpression;

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -109,8 +109,7 @@ interface CatchallKey {
 
 ## Patterns
 
-Each `Pattern` is a standalone linear sequence of text and placeholders
-that represents the output of a message.
+Each `Pattern` contains a linear sequence of text and placeholders corresponding to potential output of a message.
 
 Each element of the `Pattern` MUST either be a non-empty string or an `Expression` object.
 String values represent literal _text_.

--- a/spec/data-model/message.json
+++ b/spec/data-model/message.json
@@ -27,7 +27,10 @@
       "properties": {
         "name": { "type": "string" },
         "value": {
-          "oneOf": [{ "$ref": "#/$defs/literal" }, { "$ref": "#/$defs/variable" }]
+          "oneOf": [
+            { "$ref": "#/$defs/literal" },
+            { "$ref": "#/$defs/variable" }
+          ]
         }
       },
       "required": ["name", "value"]
@@ -104,16 +107,10 @@
     },
 
     "pattern": {
-      "type": "object",
-      "properties": {
-        "body": {
-          "type": "array",
-          "items": {
-            "oneOf": [{ "type": "string" }, { "$ref": "#/$defs/expression" }]
-          }
-        }
-      },
-      "required": ["body"]
+      "type": "array",
+      "items": {
+        "oneOf": [{ "type": "string" }, { "$ref": "#/$defs/expression" }]
+      }
     },
 
     "input-declaration": {


### PR DESCRIPTION
Feedback from writing the JS implementation:

In the data model, the wrapping object in the `Pattern` which has a single `body` property is rather useless. We should flatten this to simplify the model a bit.

One reason why the wrapping object was included earlier was to enable an extension of the data model to function as a CST, but in practice I at least found that its requirements are sufficiently different for the CST to work better as a separately defined structure.

This PR overlaps a bit with #574; whichever lands second will need a small adjustment to deconflict the merge.