### PR TITLE
[DESIGN] Maintaining the Standard, Optional and Unicode Namespace Function Sets

### DIFF
--- a/exploration/maintaining-registry.md
+++ b/exploration/maintaining-registry.md
@@ -10,7 +10,7 @@ Status: **Proposed**
 		<dt>First proposed</dt>
 		<dd>2024-02-12</dd>
 		<dt>Pull Requests</dt>
-		<dd>#000</dd>
+                <dd>#634</dd>
 	</dl>
 </details>
 

--- a/exploration/maintaining-registry.md
+++ b/exploration/maintaining-registry.md
@@ -36,7 +36,7 @@ runtimes in a wholly consistent manner.
 Because we want broad adoption in many different programming environments
 and because the capabilities 
 and functionality available in these environments varies widely,
-the default function registry must be conservative in what it required.
+the default function registry must be conservative in what it requires.
 
 At the same time, we want to promote message interoperability.
 Even though a feature cannot be adopted by all platforms,

--- a/exploration/maintaining-registry.md
+++ b/exploration/maintaining-registry.md
@@ -18,18 +18,17 @@ Status: **Proposed**
 
 _What is this proposal trying to achieve?_
 
-Describe how MFv2 will manage the default function registry
-as well was related function registries intended to promot interoperability.
+Describe how to manage the default function registry
+as well was related function registries intended to promote interoperability.
 
 ## Background
 
 _What context is helpful to understand this proposal?_
 
-> [!NOTE]
-> This design proposal is for the Tech Preview period.
-
-MessageFormat v2 envisions providing a "default registry" that all conformant
-implementations are required to implement.
+MessageFormat v2 includes a "default function registry".
+Implementations are required to implement all of the _selectors_ 
+and _formatters_ in this registry,
+including _operands_, _options_, and option values.
 Our goal is to be as universal as possible, 
 making MFv2's message syntax available to developers in many different
 runtimes in a wholly consistent manner.
@@ -62,14 +61,17 @@ for the various types of function registry.
 _What use-cases do we see? Ideally, quote concrete examples._
 
 As an implementer, I want to know what functions, options, and option values are
-required to claim support for MF2.
-I want to know what the options and their values mean.
-I also need to be able to implement all of the required functions in my runtime environment
-without difficulty.
-I don't want to be required to exactly follow CLDR or a specific release of CLDR,
-in case my local I18N support differs from what CLDR provides.
+required to claim support for MF2:
+- I want to know what options I am required to implement.
+- I want to know what the values of each option are.
+- I want to know what the options and their values mean.
+- I want to be able to implement all of the required functions using my runtime environment
+  without difficulty.
+- I want to be able to use my local I18N APIs, which might use an older release of CLDR
+  or might not be based on CLDR data at all.
+  This means that my output might not match that of an CLDR-based implementation.
 
-As an implementer, user, translators, tools author I expect functions, options
+As an implementer, user, translator, or tools author I expect functions, options
 and option values to be stable.
 The meaning and use of these, once established, should never change.
 Messages that work today should work tomorrow.
@@ -83,24 +85,41 @@ without being required to implement other APIs that I'm not ready for.
 As an implementer, I want to be assured that functions or options added in the future
 will not conflict with functions or options that I have created for my local users.
 
-As a developer, I want to be able to implement local functions or local options
+As a developer, I want to be able to implement my own local functions or local options
 and be assured that these do not conflict with future additions by the core standard.
 
 As a tools developer, I want to track both required and optional function development
 so that I can produce consistent support for messages that use these features.
 
-As a translator, I want all messages to be consistent in their meaning.
+As a translator, I want messages to be consistent in their meaning.
 I want functions and options to work consistently.
-I don't want to relearn selection or formatting rules for different implementations.
+I want to selection and formatting rules to be consistent so that I only have
+to learn them once and so that there are no local quirks.
 
-As a user, I want to be able to use required functions and their options.
+As a user, I want to be able to use required functions and their options in my messages.
 I want to be able to quickly adopt new additions as my implementation supports them
 or be able to choose plug-in or shim implementations.
-I never want to have to find/rewrite a message because a function or its option has changed.
+I never want to have to rewrite a message because a function or its options have changed.
 
 ## Requirements
 
 _What properties does the solution have to manifest to enable the use-cases above?_
+
+The default registry needs to describe the minimum set of selectors and formatters
+needed to create messages effectively.
+This must be compatible with ICU MessageFormat 1 messages.
+
+There must be a clear process for the creation of new selectors that are required
+by the default registry, 
+which includes a maturation process that permits implementer feedback.
+
+There must be a clear process for the creation of new formatters that are required
+by the default registry, 
+which includes a maturation process that permits implementer feedback.
+
+There must be a clear process for the addition of options or option values that are required
+by the default registry, 
+which includes a maturation process that permits implementer feedback.
 
 ## Constraints
 
@@ -110,7 +129,7 @@ _What prior decisions and existing conditions limit the possible design?_
 
 _Describe the proposed solution. Consider syntax, formatting, errors, registry, tooling, interchange._
 
-To address the above problem, in addition to the default registry,
+To address the above requirements, in addition to the default registry,
 create a template for registry functions
 and a process for proposing and evaluating these functions for inclusion
 into the MessageFormat v2 function registry.
@@ -120,21 +139,21 @@ There would be three levels of expected maturity:
 - **Default Registry** includes functions that are normatively required by all implementations.
   Such entries will be limited in scope to functions that can be
   implemented in nearly any programming environment.
-  > Examples: `:string`, `:number`, `:date`
+  > Examples: `:string`, `:number`, `:datetime`, `:date`, `:time`
 - **Recommended for General Implementation**
   ("RGI", deliberately similar to RGI in emoji, although we probably want to change the name
   as the words inside the acronym are themselves different)
   RGI includes functions that are not
   normatively required but whose names, operands, and options are recommended.
