### PR TITLE
Remove non-registry functions and options from examples

### DIFF
--- a/spec/errors.md
+++ b/spec/errors.md
@@ -256,16 +256,16 @@ An **_<dfn>Unsupported Statement</dfn>_** error occurs when a message includes a
 
 > For example, attempting to format either of the following messages
 > might result in a _Selection Error_ if done within a context that
-> uses a `:plural` selector function which requires its input to be numeric:
+> uses a `:number` selector function which requires its input to be numeric:
 >
 > ```
-> .match {|horse| :plural}
+> .match {|horse| :number}
 > 1 {{The value is one.}}
 > * {{The value is not one.}}
 > ```
 >
 > ```
-> .local $sel = {|horse| :plural}
+> .local $sel = {|horse| :number}
 > .match {$sel}
 > 1 {{The value is one.}}
 > * {{The value is not one.}}

--- a/spec/errors.md
+++ b/spec/errors.md
@@ -278,28 +278,29 @@ for example when encountering a value with an unsupported type
 or an internally inconsistent set of options.
 
 > For example, attempting to format any of the following messages
-> might result in a _Formatting Error_ because the `operand` type doesn't
-> match the expectations of the formatting function:
+> might result in a _Formatting Error_ if done within a context that
+>
+> 1. provides for the variable reference `$user` to resolve to
+>    an object `{ name: 'Kat', id: 1234 }`,
+> 2. provides for the variable reference `$field` to resolve to
+>    a string `'address'`, and
+> 3. uses a `:get` formatting function which requires its argument to be an object and
+>    an option `field` to be provided with a string value,
 >
 > ```
-> Hello, {horse :time} is not a date/time value!
+> Hello, {horse :get field=name}!
 > ```
-> Attempting to format a non-numeric string as a number:
+>
 > ```
-> .local $user = {|horse|}
-> {{Hello, {$user :number} is not a number!}}
+> Hello, {$user :get}!
 > ```
-> Attempting to format a number as a date:
+>
 > ```
-> .local $num = {$arg :number}
-> {{Hello, {$num :date}!}}
+> .local $id = {$user :get field=id}
+> {{Hello, {$id :get field=name}!}}
 > ```
-> Attempting to format year and month of a time value.
-> (This may not be an error on all implementations, as some may
-> convert `$time` to an incremental time value,
-> e.g. the year would be 1970 and the month January):
+>
 > ```
-> .local $time = {|20:13:27.333Z| :time}
-> {{Today is {$time :datetime year=numeric month=long}}}
+> Your {$field} is {$id :get field=$field}
 > ```
 

--- a/spec/errors.md
+++ b/spec/errors.md
@@ -282,7 +282,7 @@ or an internally inconsistent set of options.
 > match the expectations of the formatting function:
 >
 > ```
-> {{Hello, {horse :time} is not a date/time value!}}
+> Hello, {horse :time} is not a date/time value!
 > ```
 > Attempting to format a non-numeric string as a number:
 > ```

--- a/spec/errors.md
+++ b/spec/errors.md
@@ -136,19 +136,19 @@ so explicitly declaring it after such use is also an error.
 > Examples of invalid messages resulting in a _Duplicate Declaration_ error:
 >
 > ```
-> .input {$var :number maxFractionDigits=0}
-> .input {$var :number minFractionDigits=0}
+> .input {$var :number maximumFractionDigits=0}
+> .input {$var :number minimumFractionDigits=0}
 > {{Redeclaration of the same variable}}
 >
-> .local $var = {$ext :number maxFractionDigits=0}
-> .input {$var :number minFractionDigits=0}
+> .local $var = {$ext :number maximumFractionDigits=0}
+> .input {$var :number minimumFractionDigits=0}
 > {{Redeclaration of a local variable}}
 >
-> .input {$var :number minFractionDigits=0}
-> .local $var = {$ext :number maxFractionDigits=0}
+> .input {$var :number minimumFractionDigits=0}
+> .local $var = {$ext :number maximumFractionDigits=0}
 > {{Redeclaration of an input variable}}
 >
-> .input {$var :number minFractionDigits=$var2}
+> .input {$var :number minimumFractionDigits=$var2}
 > .input {$var2 :number}
 > {{Redeclaration of the implicit input variable $var2}}
 >
@@ -278,28 +278,28 @@ for example when encountering a value with an unsupported type
 or an internally inconsistent set of options.
 
 > For example, attempting to format any of the following messages
-> might result in a _Formatting Error_ if done within a context that
->
-> 1. provides for the variable reference `$user` to resolve to
->    an object `{ name: 'Kat', id: 1234 }`,
-> 2. provides for the variable reference `$field` to resolve to
->    a string `'address'`, and
-> 3. uses a `:get` formatting function which requires its argument to be an object and
->    an option `field` to be provided with a string value,
+> might result in a _Formatting Error_ because the `operand` type doesn't
+> match the expectations of the formatting function:
 >
 > ```
