### PR TITLE
Merge the unsupported-annotation sigil into its source in the data model

### DIFF
--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -236,15 +236,8 @@ interface Option {
 
 An `UnsupportedAnnotation` represents a
 _private-use annotation_ not supported by the implementation or a _reserved annotation_.
-The `sigil` corresponds to the starting sigil of the _annotation_.
-The `source` is the "raw" value (i.e. escape sequences are not processed)
-and does not include the starting `sigil`.
-
-> **Note**
-> Be aware that future versions of this specification
-> might assign meaning to _reserved annotation_ `sigil` values.
-> This would result in new interfaces being added to
-> this data model.
+The `source` is the "raw" value (i.e. escape sequences are not processed),
+including the starting sigil.
 
 When parsing the syntax of a _message_ that includes a _private-use annotation_
 supported by the implementation,
@@ -255,7 +248,6 @@ that the implementation attaches to that _annotation_.
 ```ts
 interface UnsupportedAnnotation {
   type: "unsupported-annotation";
-  sigil: "!" | "%" | "^" | "&" | "*" | "+" | "<" | ">" | "?" | "~";
   source: string;
 }
 ```

--- a/spec/data-model/message.dtd
+++ b/spec/data-model/message.dtd
@@ -41,7 +41,6 @@
 <!ATTLIST option name NMTOKEN #REQUIRED>
 
 <!ELEMENT unsupportedAnnotation (#PCDATA)>
-<!ATTLIST unsupportedAnnotation sigil CDATA #REQUIRED>
 
 <!ELEMENT attribute (literal | variable)?>
 <!ATTLIST attribute name NMTOKEN #REQUIRED>

--- a/spec/data-model/message.json
+++ b/spec/data-model/message.json
@@ -68,12 +68,9 @@
       "type": "object",
       "properties": {
         "type": { "const": "unsupported-annotation" },
-        "sigil": {
-          "enum": ["!", "#", "%", "^", "&", "*", "<", ">", "/", "?", "~"]
-        },
         "source": { "type": "string" }
       },
-      "required": ["type", "sigil", "source"]
+      "required": ["type", "source"]
     },
     "annotation": {
       "oneOf": [


### PR DESCRIPTION
Closes #652