### PR TITLE
Update default registry design doc to reflect LDML45 scope

### DIFF
--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -1,6 +1,6 @@
 # Default Registry and MF1 Compatibility
 
-Status: **Proposed**
+Status: **Accepted**
 
 <details>
 	<summary>Metadata</summary>
@@ -23,6 +23,12 @@ along with their _operands_ and _options_.
 It also contains a section comparing MF1 (as embodied by ICU4J) and MF2
 to ensure that we don't forget something.
 
+Implementations MAY provide other selectors or functions using the mechanisms defined by MF2
+but these will not be considered for the LDML45 default registry.
+The default registry is a foundational set of selectors and functions that an implementation
+claiming MF2 compatibility is required to supply.
+Therefore, addition to this list requires a higher level of rigor.
+
 ## Default Registry Entries
 
 ### Numbers
@@ -31,8 +37,6 @@ Function name: `:number`
 
 Aliases: 
 - `:integer` (implies: `maximumFractionDigits=0`)
-- `:currency` (implies: `style=currency`)
-- `:percent` (implies: `style=percent`)
 - `:plural` (no format, implies `select=plural` which is default)
 - `:ordinal` (implies: `select=ordinal`; we are missing `style=ordinal`)
 
@@ -64,7 +68,7 @@ Options:
 Function name: `:datetime`
 
 Aliases:
-- (none currently; should there be `:date` and `:time` aliases to shorthand getting particularly timeStyle?)
+- `:date` and `:time` have been proposed and will be considered for 45
 
 Operand: "iso8601"
 
@@ -103,6 +107,16 @@ Options:
 
 
 ### Other
+
+
+### Deliberately Excluded
+
+The following functionality was deliberately excluded:
+* Spellout
+* Duration
+* ChoiceFormat
+* Percent (as an alias of `:number`)
+* Currency (as an alias of `:number`)
 
 
 ## Compatibility Matrix

--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -68,7 +68,8 @@ Options:
 Function name: `:datetime`
 
 Aliases:
-- `:date` and `:time` have been proposed and will be considered for 45
+- `:date` (with `style=...` option corresponding to `:datetime dateStyle=...`)
+- `:time` (with `style=...` option corresponding to `:datetime timeStyle=...`)
 
 Operand: "iso8601"
 

--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -23,9 +23,9 @@ along with their _operands_ and _options_.
 It also contains a section comparing MF1 (as embodied by ICU4J) and MF2
 to ensure that we don't forget something.
 
-Implementations MAY provide other selectors or functions using the mechanisms defined by MF2
+Implementations MAY provide other selectors or formatters using the mechanisms defined by MF2
 but these will not be considered for the LDML45 default registry.
-The default registry is a foundational set of selectors and functions that an implementation
+The default registry is a foundational set of selectors and formatters that an implementation
 claiming MF2 compatibility is required to supply.
 Therefore, addition to this list requires a higher level of rigor.
 


### PR DESCRIPTION
In the 2024-01-15 call we agree that the functions listed in this document are the comprehensive set for the `LDML45` default registry. This updates our documentation to reflect that.

The list of options, operands, etc. remain open for discussion, but no other functions will be considered.