-> Hello, {horse :get field=name}!
+> {{Hello, {horse :time} is not a date/time value!}}
 > ```
->
+> Attempting to format a non-numeric string as a number:
 > ```
-> Hello, {$user :get}!
+> .local $user = {|horse|}
+> {{Hello, {$user :number} is not a number!}}
 > ```
->
+> Attempting to format a number as a date:
 > ```
-> .local $id = {$user :get field=id}
-> {{Hello, {$id :get field=name}!}}
+> .local $num = {$arg :number}
+> {{Hello, {$num :date}!}}
 > ```
->
+> Attempting to format year and month of a time value.
+> (This may not be an error on all implementations, as some may
+> convert `$time` to an incremental time value,
+> e.g. the year would be 1970 and the month January):
 > ```
-> Your {$field} is {$id :get field=$field}
+> .local $time = {|20:13:27.333Z| :time}
+> {{Today is {$time :datetime year=numeric month=long}}}
 > ```
+

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -584,8 +584,8 @@ foo bar {{Foo and bar}}
 
 A more-complex example is the matching found in selection APIs
 such as ICU's `PluralFormat`.
-Suppose that this API is represented here by the function `:plural`.
-This `:plural` function can match a given numeric value to a specific number _literal_
+Suppose that this API is represented here by the function `:number`.
+This `:number` function can match a given numeric value to a specific number _literal_
 and **_also_** to a plural category (`zero`, `one`, `two`, `few`, `many`, `other`)
 according to locale rules defined in CLDR.
 
@@ -594,7 +594,7 @@ and an `en` (English) locale,
 the pattern selection proceeds as follows for this message:
 
 ```
-.match {$count :plural}
+.match {$count :number}
 one {{Category match}}
 1   {{Exact match}}
 *   {{Other match}}

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -531,7 +531,7 @@ function = ":" identifier *(s option)
 > A _message_ with a _function_ operating on the _variable_ `$now`:
 >
 > ```
-> {{It is now {$now :datetime}.}}
+> It is now {$now :datetime}.
 > ```
 
 ##### Options

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -190,10 +190,10 @@ external input value does not appear in a previous _declaration_.
 > than one applied to the same _variable_ named in a _declaration_.
 > For example, this message is _valid_:
 > ```
-> .input {$var :number maxFractionDigits=0}
-> .match {$var :plural maxFractionDigits=2}
+> .input {$var :number maximumFractionDigits=0}
+> .match {$var :plural maximumFractionDigits=2}
 > 0 {{The selector can apply a different annotation to {$var} for the purposes of selection}}
-> * {{A placeholder in a pattern can apply a different annotation to {$var :number maxFractionDigits=3}}}
+> * {{A placeholder in a pattern can apply a different annotation to {$var :number maximumFractionDigits=3}}}
 > ```
 > (See the [Errors](./errors.md) section for examples of invalid messages)
 
@@ -354,8 +354,8 @@ match-statement = match 1*([s] selector)
 >
 > ```
 > .match {$count :number}
-> 1 {{You have one notification.}}
-> * {{You have {$count} notifications.}}
+> one {{You have {$count} notification.}}
+> *   {{You have {$count} notifications.}}
 > ```
 
 > A _message_ containing a _matcher_ formatted on a single line:
@@ -378,8 +378,9 @@ selector = expression
 There MUST be at least one _selector_ in a _matcher_.
 There MAY be any number of additional _selectors_.
 
-> A _message_ with a single _selector_ that uses a custom `:hasCase` _function_,
-> allowing the _message_ to choose a _pattern_ based on grammatical case:
+> A _message_ with a single _selector_ that uses a custom _function_
+> `:hasCase` which is a _selector_ that allows the _message_ to choose a _pattern_
+> based on grammatical case:
 >
 > ```
 > .match {$userName :hasCase}
@@ -391,13 +392,16 @@ There MAY be any number of additional _selectors_.
 > A message with two _selectors_:
 >
 > ```
