### PR TITLE
Reduce strictness of datetime field options

### DIFF
--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -180,7 +180,8 @@ The function `:time` has these function-specific _style_ options:
 
 Field options describe which fields to include in the formatted output
 and what format to use for that field.
-Only those fields specified in the _annotation_ appear in the formatted output.
+The implementation may use this _annotation_ to configure which fields
+appear in the formatted output.
 
 > [!NOTE]
 > Field options do not have default values because they are only to be used


### PR DESCRIPTION
Unaddressed feedback from https://github.com/unicode-org/message-format-wg/pull/648#discussion_r1491319250:

> One of the features of semantic skeleta is preventing nonsensical skeletons like "hours and seconds" without minutes. Mapping from standard skeleta to semantic skeleta may fill in some of those missing fields. Even now, fields such as hour cycle and era may appear even if not in the skeleton. Therefore, it would be better to remove the second sentence giving any guarantees about which fields appear in the formatted output.