### PR TITLE
Make declarations array optional in data model

### DIFF
--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -34,13 +34,13 @@ type Message = PatternMessage | SelectMessage;
 
 interface PatternMessage {
   type: "message";
-  declarations: Declaration[];
+  declarations?: Declaration[];
   pattern: Pattern;
 }
 
 interface SelectMessage {
   type: "select";
-  declarations: Declaration[];
+  declarations?: Declaration[];
   selectors: Expression[];
   variants: Variant[];
 }

--- a/spec/data-model/message.json
+++ b/spec/data-model/message.json
@@ -242,7 +242,7 @@
         "declarations": { "$ref": "#/$defs/declarations" },
         "pattern": { "$ref": "#/$defs/pattern" }
       },
-      "required": ["type", "declarations", "pattern"]
+      "required": ["type", "pattern"]
     },
     "select": {
       "type": "object",
@@ -268,7 +268,7 @@
           }
         }
       },
-      "required": ["type", "declarations", "selectors", "variants"]
+      "required": ["type", "selectors", "variants"]
     }
   }
 }


### PR DESCRIPTION
Most messages are simple, and have no declarations. They should be optional in the data model, so that we don't need to include an empty `declarations: []` for every one of them.