-> .match {$photoCount :number} {$userGender :equals}
-> 1 masculine {{{$userName} added a new photo to his album.}}
-> 1 feminine  {{{$userName} added a new photo to her album.}}
-> 1 *         {{{$userName} added a new photo to their album.}}
-> * masculine {{{$userName} added {$photoCount} photos to his album.}}
-> * feminine  {{{$userName} added {$photoCount} photos to her album.}}
-> * *         {{{$userName} added {$photoCount} photos to their album.}}
+> .match {$numLikes :number} {$numShares :number}
+> 0   0   {{Your item has no likes and has not been shared.}}
+> 0   one {{Your item has no likes and has been shared {$numShares} time.}}
+> 0   *   {{Your item has no likes and has been shared {$numShares} times.}}
+> one 0   {{Your item has {$numLikes} like and has not been shared.}}
+> one one {{Your item has {$numLikes} like and has been shared {$numShares} time.}}
+> one *   {{Your item has {$numLikes} like and has been shared {$numShares} times.}}
+> *   0   {{Your item has {$numLikes} likes and has not been shared.}}
+> *   one {{Your item has {$numLikes} likes and has been shared {$numShares} time.}}
+> *   *   {{Your item has {$numLikes} likes and has been shared {$numShares} times.}}
 > ```
 
 ### Variant
@@ -527,7 +531,7 @@ function = ":" identifier *(s option)
 > A _message_ with a _function_ operating on the _variable_ `$now`:
 >
 > ```
-> It is now {$now :datetime}
+> {{It is now {$now :datetime}.}}
 > ```
 
 ##### Options
@@ -552,34 +556,18 @@ option = identifier [s] "=" [s] (literal / variable)
 
 > Examples of _functions_ with _options_
 >
-> A _message_ with a `$date` _variable_ formatted with the `:datetime` _function_:
+> A _message_ using the `:datetime` function.
+> The _option_ `weekday` has the literal `long` as its value:
 >
 > ```
-> Today is {$date :datetime weekday=long}.
+> {{Today is {$date :datetime weekday=long}!}}
 > ```
 
-> A _message_ with a `$userName` _variable_ formatted with
-> the custom `:person` _function_ capable of
-> declension (using either a fixed dictionary, algorithmic declension, ML, etc.):
+> A _message_ using the `:datetime` function.
+> The _option_ `weekday` has a variable `$dateStyle` as its value:
 >
 > ```
-> Hello, {$userName :person case=vocative}!
-> ```
-
-> A _message_ with a `$userObj` _variable_ formatted with
-> the custom `:person` _function_ capable of
-> plucking the first name from the object representing a person:
->
-> ```
-> Hello, {$userObj :person firstName=long}!
-> ```
-
-> A _message_ formatted with the custom _function_ `:list`
-> that has an option `maxEntries`
-> that has a _variable_ as its value:
->
-> ```
-> Hello, {$userList :list maxEntries=$maxEntries}!
+> {{Today is {$date :datetime weekday=$dateStyle}!}}
 > ```
 
 #### Private-Use Annotations
@@ -828,7 +816,7 @@ Examples:
 >```
 >This has a {$variable}
 >```
->A function:
+> A function:
 > ```
 > This has a {:function}
 > ```

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -560,14 +560,14 @@ option = identifier [s] "=" [s] (literal / variable)
 > The _option_ `weekday` has the literal `long` as its value:
 >
 > ```
-> {{Today is {$date :datetime weekday=long}!}}
+> Today is {$date :datetime weekday=long}!
 > ```
 
 > A _message_ using the `:datetime` function.
 > The _option_ `weekday` has a variable `$dateStyle` as its value:
 >
 > ```
-> {{Today is {$date :datetime weekday=$dateStyle}!}}
+> Today is {$date :datetime weekday=$dateStyle}!
 > ```
 
 #### Private-Use Annotations
@@ -814,7 +814,7 @@ Otherwise, the set of characters allowed in a _name_ is large.
 Examples:
 > A variable:
 >```
->This has a {$variable}
+> This has a {$variable}
 >```
 > A function:
 > ```

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -191,7 +191,7 @@ external input value does not appear in a previous _declaration_.
 > For example, this message is _valid_:
 > ```
 > .input {$var :number maximumFractionDigits=0}
-> .match {$var :plural maximumFractionDigits=2}
+> .match {$var :number maximumFractionDigits=2}
 > 0 {{The selector can apply a different annotation to {$var} for the purposes of selection}}
 > * {{A placeholder in a pattern can apply a different annotation to {$var :number maximumFractionDigits=3}}}
 > ```


### PR DESCRIPTION
Fixes #569 

Going through our specs to remove or repair examples so that they match the functions in the default registry.

Some generic examples are retained, e.g. `:func` in errors.md where we want to focus the example on syntax rather than the registry.

These changes are strictly editorial. Seeking fast-track for this.

--
Errors.md:

- fix `:number` options to be spelled out correctly
- fix formatting error examples to use real functions

--
Syntax.md:

- Replace multiple selectors example with two numbers. The previous example used a mythical custom function for gender. 
- If the text said it was a _message_, enclose the example in `{{ }}`
- Replace options examples to use `:datetime` options rather than the complicated custom function