### PR TITLE
Add `:string` as formatter and selector

### DIFF
--- a/exploration/exact-match-selector-options.md
+++ b/exploration/exact-match-selector-options.md
@@ -1,6 +1,6 @@
 # Design Proposal Template
 
-Status: **Proposed**
+Status: **Acctepted**
 
 <details>
 	<summary>Metadata</summary>

--- a/exploration/exact-match-selector-options.md
+++ b/exploration/exact-match-selector-options.md
@@ -1,6 +1,6 @@
 # Design Proposal Template
 
-Status: **Acctepted**
+Status: **Accepted**
 
 <details>
 	<summary>Metadata</summary>

--- a/spec/registry.xml
+++ b/spec/registry.xml
@@ -253,7 +253,7 @@
 
   <function name="string">
     <description>
-      String formatting and selection
+      Formatting of strings as a literal and selection based on string equality
     </description>
 
     <formatSignature>

--- a/spec/registry.xml
+++ b/spec/registry.xml
@@ -6,6 +6,7 @@
   <validationRule id="positiveInteger" regex="0|([1-9]\d*)"/>
   <validationRule id="currencyCode" regex="[A-Z]{3}"/>
   <validationRule id="timeZoneId" regex="[a-zA-Z/]+"/>
+  <validationRule id="anything" regex=".*"/>
   <validationRule id="anythingNotEmpty" regex=".+"/>
   <validationRule id="iso8601" regex="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"/>
 
@@ -250,4 +251,18 @@
     </alias>
   </function>
 
+  <function name="string">
+    <description>
+      String formatting and selection
+    </description>
+
+    <formatSignature>
+      <input validationRule="anything" />
+    </formatSignature>
+
+    <matchSignature>
+      <input validationRule="anything" />
+      <match validationRule="anything" />
+    </matchSignature>
+  </function>
 </registry>


### PR DESCRIPTION
This implements the [proposed design](https://github.com/unicode-org/message-format-wg/blob/main/exploration/exact-match-selector-options.md#proposed-design), and marks the design as approved.