### PR TITLE
Add missing hourCycle to :datetime timeStyle/dateStyle <formatSignature>

### DIFF
--- a/spec/registry.xml
+++ b/spec/registry.xml
@@ -46,6 +46,11 @@
           such as "Asia/Shanghai", "Asia/Kolkata", "America/New_York".
         </description>
       </option>
+      <option name="hourCycle" values="h11 h12 h23 h24">
+        <description>
+          The hour cycle to use.
+        </description>
+      </option>
     </formatSignature>
 
     <!-- TODO: clarify if this is OK or if it is an abuse.


### PR DESCRIPTION
As discussed in https://github.com/unicode-org/message-format-wg/pull/570#discussion_r1452487765, the `hourCycle` option is also valid when using the `timeStyle` or `dateStyle` options of `:datetime`.

I suggest this is considered as an editorial change and fast-tracked.