### PR TITLE
Remove expression attributes from the data model

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -84,7 +84,7 @@ A reference to a _term_ looks like this.
 Updates to this specification will not change
 the syntactical meaning, the runtime output, or other behaviour
 of valid messages written for earlier versions of this specification
-that only use functions and expression attributes defined in this specification.
+that only use functions defined in this specification.
 Updates to this specification will not remove any syntax provided in this version.
 Future versions MAY add additional structure or meaning to existing syntax.
 

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -136,33 +136,24 @@ interface LiteralExpression {
   type: "expression";
   arg: Literal;
   annotation?: FunctionAnnotation | UnsupportedAnnotation;
-  attributes?: Attribute[];
 }
 
 interface VariableExpression {
   type: "expression";
   arg: VariableRef;
   annotation?: FunctionAnnotation | UnsupportedAnnotation;
-  attributes?: Attribute[];
 }
 
 interface FunctionExpression {
   type: "expression";
   arg?: never;
   annotation: FunctionAnnotation;
-  attributes?: Attribute[];
 }
 
 interface UnsupportedExpression {
   type: "expression";
   arg?: never;
   annotation: UnsupportedAnnotation;
-  attributes?: Attribute[];
-}
-
-interface Attribute {
-  name: string;
-  value?: Literal | VariableRef;
 }
 ```
 
@@ -251,7 +242,6 @@ interface MarkupOpen {
   kind: "open";
   name: string;
   options?: Option[];
-  attributes?: Attribute[];
 }
 
 interface MarkupStandalone {
@@ -259,14 +249,12 @@ interface MarkupStandalone {
   kind: "standalone";
   name: string;
   options?: Option[];
-  attributes?: Attribute[];
 }
 
 interface MarkupClose {
   type: "markup";
   kind: "close";
   name: string;
-  attributes?: Attribute[];
 }
 ```
 

--- a/spec/data-model/message.dtd
+++ b/spec/data-model/message.dtd
@@ -24,8 +24,8 @@
 <!ELEMENT pattern (#PCDATA | expression | markup)*>
 
 <!ELEMENT expression (
-  ((literal | variable), (functionAnnotation | unsupportedAnnotation)?, attribute*) |
-  ((functionAnnotation | unsupportedAnnotation), attribute*)
+  ((literal | variable), (functionAnnotation | unsupportedAnnotation)?) |
+  functionAnnotation | unsupportedAnnotation
 )>
 
 <!ELEMENT literal (#PCDATA)>
@@ -43,11 +43,8 @@
 <!ELEMENT unsupportedAnnotation (#PCDATA)>
 <!ATTLIST unsupportedAnnotation sigil CDATA #REQUIRED>
 
-<!ELEMENT attribute (literal | variable)?>
-<!ATTLIST attribute name NMTOKEN #REQUIRED>
-
 <!-- A <markup kind="close"> MUST NOT contain any <option> elements -->
-<!ELEMENT markup (option*, attribute*)>
+<!ELEMENT markup (option)*>
 <!ATTLIST markup
   kind (open | standalone | close) #REQUIRED
   name NMTOKEN #REQUIRED

--- a/spec/data-model/message.json
+++ b/spec/data-model/message.json
@@ -38,22 +38,6 @@
         "required": ["name", "value"]
       }
     },
-    "attributes": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": { "type": "string" },
-          "value": {
-            "oneOf": [
-              { "$ref": "#/$defs/literal" },
-              { "$ref": "#/$defs/variable" }
-            ]
-          }
-        },
-        "required": ["name"]
-      }
-    },
 
     "function-annotation": {
       "type": "object",
@@ -87,8 +71,7 @@
       "properties": {
         "type": { "const": "expression" },
         "arg": { "$ref": "#/$defs/literal" },
-        "annotation": { "$ref": "#/$defs/annotation" },
-        "attributes": { "$ref": "#/$defs/attributes" }
+        "annotation": { "$ref": "#/$defs/annotation" }
       },
       "required": ["type", "arg"]
     },
@@ -97,8 +80,7 @@
       "properties": {
         "type": { "const": "expression" },
         "arg": { "$ref": "#/$defs/variable" },
-        "annotation": { "$ref": "#/$defs/annotation" },
-        "attributes": { "$ref": "#/$defs/attributes" }
+        "annotation": { "$ref": "#/$defs/annotation" }
       },
       "required": ["type", "arg"]
     },
@@ -106,8 +88,7 @@
       "type": "object",
       "properties": {
         "type": { "const": "expression" },
-        "annotation": { "$ref": "#/$defs/function-annotation" },
-        "attributes": { "$ref": "#/$defs/attributes" }
+        "annotation": { "$ref": "#/$defs/function-annotation" }
       },
       "required": ["type", "annotation"]
     },
@@ -115,8 +96,7 @@
       "type": "object",
       "properties": {
         "type": { "const": "expression" },
-        "annotation": { "$ref": "#/$defs/unsupported-annotation" },
-        "attributes": { "$ref": "#/$defs/attributes" }
+        "annotation": { "$ref": "#/$defs/unsupported-annotation" }
       },
       "required": ["type", "annotation"]
     },
@@ -135,8 +115,7 @@
         "type": { "const": "markup" },
         "kind": { "const": "open" },
         "name": { "type": "string" },
-        "options": { "$ref": "#/$defs/options" },
-        "attributes": { "$ref": "#/$defs/attributes" }
+        "options": { "$ref": "#/$defs/options" }
       },
       "required": ["type", "kind", "name"]
     },
@@ -146,8 +125,7 @@
         "type": { "const": "markup" },
         "kind": { "const": "standalone" },
         "name": { "type": "string" },
-        "options": { "$ref": "#/$defs/options" },
-        "attributes": { "$ref": "#/$defs/attributes" }
+        "options": { "$ref": "#/$defs/options" }
       },
       "required": ["type", "kind", "name"]
     },
@@ -156,8 +134,7 @@
       "properties": {
         "type": { "const": "markup" },
         "kind": { "const": "close" },
-        "name": { "type": "string" },
-        "attributes": { "$ref": "#/$defs/attributes" }
+        "name": { "type": "string" }
       },
       "required": ["type", "kind", "name"]
     },


### PR DESCRIPTION
A follow-up to #620.

Expression attributes were proposed in [a design doc](https://github.com/unicode-org/message-format-wg/blob/main/exploration/expression-attributes.md), which was deemed out of scope for LDML 45. Instead, we decided to reserve the most likely syntax for the; this  was done in #592.

That PR reserved the *syntax*, but also added attributes as a concept in the data model. I think that's wrong and I'd like to suggest to remove expression attributes from the data model.

Our formatting spec explicitly states that the reason for reserving attributes was to be able to perform *syntax* validity checks:

> _Attributes_ are reserved for future standardization. Other than checking for valid syntax, they SHOULD NOT affect the processing or output of a _message_.

Furthermore, our stability policy doesn't guarantee anything about the data model:

> Updates to this specification will not change the syntactical meaning, the runtime output, or other behaviour of valid messages written for earlier versions of this specification that only use functions and expression attributes defined in this specification. Updates to this specification will not remove any syntax provided in this version. Future versions MAY add additional structure or meaning to existing syntax.

Interestingly, the policy mentions attributes by name, which I'm also fixing in this PR. The mention was added in #472 together with the rest of the wording of the policy; a mere month after attributes were first proposed in a doc.