-  Implementations are _strongly_ encouraged to use these function signatures
+  Implementations SHOULD use these function signatures
   when implementing the described functionality.
   This will promote message interoperability
   and reduce the learning curve for developers, tools, and translators.
   > Examples: We don't currently have any, but potential work here
   > might includes personal name formatting, gender-based selectors, etc.
 
-  RGI also includes _options_ that are not normatively required,
-  but which are reserved for future standardization.
+  RGI also includes _options_ that are not normatively required for MF2 conformance,
+  but which implementers SHOULD implement.
   These should be used as test cases to populate RGI as soon as possible in the
   Tech Preview period.
   There are a number of these in the LDML45 Tech Preview:
@@ -157,6 +176,30 @@ Having RGI means providing a process for developing and evaluating proposals.
 Since RGI functions and options are normative and stabilized,
 there should be a mechanism for making an RGI proposal
 that includes a beta period.
+
+### RGI registry process and design
+
+The timing of official releases of the default and RGI registries is the same as CLDR.
+Each CLDR release will include:
+- a machine-readable default registry
+- a machine-readable RGI registry
+- a machine-readable Unicode extension registry
+- a specification normatively incorporated into MF2 describing all entries
+  in the machine readable registries listed just above
+
+Proposals for additions to any of the above registries include the following:
+- a design document, which MUST contain:
+   - the exact text to include in the MF2 specification using a template to be named later
+   - the desired maturity level (RGI or default)
+- a machine-readable registry file matching the design
+
+Each proposal is stored in a directory indicating indicating its maturity level.
+The maturity levels are:
+- **Approved** Items waiting for the next CLDR release.
+- **Feedback** Complete designs that are in their implementation test period.
+- **Proposed** Proposals that have not yet been considered by the MFWG.
+- **Rejected** Proposals that have been rejected by the MFWG in the past.
+
 
 ## Alternatives Considered
 

--- a/exploration/maintaining-registry.md
+++ b/exploration/maintaining-registry.md
@@ -30,18 +30,32 @@ _What context is helpful to understand this proposal?_
 
 MessageFormat v2 envisions providing a "default registry" that all conformant
 implementations are required to implement.
+Our goal is to be as universal as possible, 
+making MFv2's message syntax available to developers in many different
+runtimes in a wholly consistent manner.
 Because we want broad adoption in many different programming environments
-and because the capabilities and functionality available in this vary widely,
+and because the capabilities 
+and functionality available in these environments varies widely,
 the default function registry must be conservative in what it required.
 
 At the same time, we want to promote message interoperability.
-When a feature can be adopted by many (but not all) platforms,
+Even though a feature cannot be adopted by all platforms,
 diversity in the function names, operands, options, error behavior,
-and so forth is undesirable.
-This suggests that there exist a registry at a lower level of normativeness.
+and so forth remains undesirable.
+This suggests that there exist a registry at a lower level of normativeness
+with "templates" for functions that implementations can implement 
+when they have the wherewithal to support them.
+
+An example of this might be "personal name formatting",
+whose functionality is new in CLDR and ICU.
+Few if any non-ICU implementations are currently prepared to implement
+a function such as `:person`
+and implementation and usage experience is limited in ICU.
+Where functionality is made available, we don't want it to vary from
+platform to platform.
 
 Finally, we need to establish mechanisms for managing proposals
-for either of these registries.
+for the various types of function registry.
 
 ## Use-Cases
 
@@ -70,7 +84,9 @@ There would be three levels of expected maturity:
   Such entries will be limited in scope to functions that can be
   implemented in nearly any programming environment.
   > Examples: `:string`, `:number`, `:date`
