### PR TITLE
Rename simple-start to simple-begin

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -1,7 +1,7 @@
 message           = simple-message / complex-message
 
-simple-message    = [simple-start pattern]
-simple-start      = simple-start-char / text-escape / placeholder
+simple-message    = [simple-begin pattern]
+simple-begin      = simple-start / text-escape / placeholder
 pattern           = *(text-char / text-escape / placeholder)
 placeholder       = expression / markup
 
@@ -84,19 +84,19 @@ name-char  = name-start / DIGIT / "-" / "."
            / %xB7 / %x300-36F / %x203F-2040
 
 ; Restrictions on characters in various contexts
-simple-start-char = content-char / s / "@" / "|"
-text-char         = content-char / s / "." / "@" / "|"
-quoted-char       = content-char / s / "." / "@" / "{" / "}"
-reserved-char     = content-char / "."
-content-char      = %x00-08        ; omit HTAB (%x09) and LF (%x0A)
-                  / %x0B-0C        ; omit CR (%x0D)
-                  / %x0E-19        ; omit SP (%x20)
-                  / %x21-2D        ; omit . (%x2E)
-                  / %x2F-3F        ; omit @ (%x40)
-                  / %x41-5B        ; omit \ (%x5C)
-                  / %x5D-7A        ; omit { | } (%x7B-7D)
-                  / %x7E-D7FF      ; omit surrogates
-                  / %xE000-10FFFF
+simple-start  = content-char / s / "@" / "|"
+text-char     = content-char / s / "." / "@" / "|"
+quoted-char   = content-char / s / "." / "@" / "{" / "}"
+reserved-char = content-char / "."
+content-char  = %x00-08        ; omit HTAB (%x09) and LF (%x0A)
+              / %x0B-0C        ; omit CR (%x0D)
+              / %x0E-19        ; omit SP (%x20)
+              / %x21-2D        ; omit . (%x2E)
+              / %x2F-3F        ; omit @ (%x40)
+              / %x41-5B        ; omit \ (%x5C)
+              / %x5D-7A        ; omit { | } (%x7B-7D)
+              / %x7E-D7FF      ; omit surrogates
+              / %xE000-10FFFF
 
 ; Character escapes
 text-escape     = backslash ( backslash / "{" / "}" )


### PR DESCRIPTION
Our ABNF uses the following convention (or at last seems to be using it):

* names of productions which match single characters end with `-char`,
* names of a subset of such productions which define the first characters of longer tokens end with `-start`.

Hence, for example: `name-char` and `name-start`.

There is however a small inconsistency in how we use this convention: `simple-start` is not a terminal single-char production but instead is defined as:

```abnf
simple-start      = simple-start-char / text-escape / placeholder
```

`simple-start-char` is the only production in which we use `-start-char` in the name.

I'd like to fix this. I see two ways:

1. Rename all single-char `*-start` productions to `*-start-char`. This is more explicit and also follows [XML's precedent](https://www.w3.org/TR/REC-xml/#NT-Name), but produces longer production names, and requires changes to the ABNF in a few more places than option 2.
2. Rename `simple-start` to `simple-begin`, and `simple-start-char` to `simple-start`.

This PR proposes the second solution. If approved, I'll rebase on top of #657 and make corresponding changes to the rest of the spec.