### PR TITLE
Correct bogus ABNF syntax matching literal numbers

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -49,7 +49,7 @@ literal        = quoted / unquoted
 quoted         = "|" *(quoted-char / quoted-escape) "|"
 unquoted       = name / number-literal
 ; number-literal matches JSON number (https://www.rfc-editor.org/rfc/rfc8259#section-6)
-number-literal = ["-"] (0 / ([1-9] *DIGIT)) ["." 1*DIGIT] [%i"e" ["-" / "+"] 1*DIGIT]
+number-literal = ["-"] (%x30 / (%x31-39 *DIGIT)) ["." 1*DIGIT] [%i"e" ["-" / "+"] 1*DIGIT]
 
 ; Keywords; Note that these are case-sensitive
 input = %s".input"


### PR DESCRIPTION
The `0` here was evidently meant to represent a literal character 0, but as I understand ABNF this would be interpreted as a counter modifier for a later item. It would be quoted as a string `"0"`, but the later range `[0-9]` is not quite so easy. To be a range one kind of needs to specify the actual character codes (as is done elsewhere in this very grammar). I encoded the zero as `%x30` and the range one-to-nine as `%x31-39` so all the literal digits are represented the same way.