-- **Recommend for General Implementation** includes functions that are not
+- **Recommended for General Implementation**
+  ("RGI", deliberately similar to RGI in emoji, tho' we may want to change the name)
+  includes functions that are not
   normatively required but whose names, operands, and options are recommended.
   Implementations are _strongly_ encouraged to use these function signatures
   when implementing the described functionality.

--- a/exploration/maintaining-registry.md
+++ b/exploration/maintaining-registry.md
@@ -250,11 +250,28 @@ Multiple proposals can exist for a given _function_ or _option_.
 
 ### Registry process
 
+Proposals for registration are made via issues in a unicode-org github repo
+using a specific template TBD.
+
+Proposals must be made at least _x months_ prior to the release date to be included
+in a specific LDML release.
+The CLDR-TC will consider each proposal using _process details here_ and make a determination.
+The CLDR-TC may delegate approval to the MF2 WG.
+Decisions by the MF2 WG may be appealed to the CLDR-TC.
+Decisions by the CLDR-TC may be appealed using _existing process_.
+
+Technical discussion during the approval process is strongly encouraged.
+Changes to the proposal, 
+such as in response to comments or implementation experience, are permitted
+until the proposal has been approved.
+Once approved, changes require re-approval (how?)
+
+
 The timing of official releases of the default and RGI registries is the same as CLDR/LDML.
 Each LDML release will include:
-- **Approved** specifications in the default registry
-- **Approved** specifications in the RGI registry
-- **Approved** specifications in the Unicode reserved namespace registry
+- **Released** specifications in the default registry
+- **Released** specifications in the RGI registry
+- **Released** specifications in the Unicode reserved namespace registry
 - a section of the MF2 specification specifically incorporating versions of the above
 - **Accepted** entries for each of the above available for testing and feedback
 

--- a/exploration/maintaining-registry.md
+++ b/exploration/maintaining-registry.md
@@ -38,23 +38,40 @@ and functionality available in these environments vary widely,
 the default function registry must be conservative in what it requires.
 
 At the same time, we want to promote message interoperability.
-Even though a feature cannot be adopted by all platforms,
+Even when a given feature or function cannot be adopted by all platforms,
 diversity in the function names, operands, options, error behavior,
 and so forth remains undesirable.
-This suggests that there exist a registry at a lower level of normativeness
-with "templates" for functions that implementations can implement 
-when they have the wherewithal to support them.
+Another way to say this is that, ideally, there should be only one way to
+do a given formatting or selection operation in terms of the syntax of a message.
 
-An example of this might be "personal name formatting",
-whose functionality is new in CLDR and ICU.
-Few if any non-ICU implementations are currently prepared to implement
-a function such as `:person`
-and implementation and usage experience is limited in ICU.
+This suggests that there exist a registry besides the "default function registry"
+that contains the "templates" for functions that go beyond those every implementation 
+must provide or which contain additional, optional features (options, option values)
+that implementations can provide if they are motivated and capable of doing so.
+This lower level of registry is normative for the functionality that it provides,
+but not obligatory.
+This lower level of registry uses the default namespace and can serve to incubate
+functions or options that might be promoted to the default registry over time.
+
+### Examples
+
+_Function Incubation_
+
+CLDR and ICU have defined locale data and formatting for personal names.
+This functionality is new in CLDR and ICU.
+Because it is new, few, if any, non-ICU implementations are currently prepared to implement
+a function such as a `:person` formatter or selector.
+Implementation and usage experience is limited in ICU.
 Where functionality is made available, we don't want it to vary from
 platform to platform.
 
-Finally, we need to establish mechanisms for managing proposals
-for the various types of function registry.
+_Option Incubation_
+
+In the Tech Preview (LDML45) release, options for `:number` (and friends)
+and `:datetime` (and friends) were omitted, including `currency` for `:number`
+and `timeZone` for `:datetime`.
+The options and their values were reserved, possibly for the LDML46 release as required,
+but they also might be retained at a lower level of maturity.
 
 ## Use-Cases
 
@@ -69,18 +86,18 @@ required to claim support for MF2:
   without difficulty.
 - I want to be able to use my local I18N APIs, which might use an older release of CLDR
   or might not be based on CLDR data at all.
-  This means that my output might not match that of an CLDR-based implementation.
+  This could mean that my output might not match that of an CLDR-based implementation.
 
 As an implementer, user, translator, or tools author I expect functions, options
 and option values to be stable.
 The meaning and use of these, once established, should never change.
-Messages that work today should work tomorrow.
+Messages that work today must work tomorrow.
 This doesn't mean that the output is stabilized or that selectors won't
-produce different results for a given input/locale.
+produce different results for a given input or locale.
 
 As an implementer, I want to track best practices for newer I18N APIs
 (such as implementing personal name formatting/selection)
-without being required to implement other APIs that I'm not ready for.
+without being required to implement any such APIs that I'm not ready for.
 
 As an implementer, I want to be assured that functions or options added in the future
 will not conflict with functions or options that I have created for my local users.
@@ -100,6 +117,11 @@ As a user, I want to be able to use required functions and their options in my m
 I want to be able to quickly adopt new additions as my implementation supports them
 or be able to choose plug-in or shim implementations.
 I never want to have to rewrite a message because a function or its options have changed.
+
+As an implementer or user, I want to be able to suggest useful additions to MF2 functionality
+so that users can benefit from consistent, standardized features.
+I want to understand the status of my proposal (and those of others) and know that a public,
+structured, well-managed process has been applied.
 
 ## Requirements
 
@@ -121,6 +143,10 @@ There must be a clear process for the addition of options or option values that 
 by the default registry, 
 which includes a maturation process that permits implementer feedback.
 
+There must be a clear process for the deprecation of any functions, options, or option values
+that are no longer I18N best practices.
+The stability guarantees of our standard do not permit removal of any of these.
+
 ## Constraints
 
 _What prior decisions and existing conditions limit the possible design?_
@@ -137,7 +163,7 @@ into the MessageFormat v2 function registry.
 There would be three levels of expected maturity:
 
 - **Default Registry** includes functions that are normatively required by all implementations.
-  Such entries will be limited in scope to functions that can be
+  Such entries will be limited in scope to functions that can reasonably be
   implemented in nearly any programming environment.
   > Examples: `:string`, `:number`, `:datetime`, `:date`, `:time`
 - **Recommended for General Implementation**
@@ -162,9 +188,12 @@ There would be three levels of expected maturity:
 - **Unicode Extensions** includes optional functionality that implementations
   may adopt at their discretion.
   These are provided as a reference.
-  Unicode extensions use the namespace `:u` (which should be reserved).
-  This is also intended as a useful means of incubating functionality before
-  adding it to the default or RGI registries in future releases.
+  Unicode extensions use the namespace `:u` (which is reserved by the specification).
+  Entries in the Unicode extension are stable and subject to the stability policy.
+  That is, they will never be removed (but may be deprecated).
+  Unicode extensions can be used to incubate functionality before
+  promotion (removing the `u:` namespace) to the RGI or default registries in future releases,
+  although, in general, this should be avoided.
   > Examples: Number and date skeletons are an example of Unicode extension
   > possibilities.
   > Providing a well-documented shorthand to augment "option bags" is
@@ -181,17 +210,15 @@ that includes a beta period.
 
 The timing of official releases of the default and RGI registries is the same as CLDR.
 Each CLDR release will include:
-- a machine-readable default registry
-- a machine-readable RGI registry
-- a machine-readable Unicode extension registry
-- a specification normatively incorporated into MF2 describing all entries
-  in the machine readable registries listed just above
+- a specification for the default registry
+- a specification for the RGI registry
+- a specification for the Unicode extension registry
+- a section of the MF2 specification specifically incorporating versions of the above
 
 Proposals for additions to any of the above registries include the following:
 - a design document, which MUST contain:
    - the exact text to include in the MF2 specification using a template to be named later
    - the desired maturity level (RGI or default)
-- a machine-readable registry file matching the design
 
 Each proposal is stored in a directory indicating indicating its maturity level.
 The maturity levels are:
@@ -199,7 +226,6 @@ The maturity levels are:
 - **Feedback** Complete designs that are in their implementation test period.
 - **Proposed** Proposals that have not yet been considered by the MFWG.
 - **Rejected** Proposals that have been rejected by the MFWG in the past.
-
 
 ## Alternatives Considered
 

--- a/exploration/maintaining-registry.md
+++ b/exploration/maintaining-registry.md
@@ -1,4 +1,4 @@
-# Maintaining the Function Registry
+# Maintaining and Registering Functions
 
 Status: **Proposed**
 
@@ -18,16 +18,26 @@ Status: **Proposed**
 
 _What is this proposal trying to achieve?_
 
-Describe how to manage the default function registry
-as well was related function registries intended to promote interoperability.
+Describe how to manage the registration of functions and options under the 
+auspices of MessageFormat 2.0.
+This includes the Standard Functions which are normatively required by MF2.0,
+functions or options in the Unicode `u:` namespace,
+and functions/options that are recommended for interoperability.
 
 ## Background
 
 _What context is helpful to understand this proposal?_
 
-MessageFormat v2 includes a "default function registry".
+MessageFormat v2 originally included the concept of "function registries",
+including a "default function registry" required of conformant implementations.
+
+The terms "registry" and "default registry" suggest machine-readbility
+and various relationships between function sets that the working group decided
+was not appropriate.
+
+MessageFormat v2 includes a standard set of functions.
 Implementations are required to implement all of the _selectors_ 
-and _formatters_ in this registry,
+and _formatters_ in this set,
 including _operands_, _options_, and option values.
 Our goal is to be as universal as possible, 
 making MFv2's message syntax available to developers in many different
@@ -35,23 +45,27 @@ runtimes in a wholly consistent manner.
 Because we want broad adoption in many different programming environments
 and because the capabilities 
 and functionality available in these environments vary widely,
-the default function registry must be conservative in what it requires.
+this standard set of functions must be conservative in its requirements
+such that every implementation can reasonably implement it.
 
-At the same time, we want to promote message interoperability.
+Promoting message interoperability can and should go beyond this.
 Even when a given feature or function cannot be adopted by all platforms,
 diversity in the function names, operands, options, error behavior,
 and so forth remains undesirable.
 Another way to say this is that, ideally, there should be only one way to
 do a given formatting or selection operation in terms of the syntax of a message.
 
-This suggests that there exist a registry besides the "default function registry"
-that contains the "templates" for functions that go beyond those every implementation 
+This suggests that there exist a set of functions and options that
+extends the standard set of functions.
+Such a set contains the "templates" for functions that go beyond those every implementation 
 must provide or which contain additional, optional features (options, option values)
 that implementations can provide if they are motivated and capable of doing so.
-This lower level of registry is normative for the functionality that it provides,
-but not obligatory.
-This lower level of registry uses the default namespace and can serve to incubate
-functions or options that might be promoted to the default registry over time.
+These specifications are normative for the functionality that they provide,
+but are optional for implementaters.
+
+There also needs to be a mechanism and process by which functions in the default namespace
+can be incubated for future inclusion in either the standard set of functions
+or in this extended, optional set.
 
 ### Examples
 
@@ -127,20 +141,20 @@ structured, well-managed process has been applied.
 
 _What properties does the solution have to manifest to enable the use-cases above?_
 
-The default registry needs to describe the minimum set of selectors and formatters
+The Standard Function Set needs to describe the minimum set of selectors and formatters
 needed to create messages effectively.
 This must be compatible with ICU MessageFormat 1 messages.
 
 There must be a clear process for the creation of new selectors that are required
-by the default registry, 
+by the Standard Function Set, 
 which includes a maturation process that permits implementer feedback.
 
 There must be a clear process for the creation of new formatters that are required
-by the default registry, 
+by the Standard Function Set, 
 which includes a maturation process that permits implementer feedback.
 
 There must be a clear process for the addition of options or option values that are required
-by the default registry, 
+by the Standard Function Set, 
 which includes a maturation process that permits implementer feedback.
 
 There must be a clear process for the deprecation of any functions, options, or option values
@@ -155,73 +169,80 @@ _What prior decisions and existing conditions limit the possible design?_
 
 _Describe the proposed solution. Consider syntax, formatting, errors, registry, tooling, interchange._
 
-The MessageFormat WG will maintain three separate function and option registries 
-beginning with the LDML46 release.
-Future updates to these registries will coincide with LDML releases.
+The MessageFormat WG will a set of specifications
+that standardize the implementation of functions and options in the default namespace of 
+MessageFormat v2 beginning with the LDML46 release.
+Implementations and users are strongly discourages from defining values that use
+the default namespace.
+Future updates to these sets of functions and options will coincide with LDML releases.
 
-Each registry consists of a set of template-derived documents.
-Each _function_ or _option_ entry in a registry consists of a separate document.
-An _option_ entry in a given registry will not be created if there is a corresponding
-_function_ entry in the same registry for which it is an _option_.
-Proposals to include functions into the default registry
-or to include functions or options into the RGI registry
-or to include functions or options into the Unicode reserved namespace registry
-need to follow a specific process.
+Each _function_ is described by a single specification document.
+Each such document will use a common template.
+A _function_ can be a _formatting function_,
+a _selector_,
+or both.
 
-The three registries are:
+The specification will indicate if the _formatting function_,
+the _selector function_, or, where applicable, both are `Standard` or `Optional`.
+The specification must describe operands, including literal representations.
 
-1. **Default Registry**
-This is a _function_ registry.
-It includes _functions_ (and only functions) that are normatively required to be
-implemented by all implementations.
-Each function describes it's operand or operands,
+The specification includes all defined _options_ for the function.
+Each _option_ must define which values it accepts.
+An _option_  is either `Standard` or `Optional`.
+
+_Functions_ or _options_ that have an `Optional` status
+must have a maturity level assigned.
+The maturity levels are:
+- **Proposed**
+- **Accepted**
+- **Released**
+- **Deprecated**
+
+_Functions_ and _options_ that have a `Standard` status have only the
+`Released` and `Deprecated` statuses.
+
+* An _option_ can be `Standard` for an `Optional` function.
+  This means that the function is optional to implement, but that, when implemented, must include the option.
+* An _option_ can be `Optional` for a `Standard` function.
+  This means that the function is required, but implementations are not required to implement the option.
+* An _option_ can be `Optional` for an `Optional` function.
+  This means that the function is optional to implement and the option is optional when implementing the function.
+
+A function specification describes the functions _operand_ or _operands_,
 its formatting options (if any) and their values,
 its selection options (if any) and their values,
 its formatting behavior (if any),
 its selection behavior (if any),
 and its resolved value behavior.
-Items in this registry are stable and subject to stability guarantees.
+
+`Standard` functions are stable and subject to stability guarantees.
 Such entries will be limited in scope to functions that can reasonably be
 implemented in nearly any programming environment.
 > Examples: `:string`, `:number`, `:datetime`, `:date`, `:time`
 
-2. **Recommended for General Implementation**
-("RGI", deliberately similar to RGI in emoji, although we probably want to change the name
-as the words inside the acronym are themselves different)
-This registry can contain _functions_.
-It can also contain _options_ registered for _functions_ found in the default registry.
-Implmentations are not required to implement either _functions_ or _options_ to claim
-MF2 conformance, but MUST NOT implement functions or options that conflict with RGI entries.
-Each function describes it's operand or operands,
-its formatting options (if any) and their values,
-its selection options (if any) and their values,
-its formatting behavior (if any),
-its selection behavior (if any),
-and its resolved value behavior.
-Each option registry entry describes whether it affects formatting, selection or both;
-what its values are;
-and whether it is retained or affects the resolved value.
-Items in the RGI function or option registries are stable and subject to stability guarantees
-except that they MAY be promoted to the default registry.
+
+`Optional` functions are stable and subject to stability guarantees once they
+reach the status of **Released**.
+Implmentations are not required to implement _functions_ or _options_ with an `Optional` status
+when claiming MF2 conformance.
+Implementations MUST NOT implement functions or options that conflict with `Optional` functions or options.
+
+`Optional` values may have their status changed to `Standard`,
+but not vice-versa.
+
 > Option Examples `:datetime` might have a `timezone` option in LDML46.
 > Function Examples: We don't currently have any, but potential work here
 > might includes personal name formatting, gender-based selectors, etc.
 
-RGI includes functions that are not
-normatively required but whose names, operands, and options are recommended.
-Implementations SHOULD use these function signatures
-when implementing the described functionality.
-This will promote message interoperability
-and reduce the learning curve for developers, tools, and translators.
+The CLDR-TC reserves the `u:` namespace for use by the Unicode Consortium.
+This namespace can contain _functions_ or _options_.
+Implementations are not required to implement these _functions_ or _options_
+and may adopt or ignore them at their discretion,
+but are encouraged to implement these items.
 
-3. **Unicode Reserved Namespace**
-This registry is for items in the namespace `u:`, which is reserved for use by the Unicode Consortium.
-This registry can contain _functions_ or _options_.
-Implementations are not required to implement any values found in this registry
-and may adopt or ignore registry entries at their discretion.
-Items in the Unicode Reserved Namespace function or option registries are stable and subject to stability guarantees.
-This registry might sometimes be used to incubate functionality before
-promotion to the RGI or default registry in a future release.
+Items in the Unicode Reserved Namespace are stable and subject to stability guarantees.
+This namespace might sometimes be used to incubate functionality before
+promotion to the default namespace in a future release.
 In such cases, the `u:` namespace version is retained, but deprecated.
 > Examples: Number and date skeletons are an example of Unicode extension
 > possibilities.
@@ -230,28 +251,31 @@ In such cases, the `u:` namespace version is retained, but deprecated.
 > but it is not universally available and could represent a barrier to adoption
 > if normatively required.
 
-Any registry entry goes through a development process that includes these levels of maturity:
+All `Standard`, `Optional`, and Unicode namespace function or option specifications goes through 
+a development process that includes these levels of maturity:
 
 1. **Proposed** The _function_ or _option_, along with necessary documentation,
    has been proposed for inclusion in a future release.
 2. **Accepted** The _function_ or _option_ has been accepted but is not yet released.
    During this period, changes can still be made.
 3. **Released** The _function_ or _option_ is accepted as of a given LDML release that MUST be specified.
-   1. **Deprecated** The _function_ or _option_ was previously _released_ but has been deprecated.
-      Implementations are still required to support deprecated items in the default registry.
-4. **Rejected** The _function_ or _option_ was considered and rejected by the MF2 WG and/or the CLDR-TC.
-   Such items are not part of any registry, but might be maintained for historical reference.
+4. **Deprecated** The _function_ or _option_ was previously _released_ but has been deprecated.
+   Implementations are still required to support `Standard` functions or options that are deprecated.
+5. **Rejected** The _function_ or _option_ was considered and rejected by the MF2 WG and/or the CLDR-TC.
+   Such items are not part of any standard, but might be maintained for historical reference.
 
-A proposal can seek to modify an existing entry in a given registry.
-For example, if a _function_ `:foo` existed in the RGI registry,
+A proposal can seek to modify an existing function.
+For example, if a _function_ `:foo` were an `Optional` function in the LDMLxx release,
 a proposal to add an _option_ `bar` to this function would take the form
-of a proposal to alter the existing registration of `:foo`.
+of a proposal to alter the existing specification of `:foo`.
 Multiple proposals can exist for a given _function_ or _option_.
 
-### Registry process
+### Process
 
-Proposals for registration are made via issues in a unicode-org github repo
+Proposals for additions are made via pull requests in a unicode-org github repo
 using a specific template TBD.
+Proposals for changes are made via pull requests in a unicode-org github repo
+using a specific template TBD against the existing specification for the function or option.
 
 Proposals must be made at least _x months_ prior to the release date to be included
 in a specific LDML release.
@@ -267,18 +291,16 @@ until the proposal has been approved.
 Once approved, changes require re-approval (how?)
 
 
-The timing of official releases of the default and RGI registries is the same as CLDR/LDML.
+The timing of official releases of the Standard Function Set and Optional Set is the same as CLDR/LDML.
 Each LDML release will include:
-- **Released** specifications in the default registry
-- **Released** specifications in the RGI registry
-- **Released** specifications in the Unicode reserved namespace registry
+- **Released** specifications in the Standard Function Set
+- **Released** specifications in the Unicode reserved namespace
 - a section of the MF2 specification specifically incorporating versions of the above
 - **Accepted** entries for each of the above available for testing and feedback
 
-Proposals for additions to any of the above registries include the following:
+Proposals for additions to any of the above include the following:
 - a design document, which MUST contain:
    - the exact text to include in the MF2 specification using a template to be named later
-   - the desired maturity level (RGI or default)
 
 Each proposal is stored in a directory indicating indicating its maturity level.
 The maturity levels are:

--- a/exploration/maintaining-registry.md
+++ b/exploration/maintaining-registry.md
@@ -61,6 +61,43 @@ for the various types of function registry.
 
 _What use-cases do we see? Ideally, quote concrete examples._
 
+As an implementer, I want to know what functions, options, and option values are
+required to claim support for MF2.
+I want to know what the options and their values mean.
+I also need to be able to implement all of the required functions in my runtime environment
+without difficulty.
+I don't want to be required to exactly follow CLDR or a specific release of CLDR,
+in case my local I18N support differs from what CLDR provides.
+
+As an implementer, user, translators, tools author I expect functions, options
+and option values to be stable.
+The meaning and use of these, once established, should never change.
+Messages that work today should work tomorrow.
+This doesn't mean that the output is stabilized or that selectors won't
+produce different results for a given input/locale.
+
+As an implementer, I want to track best practices for newer I18N APIs
+(such as implementing personal name formatting/selection)
+without being required to implement other APIs that I'm not ready for.
+
+As an implementer, I want to be assured that functions or options added in the future
+will not conflict with functions or options that I have created for my local users.
+
+As a developer, I want to be able to implement local functions or local options
+and be assured that these do not conflict with future additions by the core standard.
+
+As a tools developer, I want to track both required and optional function development
+so that I can produce consistent support for messages that use these features.
+
+As a translator, I want all messages to be consistent in their meaning.
+I want functions and options to work consistently.
+I don't want to relearn selection or formatting rules for different implementations.
+
+As a user, I want to be able to use required functions and their options.
+I want to be able to quickly adopt new additions as my implementation supports them
+or be able to choose plug-in or shim implementations.
+I never want to have to find/rewrite a message because a function or its option has changed.
+
 ## Requirements
 
 _What properties does the solution have to manifest to enable the use-cases above?_
@@ -85,8 +122,9 @@ There would be three levels of expected maturity:
   implemented in nearly any programming environment.
   > Examples: `:string`, `:number`, `:date`
 - **Recommended for General Implementation**
-  ("RGI", deliberately similar to RGI in emoji, tho' we may want to change the name)
-  includes functions that are not
+  ("RGI", deliberately similar to RGI in emoji, although we probably want to change the name
+  as the words inside the acronym are themselves different)
+  RGI includes functions that are not
   normatively required but whose names, operands, and options are recommended.
   Implementations are _strongly_ encouraged to use these function signatures
   when implementing the described functionality.
@@ -94,6 +132,14 @@ There would be three levels of expected maturity:
   and reduce the learning curve for developers, tools, and translators.
   > Examples: We don't currently have any, but potential work here
   > might includes personal name formatting, gender-based selectors, etc.
+
+  RGI also includes _options_ that are not normatively required,
+  but which are reserved for future standardization.
+  These should be used as test cases to populate RGI as soon as possible in the
+  Tech Preview period.
+  There are a number of these in the LDML45 Tech Preview:
+  - `:number`/`:integer` have: `currency`, `unit`, `currencyDisplay`, `currencySign`, and `unitDisplay`
+  - `:datetime` (et al) have: `calendar`, `numberingSystem`, and `timeZone`
 - **Unicode Extensions** includes optional functionality that implementations
   may adopt at their discretion.
   These are provided as a reference.
@@ -106,6 +152,11 @@ There would be three levels of expected maturity:
   > popular with some developers,
   > but it is not universally available and could represent a barrier to adoption
   > if normatively required.
+
+Having RGI means providing a process for developing and evaluating proposals.
+Since RGI functions and options are normative and stabilized,
+there should be a mechanism for making an RGI proposal
+that includes a beta period.
 
 ## Alternatives Considered
 

--- a/exploration/maintaining-registry.md
+++ b/exploration/maintaining-registry.md
@@ -155,65 +155,108 @@ _What prior decisions and existing conditions limit the possible design?_
 
 _Describe the proposed solution. Consider syntax, formatting, errors, registry, tooling, interchange._
 
-To address the above requirements, in addition to the default registry,
-create a template for registry functions
-and a process for proposing and evaluating these functions for inclusion
-into the MessageFormat v2 function registry.
+The MessageFormat WG will maintain three separate function and option registries 
+beginning with the LDML46 release.
+Future updates to these registries will coincide with LDML releases.
 
-There would be three levels of expected maturity:
+Each registry consists of a set of template-derived documents.
+Each _function_ or _option_ entry in a registry consists of a separate document.
+An _option_ entry in a given registry will not be created if there is a corresponding
+_function_ entry in the same registry for which it is an _option_.
+Proposals to include functions into the default registry
+or to include functions or options into the RGI registry
+or to include functions or options into the Unicode reserved namespace registry
+need to follow a specific process.
 
-- **Default Registry** includes functions that are normatively required by all implementations.
-  Such entries will be limited in scope to functions that can reasonably be
-  implemented in nearly any programming environment.
-  > Examples: `:string`, `:number`, `:datetime`, `:date`, `:time`
-- **Recommended for General Implementation**
-  ("RGI", deliberately similar to RGI in emoji, although we probably want to change the name
-  as the words inside the acronym are themselves different)
-  RGI includes functions that are not
-  normatively required but whose names, operands, and options are recommended.
-  Implementations SHOULD use these function signatures
-  when implementing the described functionality.
-  This will promote message interoperability
-  and reduce the learning curve for developers, tools, and translators.
-  > Examples: We don't currently have any, but potential work here
-  > might includes personal name formatting, gender-based selectors, etc.
+The three registries are:
 
-  RGI also includes _options_ that are not normatively required for MF2 conformance,
-  but which implementers SHOULD implement.
-  These should be used as test cases to populate RGI as soon as possible in the
-  Tech Preview period.
-  There are a number of these in the LDML45 Tech Preview:
-  - `:number`/`:integer` have: `currency`, `unit`, `currencyDisplay`, `currencySign`, and `unitDisplay`
-  - `:datetime` (et al) have: `calendar`, `numberingSystem`, and `timeZone`
-- **Unicode Extensions** includes optional functionality that implementations
-  may adopt at their discretion.
-  These are provided as a reference.
-  Unicode extensions use the namespace `:u` (which is reserved by the specification).
-  Entries in the Unicode extension are stable and subject to the stability policy.
-  That is, they will never be removed (but may be deprecated).
-  Unicode extensions can be used to incubate functionality before
-  promotion (removing the `u:` namespace) to the RGI or default registries in future releases,
-  although, in general, this should be avoided.
-  > Examples: Number and date skeletons are an example of Unicode extension
-  > possibilities.
-  > Providing a well-documented shorthand to augment "option bags" is
-  > popular with some developers,
-  > but it is not universally available and could represent a barrier to adoption
-  > if normatively required.
+1. **Default Registry**
+This is a _function_ registry.
+It includes _functions_ (and only functions) that are normatively required to be
+implemented by all implementations.
+Each function describes it's operand or operands,
+its formatting options (if any) and their values,
+its selection options (if any) and their values,
+its formatting behavior (if any),
+its selection behavior (if any),
+and its resolved value behavior.
+Items in this registry are stable and subject to stability guarantees.
+Such entries will be limited in scope to functions that can reasonably be
+implemented in nearly any programming environment.
+> Examples: `:string`, `:number`, `:datetime`, `:date`, `:time`
 
-Having RGI means providing a process for developing and evaluating proposals.
-Since RGI functions and options are normative and stabilized,
-there should be a mechanism for making an RGI proposal
-that includes a beta period.
+2. **Recommended for General Implementation**
+("RGI", deliberately similar to RGI in emoji, although we probably want to change the name
+as the words inside the acronym are themselves different)
+This registry can contain _functions_.
+It can also contain _options_ registered for _functions_ found in the default registry.
+Implmentations are not required to implement either _functions_ or _options_ to claim
+MF2 conformance, but MUST NOT implement functions or options that conflict with RGI entries.
+Each function describes it's operand or operands,
+its formatting options (if any) and their values,
+its selection options (if any) and their values,
+its formatting behavior (if any),
+its selection behavior (if any),
+and its resolved value behavior.
+Each option registry entry describes whether it affects formatting, selection or both;
+what its values are;
+and whether it is retained or affects the resolved value.
+Items in the RGI function or option registries are stable and subject to stability guarantees
+except that they MAY be promoted to the default registry.
+> Option Examples `:datetime` might have a `timezone` option in LDML46.
+> Function Examples: We don't currently have any, but potential work here
+> might includes personal name formatting, gender-based selectors, etc.
 
-### RGI registry process and design
+RGI includes functions that are not
+normatively required but whose names, operands, and options are recommended.
+Implementations SHOULD use these function signatures
+when implementing the described functionality.
+This will promote message interoperability
+and reduce the learning curve for developers, tools, and translators.
 
-The timing of official releases of the default and RGI registries is the same as CLDR.
-Each CLDR release will include:
-- a specification for the default registry
-- a specification for the RGI registry
-- a specification for the Unicode extension registry
+3. **Unicode Reserved Namespace**
+This registry is for items in the namespace `u:`, which is reserved for use by the Unicode Consortium.
+This registry can contain _functions_ or _options_.
+Implementations are not required to implement any values found in this registry
+and may adopt or ignore registry entries at their discretion.
+Items in the Unicode Reserved Namespace function or option registries are stable and subject to stability guarantees.
+This registry might sometimes be used to incubate functionality before
+promotion to the RGI or default registry in a future release.
+In such cases, the `u:` namespace version is retained, but deprecated.
+> Examples: Number and date skeletons are an example of Unicode extension
+> possibilities.
+> Providing a well-documented shorthand to augment "option bags" is
+> popular with some developers,
+> but it is not universally available and could represent a barrier to adoption
+> if normatively required.
+
+Any registry entry goes through a development process that includes these levels of maturity:
+
+1. **Proposed** The _function_ or _option_, along with necessary documentation,
+   has been proposed for inclusion in a future release.
+2. **Accepted** The _function_ or _option_ has been accepted but is not yet released.
+   During this period, changes can still be made.
+3. **Released** The _function_ or _option_ is accepted as of a given LDML release that MUST be specified.
+   1. **Deprecated** The _function_ or _option_ was previously _released_ but has been deprecated.
+      Implementations are still required to support deprecated items in the default registry.
+4. **Rejected** The _function_ or _option_ was considered and rejected by the MF2 WG and/or the CLDR-TC.
+   Such items are not part of any registry, but might be maintained for historical reference.
+
+A proposal can seek to modify an existing entry in a given registry.
+For example, if a _function_ `:foo` existed in the RGI registry,
+a proposal to add an _option_ `bar` to this function would take the form
+of a proposal to alter the existing registration of `:foo`.
+Multiple proposals can exist for a given _function_ or _option_.
+
+### Registry process
+
+The timing of official releases of the default and RGI registries is the same as CLDR/LDML.
+Each LDML release will include:
+- **Approved** specifications in the default registry
+- **Approved** specifications in the RGI registry
+- **Approved** specifications in the Unicode reserved namespace registry
 - a section of the MF2 specification specifically incorporating versions of the above
+- **Accepted** entries for each of the above available for testing and feedback
 
 Proposals for additions to any of the above registries include the following:
 - a design document, which MUST contain:

--- a/exploration/maintaining-registry.md
+++ b/exploration/maintaining-registry.md
@@ -35,7 +35,7 @@ making MFv2's message syntax available to developers in many different
 runtimes in a wholly consistent manner.
 Because we want broad adoption in many different programming environments
 and because the capabilities 
-and functionality available in these environments varies widely,
+and functionality available in these environments vary widely,
 the default function registry must be conservative in what it requires.
 
 At the same time, we want to promote message interoperability.

--- a/exploration/maintaining-registry.md
+++ b/exploration/maintaining-registry.md
@@ -169,11 +169,11 @@ _What prior decisions and existing conditions limit the possible design?_
 
 _Describe the proposed solution. Consider syntax, formatting, errors, registry, tooling, interchange._
 
-The MessageFormat WG will a set of specifications
+The MessageFormat WG will release a set of specifications
 that standardize the implementation of functions and options in the default namespace of 
 MessageFormat v2 beginning with the LDML46 release.
-Implementations and users are strongly discourages from defining values that use
-the default namespace.
+Implementations and users are strongly discouraged from defining 
+their own functions or options that use the default namespace
 Future updates to these sets of functions and options will coincide with LDML releases.
 
 Each _function_ is described by a single specification document.
@@ -304,9 +304,9 @@ Proposals for additions to any of the above include the following:
 
 Each proposal is stored in a directory indicating indicating its maturity level.
 The maturity levels are:
-- **Approved** Items waiting for the next CLDR release.
-- **Feedback** Complete designs that are in their implementation test period.
-- **Proposed** Proposals that have not yet been considered by the MFWG.
+- **Accepted** Items waiting for the next CLDR release.
+- **Released** Complete designs that are released.
+- **Proposed** Proposals that have not yet been considered by the MFWG or which are under active development.
 - **Rejected** Proposals that have been rejected by the MFWG in the past.
 
 ## Alternatives Considered

--- a/exploration/maintaining-registry.md
+++ b/exploration/maintaining-registry.md
@@ -1,0 +1,98 @@
+# Maintaining the Function Registry
+
+Status: **Proposed**
+
+<details>
+	<summary>Metadata</summary>
+	<dl>
+		<dt>Contributors</dt>
+		<dd>@aphillips</dd>
+		<dt>First proposed</dt>
+		<dd>2024-02-12</dd>
+		<dt>Pull Requests</dt>
+		<dd>#000</dd>
+	</dl>
+</details>
+
+## Objective
+
+_What is this proposal trying to achieve?_
+
+Describe how MFv2 will manage the default function registry
+as well was related function registries intended to promot interoperability.
+
+## Background
+
+_What context is helpful to understand this proposal?_
+
+> [!NOTE]
+> This design proposal is for the Tech Preview period.
+
+MessageFormat v2 envisions providing a "default registry" that all conformant
+implementations are required to implement.
+Because we want broad adoption in many different programming environments
+and because the capabilities and functionality available in this vary widely,
+the default function registry must be conservative in what it required.
+
+At the same time, we want to promote message interoperability.
+When a feature can be adopted by many (but not all) platforms,
+diversity in the function names, operands, options, error behavior,
+and so forth is undesirable.
+This suggests that there exist a registry at a lower level of normativeness.
+
+Finally, we need to establish mechanisms for managing proposals
+for either of these registries.
+
+## Use-Cases
+
+_What use-cases do we see? Ideally, quote concrete examples._
+
+## Requirements
+
+_What properties does the solution have to manifest to enable the use-cases above?_
+
+## Constraints
+
+_What prior decisions and existing conditions limit the possible design?_
+
+## Proposed Design
+
+_Describe the proposed solution. Consider syntax, formatting, errors, registry, tooling, interchange._
+
+To address the above problem, in addition to the default registry,
+create a template for registry functions
+and a process for proposing and evaluating these functions for inclusion
+into the MessageFormat v2 function registry.
+
+There would be three levels of expected maturity:
+
+- **Default Registry** includes functions that are normatively required by all implementations.
+  Such entries will be limited in scope to functions that can be
+  implemented in nearly any programming environment.
+  > Examples: `:string`, `:number`, `:date`
+- **Recommend for General Implementation** includes functions that are not
+  normatively required but whose names, operands, and options are recommended.
+  Implementations are _strongly_ encouraged to use these function signatures
+  when implementing the described functionality.
+  This will promote message interoperability
+  and reduce the learning curve for developers, tools, and translators.
+  > Examples: We don't currently have any, but potential work here
+  > might includes personal name formatting, gender-based selectors, etc.
+- **Unicode Extensions** includes optional functionality that implementations
+  may adopt at their discretion.
+  These are provided as a reference.
+  Unicode extensions use the namespace `:u` (which should be reserved).
+  This is also intended as a useful means of incubating functionality before
+  adding it to the default or RGI registries in future releases.
+  > Examples: Number and date skeletons are an example of Unicode extension
+  > possibilities.
+  > Providing a well-documented shorthand to augment "option bags" is
+  > popular with some developers,
+  > but it is not universally available and could represent a barrier to adoption
+  > if normatively required.
+
+## Alternatives Considered
+
+_What other solutions are available?_
+_How do they compare against the requirements?_
+_What other properties they have?_


### PR DESCRIPTION
Capture for discussion the general ideas for how to organize the registry in the post-45 time period.

Notably, @sffc [mentioned number skeletons](https://github.com/unicode-org/message-format-wg/pull/621#discussion_r1482260505) in a comment on #621:

> Note: My original idea from 5 years ago was that MF would use number skeletons and then become the specification that defines number skeletons since they are currently specified only in the ICU documentation.

This goaded me to write down some of the concepts floating around in my head about how to manage the registry going forwards.