### PR TITLE
Implement the default registry in the spec

### DIFF
--- a/spec/registry.md
+++ b/spec/registry.md
@@ -310,36 +310,17 @@ All other values produce a _Resolution Error_.
 
 ### Options
 
+Some options do not have default values defined in this specification.
+The defaults for these options are implementation-dependent.
+In general, the default values for such options depend on the locale, 
+the value of other options, or both.
+
 The following options and their values are required in the default registry to be available on the 
 function `:number`:
 - `select`
-   -  `plural` (default)
+   -  `plural` (default; see [Default Value of `select` Option](#default-value-of-select-option) below)
    -  `ordinal`
    -  `exact`
-
- 
-> [!IMPORTANT]
-> **Default Value of `select` Option**
->
-> The value `plural` is default for the option `select` 
-> because it is the most common use case for numeric selection.
-> It can be used for exact value matches but also allows for the grammatical needs of 
-> languages using CLDR's plural rules.
-> This might not be noticeable in the source language (particularly English), 
-> but can cause problems in target locales that the original developer is not considering.
->
-> For example, a naive developer might use a special message for the value `1` without
-> considering a locale's need for a `one` plural:
->
->```
-> .match {$var}
-> 1   {{You have one last chance}}
-> one {{You have {$var} chance remaining}} // needed by languages such as Polish or Russian
->                                          // such locales typically require other keywords
->                                          // such as two, few, many, and so forth
-> *   {{You have {$var} chances remaining}}
->```
-
 - `compactDisplay` (this option only has meaning when combined with the option `notation=compact`)
    - `short` (default)
    - `long`
@@ -367,11 +348,6 @@ function `:number`:
   - `min2`
 - `minimumIntegerDigits`
   - (non-negative integer, default: `1`)
-> [!NOTE]
-> The following options do not have default values because they are only to be used
-> as overrides for an existing locale-and-value dependent implementation-defined
-> default
-
 - `minimumFractionDigits`
   - (non-negative integer)
 - `maximumFractionDigits`
@@ -401,18 +377,10 @@ function `:integer`:
   - `percent` (see [Percent Style](#percent-style) below)
 - `useGrouping`
   - `auto` (default)
-  - `true`
-  - `false`
-  - `min2`
   - `always`
+  - `min2`
 - `minimumIntegerDigits`
   - (non-negative integer, default: `1`)
-
-> [!NOTE]
-> The following option does not have a default value because it is only to be used
-> as an override for an existing locale-and-value dependent implementation-defined
-> default
-
 - `maximumSignificantDigits`
   - (non-negative integer)
 
@@ -446,6 +414,26 @@ are encouraged to track development of these options during Tech Preview:
    - `long`
    - `short` (default)
    - `narrow`
+
+#### Default Value of `select` Option
+
+The value `plural` is default for the option `select` 
+because it is the most common use case for numeric selection.
+It can be used for exact value matches but also allows for the grammatical needs of 
+languages using CLDR's plural rules.
+This might not be noticeable in the source language (particularly English), 
+but can cause problems in target locales that the original developer is not considering.
+
+For example, a naive developer might use a special message for the value `1` without
+considering a locale's need for a `one` plural:
+```
+.match {$var}
+1   {{You have one last chance}}
+one {{You have {$var} chance remaining}} // needed by languages such as Polish or Russian
+                                         // such locales typically require other keywords
+                                         // such as two, few, many, and so forth
+*   {{You have {$var} chances remaining}}
+```
 
 #### Percent Style
 When implementing `style=percent`, the numeric value of the _operand_ 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -344,7 +344,7 @@ and formatting numeric values as integers.
 
 The _operand_ of a number function is either an implementation-defined type or
 a literal whose contents match the `number-literal` production in the [ABNF](/spec/message.abnf).
-All other values produce an _Invalid Expression Error_.
+All other values produce an _Invalid Expression_ error.
 
 > For example, in Java, any subclass of `java.lang.Number` plus the primitive
 > types (`byte`, `short`, `int`, `long`, `float`, `double`, etc.) 
@@ -645,7 +645,7 @@ If no options are specified, each of the functions defaults to the following:
 The _operand_ of a date/time function is either 
 an implementation-defined date/time type (passed in as an argument)
 or a _date/time literal value_, as defined below.
-All other _operand_ values produce a _Selection Error_.
+All other _operand_ values produce an _Invalid Expression_ error.
 
 A **_<dfn>date/time literal value</dfn>_** is a non-empty string consisting of 
 one of the following:

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -609,8 +609,8 @@ the two strings are equal.
 
 > [!NOTE]
 > Implementations are not expected to implement this exactly as written,
-as there are clearly optimizations that can be applied.
-However, the observed behavior must be consistent with what is described here.
+> as there are clearly optimizations that can be applied.
+> However, the observed behavior must be consistent with what is described here.
 
 > [!NOTE]
 > Only integer matching is required in the Technical Preview.

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -255,3 +255,502 @@ which only expects the `accord` option:
 > .input {$object :noun case=nominative}
 > {{You see {$color :adjective article=indefinite accord=$object} {$object}!}}
 >```
+
+# Default Registry for LDML45
+
+This section describes the functions which each implementation MUST provide to be conformant with
+the LDML45 Technical Preview of MessageFormat v2.
+
+## String Value Selection and Formatting
+
+(Pending)
+
+## Numeric Value Selection and Formatting
+
+### Functions
+
+The following functions use numeric selection:
+
+The function `:number` is the default selector for numeric values.
+
+The function `:integer` provides a reduced set of options for selecting
+and formatting numeric values as integers.
+
+### Operands
+
+The _operand_ of a number function is either an implementation-defined type or
+a literal that matches the `number-literal` production in the [ABNF](/main/spec/message.abnf).
+All other values produce a _Selection Error_ when evaluated for selection
+or a _Formatting Error_ when attempting to format the value.
+
+> For example, in Java, any subclass of `java.lang.Number` plus the primitive
+> types (`byte`, `short`, `int`, `long`, `float`, `double`, etc.) 
+> might be considered as the "implementation-defined numeric types".
+> Implementations in other programming languages would define different types
+> or classes according to their local needs.
+
+> [!NOTE]
+> String values passed as variables in the _formatting context_'s
+> _input mapping_ can be formatted as numeric values as long as their
+> contents match the `number-literal` production in the [ABNF](/main/spec/message.abnf).
+>
+> For example, if the value of the variable `num` were the string
+> `-1234.567`, it would behave identically to the local
+> variable in this example:
+> ```
+> .local $example = {|-1234.567| :number}
+> {{{$num :number} == {$example}}}
+> ```
+
+> [!NOTE]
+> Implementations are encouraged to provide support for compound types or data structures
+> that provide additional semantic meaning to the formatting of number-like values.
+> For example, in ICU4J, the type `com.ibm.icu.util.Measure` can be used to communicate
+> a value that include a unit
+> or the type `com.ibm.icu.util.CurrencyAmount` can be used to set the currency and related
+> options (such as the number of fraction digits).
+
+
+### Options
+
+The following options and their values are required in the default registry to be available on the 
+function `:number`:
+- `select`
+   -  `plural` (default)
+   -  `ordinal`
+   -  `exact`
+
+ 
+> [!IMPORTANT]
+> **Default Value of `select` Option**
+>
+> The value `plural` is default for the option `select` 
+> because it is the most common use case for numeric selection.
+> It can be used for exact value matches but also allows for the grammatical needs of other 
+> languages using CLDR's plural rules.
+> This might not be noticeable in the source language (particularly English), 
+> but can cause problems in target locales that the original developer is not considering.
+>
+> > For example, a naive developer might use a special message for the value `1` without
+> > considering other locale's need for a `one` plural:
+> >
+> >```
+> > .match {$var}
+> > 1   {{You have one last chance}}
+> > one {{You have {$var} chance remaining}} // needed by languages such as Polish or Russian
+> >                                          // such locales typically require other keywords
+> >                                          // such as two, few, many, and so forth
+> > *   {{You have {$var} chances remaining}}
+> >```
+
+- `compactDisplay` // this option only has meaning when combined with the option `notation=compact`
+   - `short` (default)
+   - `long`
+- `notation`
+   - `standard` (default)
+   - `scientific`
+   - `engineering`
+   - `compact`
+- `numberingSystem`
+   - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+     (default is locale-specific)
+- `signDisplay`
+   -  `auto` (default)
+   -  `always`
+   -  `exceptZero`
+   -  `negative`
+   -  `never`
+- `style`
+  - `decimal` (default)
+  - `percent` (see [Percent Style](#percent-style) below)
+- `useGrouping`
+  - `auto` (default)
+  - `always`
+  - `never`
+  - `min2`
+- `minimumIntegerDigits`
+  - (non-negative integer, default: `1`)
+  - 
+> [!NOTE]
+> The following options do not have default values because they are only to be used
+> as overrides for an existing locale-and-value dependent implementation-defined
+> default
+
+- `minimumFractionDigits`
+  - (non-negative integer)
+- `maximumFractionDigits`
+  - (non-negative integer)
+- `minimumSignificantDigits`
+  - (non-negative integer)
+- `maximumSignificantDigits`
+  - (non-negative integer)
+
+The following options and their values are required in the default registry to be available on the 
+function `:integer`:
+- `select`
+   -  `plural` (default)
+   -  `ordinal`
+   -  `exact`
+- `numberingSystem`
+   - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+     (default is locale-specific)
+- `signDisplay`
+   -  `auto` (default)
+   -  `always`
+   -  `exceptZero`
+   -  `negative`
+   -  `never`
+- `style`
+  - `decimal` (default)
+  - `percent` (see [Percent Style](#percent-style) below)
+- `useGrouping`
+  - `auto` (default)
+  - `true`
+  - `false`
+  - `min2`
+  - `always`
+- `minimumIntegerDigits`
+  - (non-negative integer, default: `1`)
+
+> [!NOTE]
+> The following option does not have a default value because it is only to be used
+> as an override for an existing locale-and-value dependent implementation-defined
+> default
+
+- `maximumSignificantDigits`
+  - (non-negative integer)
+
+> [!NOTE]
+> The following options or option values are being developed during the Technical Preview
+> period.
+
+The following values for the option `style` are _not_ part of the default registry.
+Implementations SHOULD avoid creating options that conflict with these, but
+are encouraged to track development of these options during Tech Preview:
+- `currency`
+- `unit`
+
+The following options are _not_ part of the default registry.
+Implementations SHOULD avoid creating options that conflict with these, but
+are encouraged to track development of these options during Tech Preview:
+- `currency`
+   - valid [Unicode Currency Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCurrencyIdentifier)
+     (no default)
+- `currencyDisplay`
+   - `symbol` (default)
+   - `narrowSymbol`
+   - `code`
+   - `name`
+- `currencySign`
+  - `accounting`
+  - `standard` (default)
+- `unit`
+   - (anything not empty)
+- `unitDisplay`
+   - `long`
+   - `short` (default)
+   - `narrow`
+
+### Percent Style
+When implementing `style=percent`, the numeric value of the _operand_ 
+MUST be divided by 100 for the purposes of formatting.
+
+> For example,
+> `The total was {|100| :number style=percent}.` should format
+> in a manner similar to:
+> > The total was 1%.
+
+### Selection
+
+Number selection has three modes:
+- `exact` selection matches the operand to explicit numeric keys exactly
+- `plural` selection matches the operand to explicit numeric keys exactly
+  or to plural rule categories if there is no explicit match
+- `ordinal` selection matches the operand to explicit numeric keys exactly
+  or to ordinal rule categories if there is no explicit match
+
+When implementing [`MatchSelectorKeys`](spec/formatting.md#resolve-preferences), 
+numeric selectors perform as described below.
+
+- Let `return_value` be a new empty list of strings.
+- Let `operand` be the resolved value of the _operand_.
+  If the `operand` is not a number type, emit a _Selection Error_
+  and return `return_value`.
+- Let `keys` be a list of strings containing keys to match.
+  (Hint: this list is an argument to `MatchSelectorKeys`)
+- For each string `key` in `keys`:
+   - If the value of `key` matches the production `number-literal`:
+     - If the parsed value of `key` is an [exact match](#determining-exact-literal-match)
+       of the value of the `operand`, then `key` matches the selector.
+       Add `key` to the front of the `return_value` list.
+   - Else, if the value of `key` is a keyword:
+      - Let `keyword` be a string which is the result of [rule selection](#rule-selection).
+      - If `keyword` equals `key`, then `key` matches the selector.
+        Append `key` to the end of the `return_value` list.
+   - Else, `key` is invalid;
+     emit a _Selection Error_.
+     Do not add `key` to `return_value`
+- Return `return_value`
+
+### Plural/Ordinal Keywords
+The _plural/ordinal keywords_ are: `zero`, `one`, `two`, `few`, `many`, and
+`other`.
+
+### Rule Selection
+
+If the option `select` is set to `exact`, rule-based selection is not used.
+Return the empty string.
+
+> [!NOTE]
+> Since keys cannot be the empty string in a numeric selector, returning the
+> empty string disables keyword selection
+
+If the option `select` is set to `plural`, selection should be based on CLDR plural rule data
+of type `cardinal`. See [charts](https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html)
+for examples.
+
+If the option `select` is set to `ordinal`, selection should be based on CLDR plural rule data
+of type `ordinal`. See [charts](https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html)
+for examples.
+
+Apply the rules defined by CLDR to the resolved value of the operand and the function options,
+and return the resulting keyword.
+If no rules match, return `other`.
+
+> **Example.**
+> In CLDR 44, the Czech (`cs`) plural rule set can be found
+> [here](https://www.unicode.org/cldr/charts/44/supplemental/language_plural_rules.html#cs).
+>
+> A message in Czech might be:
+> ```
+> .match {$numDays :number}
+> one  {{{$numDays} den}}
+> few  {{{$numDays} dny}}
+> many {{{$numDays} dne}}
+> *    {{{$numDays} dní}}
+> ```
+> Using the rules found above, the results of various `operand` values might look like:
+> | Operand value | Keyword | Formatted Message |
+> |---|---|---|
+> | 1 | `one` | 1 den |
+> | 2 | `few` | 2 dny |
+> | 5 | `other` | 5 dní |
+> | 22 | `few` | 22 dny |
+> | 27 | `other` | 27 dní |
+> | 2.4 | `many` | 2,4 dne |
+
+### Determining Exact Literal Match
+
+> [!IMPORTANT]
+> The exact behavior of exact literal match is only defined for non-zero-filled
+> integer values.
+> Annotations that use fraction digits or significant digits might work in specific
+> implementation-defined ways.
+> Users should avoid depending on these types of keys in message selection.
+
+
+Number literals in the MessageFormat 2 syntax use the 
+[format defined for a JSON number](https://www.rfc-editor.org/rfc/rfc8259#section-6).
+The resolved value of an `operand` exactly matches a numeric literal `key`
+if, when the `operand` is serialized using the format for a JSON number
+the two strings are equal.
+
+> [!NOTE]
+> Implementations are not expected to implement this exactly as written,
+> as there are clearly optimizations that can be applied.
+
+> [!NOTE]
+> Only integer matching is required in the Technical Preview.
+> Feedback describing use cases for fractional and significant digits-based
+> selection would be helpful.
+> Otherwise, users should avoid using matching with fractional numbers or significant digits.
+
+## Date and Time Value Formatting
+
+This subsection describes the functions and options for date/time formatting.
+Selection based on date and time values is not required in this release.
+
+#### Functions
+
+Functions for formatting [date/time values](#operands) in the default registry are:
+
+- `:datetime`
+- `:date`
+- `:time`
+
+If no options are specified, each of the functions defaults to the following:
+- `{$d :datetime}` is the same as `{$d :datetime dateStyle=short timeStyle=short}`
+- `{$d :date}` is the same as `{$d :date style=short}`
+- `{$t :time}` is the same as `{$t :time style=short}`
+
+> [!NOTE]
+> Pattern selection based on date/time values is a complex topic and no support for this
+> is required in this release.
+
+> [!NOTE]
+> The default formatting behavior of `:datetime` is inconsistent with `Intl.DateTimeFormat`
+> in JavaScript and with `{d,date}` in MessageFormat v1.
+> This is because, unlike those implementations, `:datetime` is distinct from `:date` and `:time`.
+
+#### Operands
+
+The _operand_ of a date/time function is either 
+an implementation-defined date/time type (passed in as an argument)
+or a _date/time literal value_, as defined below.
+All other _operand_ values produce a _Selection Error_ when evaluated for selection
+or a _Formatting Error_ when formatting the value.
+
+A **_<dfn>date/time literal value</dfn>_** is a non-empty string consisting of 
+one of the following:
+- an XMLSchema 1.1 [dateTime](https://www.w3.org/TR/xmlschema11-2/#dateTime)
+- an XMLSchema 1.1 [time](https://www.w3.org/TR/xmlschema11-2/#time)
+- an XMLSchema 1.1 [date](https://www.w3.org/TR/xmlschema11-2/#date)
+
+The `timezoneOffset` of each of these formats is optional. 
+When the offset is not present, implementations should use a floating time type
+(such as Java's `java.time.LocalDateTime`) to represent the time value.
+For more information, see [Working with Timezones](https://w3c.github.io/timezone).
+
+> [!IMPORTANT]
+> The [ABNF](/spec/message.abnf) and [syntax](/spec/syntax.md) of MFv2
+> do not formally define date/time literals. 
+> This means that a _message_ can be syntactically valid but produce
+> an _Operand Mismatch Error_ at runtime.
+
+> [!NOTE]
+> String values passed as variables in the _formatting context_'s
+> _input mapping_ can be formatted as date/time values as long as their
+> contents are date/time literals.
+>
+> For example, if the value of the variable `now` were the string
+> `2024-02-06T16:40:00Z`, it would behave identically to the local
+> variable in this example:
+> ```
+> .local $example = {|2024-02-06T16:40:00Z| :datetime}
+> {{{$now :datetime} == {$example}}}
+> ```
+
+> [!NOTE]
+> True time zone support in serializations is expected to coincide with the adoption
+> of Temporal in JavaScript.
+> The form of these serializations is known and is a de facto standard.
+> Support for these extensions is expected to be required in the post-tech preview.
+> See: https://datatracker.ietf.org/doc/draft-ietf-sedate-datetime-extended/
+
+#### Options
+
+A function can use either the appropriate _style_ options for that function
+or can use a collection of _field options_ (but not both) to control the formatted 
+output.
+
+If both are specified, an _Invalid Expression_ error MUST be emitted
+and a _fallback value_ used as the resolved value of the _expression_.
+
+##### Style Options
+
+The function `:datetime` has these function-specific _style_ options.
+- `dateStyle`
+  - `full`
+  - `long`
+  - `medium`
+  - `short`
+- `timeStyle`
+  - `full`
+  - `long`
+  - `medium`
+  - `short`
+
+The function `:date` has these function-specific _style_ options:
+- `style`
+  - `full`
+  - `long`
+  - `medium`
+  - `short` (default)
+
+The function `:time` has these function-specific _style_ options:
+- `style`
+  - `full`
+  - `long`
+  - `medium`
+  - `short` (default)
+
+##### Field Options
+
+Field options describe which fields to include in the formatted output
+and what format to use for that field.
+The implementation may use this _annotation_ to configure which fields
+appear in the formatted output.
+
+> [!NOTE]
+> Field options do not have default values because they are only to be used
+> to compose the formatter.
+
+The _field_ options are defined as follows:
+
+The function `:datetime` has the following options:
+- `weekday`
+  - `long`
+  - `short`
+  - `narrow`
+- `era`
+  - `long`
+  - `short`
+  - `narrow`
+- `year`
+  - `numeric`
+  - `2-digit`
+- `month`
+  - `numeric`
+  - `2-digit`
+  - `long`
+  - `short`
+  - `narrow`
+- `day`
+  - `numeric`
+  - `2-digit`
+- `hour`
+  - `numeric`
+  - `2-digit`
+- `minute`
+  - `numeric`
+  - `2-digit`
+- `second`
+  - `numeric`
+  - `2-digit`
+- `fractionalSecondDigits`
+  - `1`
+  - `2`
+  - `3`
+- `hourCycle` (default is locale-specific)
+  - `h11`
+  - `h12`
+  - `h23`
+  - `h24`
+- `timeZoneName`
+  - `long`
+  - `short`
+  - `shortOffset`
+  - `longOffset`
+  - `shortGeneric`
+  - `longGeneric`
+
+> [!NOTE]
+> The following options do not have default values because they are only to be used
+> as overrides for locale-and-value dependent implementation-defined defaults.
+
+The followind date/time options are *not* part of the default registry.
+Implementations SHOULD avoid creating options that conflict with these, but
+are encouraged to track development of these options during Tech Preview:
+- `calendar` (default is locale-specific)
+  - valid [Unicode Calendar Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCalendarIdentifier)
+- `numberingSystem` (default is locale-specific)
+   - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+- `timeZone` (default is system default time zone or UTC)
+  - valid identifier per [BCP175](https://www.rfc-editor.org/rfc/rfc6557)
+
+#### Selection
+
+Selection based on date/time types is not required by MFv2.
+Implementations should use care when defining selectors based on date/time types.
+The types of queries found in implementations such as `java.time.TemporalAccessor`
+are complex and user expectations may be inconsistent with good I18N practices.

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -588,7 +588,7 @@ If no options are specified, each of the functions defaults to the following:
 > in JavaScript and with `{d,date}` in ICU MessageFormat 1.0.
 > This is because, unlike those implementations, `:datetime` is distinct from `:date` and `:time`.
 
-#### Operands
+### Operands
 
 The _operand_ of a date/time function is either 
 an implementation-defined date/time type (passed in as an argument)

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -366,7 +366,7 @@ All other values produce an _Invalid Expression_ error.
 > [!NOTE]
 > String values passed as variables in the _formatting context_'s
 > _input mapping_ can be formatted as numeric values as long as their
-> contents match the `number-literal` production in the [ABNF](/main/spec/message.abnf).
+> contents match the `number-literal` production in the [ABNF](/spec/message.abnf).
 >
 > For example, if the value of the variable `num` were the string
 > `-1234.567`, it would behave identically to the local

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -326,6 +326,10 @@ the result of converting `operand` to a string literal.
 > in each string.
 > As a result, variations in how text can be encoded can affect the performance of matching.
 > The function `:string` does not perform case folding or Unicode Normalization of string values.
+> Users SHOULD encode _messages_ and their parts (such as _keys_ and _operands_),
+> in Unicode Normalization Form C (NFC) unless there is a very good reason
+> not to.
+> See also: [String Matching](https://www.w3.org/TR/charmod-norm)
 
 > [!NOTE]
 > Unquoted string literals in a _variant_ do not include spaces.

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -303,26 +303,20 @@ The function `:string` has no options.
 
 ### Selection
 
-When implementing [`MatchSelectorKeys(rv, keys)`](spec/formatting.md#resolve-preferences), 
+When implementing [`MatchSelectorKeys(resolvedSelector, keys)`](/spec/formatting.md#resolve-preferences)
+where `resolvedSelector` is the resolved value of a _selector_ _expression_
+and `keys` is a list of strings,
 the `:string` selector performs as described below.
 
-- Let `return_value` be a new empty list of strings.
-- Let `operand` be _rv_.
-If `operand` is not a string literal, let `operand` be
-the result of converting `operand` to a string literal.
-  or, optionally: emit a _Selection Error_ and return `return_value`.
-- Let `keys` be a list of strings containing keys to match.
-  (Hint: this list is an argument to `MatchSelectorKeys`)
-- For each string `key` in `keys`:
-   - If the value of `key` is equal to the string value of `operand`
-     then `key` matches the selector.
-     A `key` and an `operand` are equal if they consist of the same
-     sequence of Unicode code points.
-     Add `key` to the front of the `return_value` list.
-- Return `return_value`.
+1. Let `compare` be the string value of `resolvedSelector`.
+1. Let `result` be a new empty list of strings.
+1. For each string `key` in `keys`:
+   1. If `key` and `compare` consist of the same sequence of Unicode code points, then
+      1. Append `key` as the last element of the list `result`.
+1. Return `result`.
 
 > [!NOTE]
-> Matching of `key` and `operand` values is sensitive to the sequence of code points
+> Matching of `key` and `compare` values is sensitive to the sequence of code points
 > in each string.
 > As a result, variations in how text can be encoded can affect the performance of matching.
 > The function `:string` does not perform case folding or Unicode Normalization of string values.

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -555,7 +555,7 @@ Return the empty string.
 
 > [!NOTE]
 > Since keys cannot be the empty string in a numeric selector, returning the
-> empty string disables keyword selection
+> empty string disables keyword selection.
 
 If the option `select` is set to `plural`, selection should be based on CLDR plural rule data
 of type `cardinal`. See [charts](https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html)

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -278,8 +278,7 @@ and formatting numeric values as integers.
 
 The _operand_ of a number function is either an implementation-defined type or
 a literal that matches the `number-literal` production in the [ABNF](/spec/message.abnf).
-All other values produce a _Selection Error_ when evaluated for selection
-or a _Formatting Error_ when attempting to format the value.
+All other values produce a _Resolution Error_.
 
 > For example, in Java, any subclass of `java.lang.Number` plus the primitive
 > types (`byte`, `short`, `int`, `long`, `float`, `double`, etc.) 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -258,8 +258,8 @@ which only expects the `accord` option:
 
 # Default Registry
 
-This section describes the functions which each implementation MUST provide to be conformant with
-this specification.
+This section describes the functions which each implementation MUST provide
+to be conformant with this specification.
 
 ## String Value Selection and Formatting
 
@@ -290,12 +290,13 @@ The function `:string` has no options.
 
 ### Selection
 
-When implementing [`MatchSelectorKeys`](spec/formatting.md#resolve-preferences), 
+When implementing [`MatchSelectorKeys(rv, keys)`](spec/formatting.md#resolve-preferences), 
 the `:string` selector performs as described below.
 
 - Let `return_value` be a new empty list of strings.
-- Let `operand` be the resolved value of the _operand_.
-  If the `operand` is not a string literal, convert the value to a string literal,
+- Let `operand` be _rv_.
+If `operand` is not a string literal, let `operand` be
+the result of converting `operand` to a string literal.
   or, optionally: emit a _Selection Error_ and return `return_value`.
 - Let `keys` be a list of strings containing keys to match.
   (Hint: this list is an argument to `MatchSelectorKeys`)
@@ -305,7 +306,7 @@ the `:string` selector performs as described below.
      A `key` and an `operand` are equal if they consist of the same
      sequence of Unicode code points.
      Add `key` to the front of the `return_value` list.
-- Return `return_value`
+- Return `return_value`.
 
 > [!NOTE]
 > Matching of `key` and `operand` values is sensitive to the sequence of code points
@@ -343,7 +344,7 @@ and formatting numeric values as integers.
 
 The _operand_ of a number function is either an implementation-defined type or
 a literal whose contents match the `number-literal` production in the [ABNF](/spec/message.abnf).
-All other values produce a _Resolution Error_.
+All other values produce an _Invalid Expression Error_.
 
 > For example, in Java, any subclass of `java.lang.Number` plus the primitive
 > types (`byte`, `short`, `int`, `long`, `float`, `double`, etc.) 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -271,27 +271,15 @@ The function `:string` provides string selection and formatting.
 
 ### Operands
 
-The _operand_ is any _literal_ value
-or an implementation-defined set of string or character-sequence types.
-The value of a _literal_ does not include any quotes around the _literal_ and 
-has converted any `quoted-escape` sequences to the escaped characters.
-It does include any enclosed spaces or control characters.
+The _operand_ of `:string` is either any implementation-defined type
+that is a string or for which conversion to a string is supported,
+or any _literal_ value.
+All other values produce an _Invalid Expression_ error.
 
-> Examples of _literals_ and their values:
-> | Literal | Value | Notes |
-> |---|---|---|
-> | \|1\| | `1` | Does not include quotes `\|` |
-> | \|ab\\\|cd\| | `ab\|cd` | Unescape escaped `\|` |
-> | hello | `hello` | Unquoted literal |
-> | -13.2 | `-13.2` | Unquoted number-literal |
-> | \| spaces \| | ` spaces ` | Includes one space before and after |
-
-
-> [!NOTE]
-> This should probably include individual character types, such as `char`.
-
-In addition, implementations MAY perform formatting and selection on 
-`operand` values that do not otherwise have a formatting function registered.
+> For example, in Java, any subclass of `java.lang.String` plus the primitive
+> type `char` might be considered as the "implementation-defined type".
+> Implementations in other programming languages would define different types
+> or classes according to their local needs.
 
 ### Options
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -483,7 +483,7 @@ are encouraged to track development of these options during Tech Preview:
 
 #### Default Value of `select` Option
 
-The value `plural` is default for the option `select` 
+The value `plural` is the default for the option `select` 
 because it is the most common use case for numeric selection.
 It can be used for exact value matches but also allows for the grammatical needs of 
 languages using CLDR's plural rules.
@@ -542,7 +542,7 @@ numeric selectors perform as described below.
    - Else, `key` is invalid;
      emit a _Selection Error_.
      Do not add `key` to `return_value`.
-- Return `return_value`
+- Return `return_value`.
 
 #### Plural/Ordinal Keywords
 The _plural/ordinal keywords_ are: `zero`, `one`, `two`, `few`, `many`, and
@@ -609,7 +609,8 @@ the two strings are equal.
 
 > [!NOTE]
 > Implementations are not expected to implement this exactly as written,
-> as there are clearly optimizations that can be applied.
+as there are clearly optimizations that can be applied.
+However, the observed behavior must be consistent with what is described here.
 
 > [!NOTE]
 > Only integer matching is required in the Technical Preview.

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -332,11 +332,11 @@ the `:string` selector performs as described below.
 > to a key, the `key` needs to be quoted.
 >
 > For example:
->```
+> ```
 > .match {$string :string}
 > | space key | {{Matches the string " space key "}}
 > *             {{Matches the string "space key"}}
->```
+> ```
 
 ### Formatting
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -735,16 +735,16 @@ The function `:time` has these function-specific _options_ for _style_:
 
 #### Field Options
 
-Field options describe which fields to include in the formatted output
+_Field options_ describe which fields to include in the formatted output
 and what format to use for that field.
 The implementation may use this _annotation_ to configure which fields
 appear in the formatted output.
 
 > [!NOTE]
-> Field options do not have default values because they are only to be used
+> _Field options_ do not have default values because they are only to be used
 > to compose the formatter.
 
-The _field_ options are defined as follows:
+The _field options_ are defined as follows:
 
 The function `:datetime` has the following options:
 - `weekday`

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -276,10 +276,16 @@ that is a string or for which conversion to a string is supported,
 or any _literal_ value.
 All other values produce an _Invalid Expression_ error.
 
-> For example, in Java, any subclass of `java.lang.String` plus the primitive
-> type `char` might be considered as the "implementation-defined type".
-> Implementations in other programming languages would define different types
-> or classes according to their local needs.
+> For example, in Java, implementations of the `java.lang.CharSequence` interface
+> (such as `java.lang.String` or `java.lang.StringBuilder`),
+> the type `char`, or the class `java.lang.Character` might be considered
+> as the "implementation-defined types".
+> Such an implementation might also support other classes via the method `toString()`.
+> This might be used to enable selection of a `enum` value by name, for example.
+>
+> Other programming languages would define string and character sequence types or
+> classes according to their local needs, including, where appropriate,
+> coercion to string.
 
 ### Options
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -541,7 +541,7 @@ numeric selectors perform as described below.
         Append `key` to the end of the `return_value` list.
    - Else, `key` is invalid;
      emit a _Selection Error_.
-     Do not add `key` to `return_value`
+     Do not add `key` to `return_value`.
 - Return `return_value`
 
 #### Plural/Ordinal Keywords

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -271,8 +271,21 @@ The function `:string` provides string selection and formatting.
 
 ### Operands
 
-The _operand_ is any literal or an implementation-defined set of string or
-character-sequence types.
+The _operand_ is any _literal_ value
+or an implementation-defined set of string or character-sequence types.
+The value of a _literal_ does not include any quotes around the _literal_ and 
+has converted any `quoted-escape` sequences to the escaped characters.
+It does include any enclosed spaces or control characters.
+
+> Examples of _literals_ and their values:
+> | Literal | Value | Notes |
+> |---|---|---|
+> | \|1\| | `1` | Does not include quotes `\|` |
+> | \|ab\\\|cd\| | `ab\|cd` | Unescape escaped `\|` |
+> | hello | `hello` | Unquoted literal |
+> | -13.2 | `-13.2` | Unquoted number-literal |
+> | \| spaces \| | ` spaces ` | Includes one space before and after |
+
 
 > [!NOTE]
 > This should probably include individual character types, such as `char`.

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -726,7 +726,7 @@ The function `:date` has these function-specific _style_ options:
   - `medium`
   - `short` (default)
 
-The function `:time` has these function-specific _style_ options:
+The function `:time` has these function-specific _options_ for _style_:
 - `style`
   - `full`
   - `long`

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -719,7 +719,7 @@ The function `:date` has these function-specific _style options_:
   - `medium`
   - `short` (default)
 
-The function `:time` has these function-specific _options_ for _style_:
+The function `:time` has these function-specific _style options_:
 - `style`
   - `full`
   - `long`

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -449,12 +449,14 @@ are encouraged to track development of these options during Tech Preview:
 
 ### Percent Style
 When implementing `style=percent`, the numeric value of the _operand_ 
-MUST be divided by 100 for the purposes of formatting.
+MUST be multiplied by 100 for the purposes of formatting.
 
 > For example,
-> `The total was {|100| :number style=percent}.` should format
-> in a manner similar to:
-> > The total was 1%.
+> ```
+> The total was {0.5 :number style=percent}.
+> ```
+> should format in a manner similar to:
+> > The total was 50%.
 
 ### Selection
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -346,7 +346,7 @@ The `:string` function returns the string value of the resolved value of the _op
 
 ### Functions
 
-The function `:number` is the default selector and formatter for numeric values.
+The function `:number` is a selector and formatter for numeric values.
 
 The function `:integer` provides a reduced set of options for selecting
 and formatting numeric values as integers.

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -447,7 +447,7 @@ are encouraged to track development of these options during Tech Preview:
    - `short` (default)
    - `narrow`
 
-### Percent Style
+#### Percent Style
 When implementing `style=percent`, the numeric value of the _operand_ 
 MUST be multiplied by 100 for the purposes of formatting.
 
@@ -490,7 +490,7 @@ numeric selectors perform as described below.
      Do not add `key` to `return_value`
 - Return `return_value`
 
-### Plural/Ordinal Keywords
+#### Plural/Ordinal Keywords
 The _plural/ordinal keywords_ are: `zero`, `one`, `two`, `few`, `many`, and
 `other`.
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -535,7 +535,7 @@ If no rules match, return `other`.
 > | 27 | `other` | 27 dní |
 > | 2.4 | `many` | 2,4 dne |
 
-### Determining Exact Literal Match
+#### Determining Exact Literal Match
 
 > [!IMPORTANT]
 > The exact behavior of exact literal match is only defined for non-zero-filled

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -59,7 +59,7 @@ tailored versions of the registry for consumption by tools
 and to encourage any add-on or plug-in functionality to provide
 a registry to support localization tooling.
 
-## Data Model
+## Registry Data Model
 
 _This section is non-normative._
 
@@ -263,7 +263,72 @@ this specification.
 
 ## String Value Selection and Formatting
 
-(Pending)
+### Functions
+
+The following functions are provided:
+
+The function `:string` provides string selection and formatting.
+
+### Operands
+
+The _operand_ is any literal or an implementation-defined set of string or
+character-sequence types.
+
+> [!NOTE]
+> This should probably include individual character types, such as `char`.
+
+In addition, implementations MAY perform formatting and selection on 
+`operand` values that do not otherwise have a formatting function registered.
+
+### Options
+
+The function `:string` has no options.
+
+> [!NOTE]
+> Proposals for string transformation options or implementation
+> experience with user requirements is desired during the Tech Preview.
+
+### Selection
+
+When implementing [`MatchSelectorKeys`](spec/formatting.md#resolve-preferences), 
+the `:string` selector performs as described below.
+
+- Let `return_value` be a new empty list of strings.
+- Let `operand` be the resolved value of the _operand_.
+  If the `operand` is not a string literal, convert the value to a string literal,
+  or, optionally: emit a _Selection Error_ and return `return_value`.
+- Let `keys` be a list of strings containing keys to match.
+  (Hint: this list is an argument to `MatchSelectorKeys`)
+- For each string `key` in `keys`:
+   - If the value of `key` is equal to the string value of `operand`
+     then `key` matches the selector.
+     A `key` and an `operand` are equal if they consist of the same
+     sequence of Unicode code points.
+     Add `key` to the front of the `return_value` list.
+- Return `return_value`
+
+> [!NOTE]
+> Matching of `key` and `operand` values is sensitive to the sequence of code points
+> in each string.
+> As a result, variations in how text can be encoded can affect the performance of matching.
+> The function `:string` does not perform case folding or Unicode Normalization of string values.
+
+> [!NOTE]
+> Unquoted string literals in a _variant_ do not include spaces.
+> If users wish to match strings that include whitespace
+> (including U+3000 `IDEOGRAPHIC SPACE`)
+> to a key, the `key` needs to be quoted.
+>
+> For example:
+>```
+> .match {$string :string}
+> | space key | {{Matches the string " space key "}}
+> *             {{Matches the string "space key"}}
+>```
+
+### Formatting
+
+The `:string` function returns the string value of the resolved value of the _operand_.
 
 ## Numeric Value Selection and Formatting
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -277,7 +277,7 @@ and formatting numeric values as integers.
 ### Operands
 
 The _operand_ of a number function is either an implementation-defined type or
-a literal that matches the `number-literal` production in the [ABNF](/spec/message.abnf).
+a literal whose contents match the `number-literal` production in the [ABNF](/spec/message.abnf).
 All other values produce a _Resolution Error_.
 
 > For example, in Java, any subclass of `java.lang.Number` plus the primitive
@@ -303,7 +303,7 @@ All other values produce a _Resolution Error_.
 > Implementations are encouraged to provide support for compound types or data structures
 > that provide additional semantic meaning to the formatting of number-like values.
 > For example, in ICU4J, the type `com.ibm.icu.util.Measure` can be used to communicate
-> a value that include a unit
+> a value that includes a unit
 > or the type `com.ibm.icu.util.CurrencyAmount` can be used to set the currency and related
 > options (such as the number of fraction digits).
 
@@ -323,13 +323,13 @@ function `:number`:
 >
 > The value `plural` is default for the option `select` 
 > because it is the most common use case for numeric selection.
-> It can be used for exact value matches but also allows for the grammatical needs of other 
+> It can be used for exact value matches but also allows for the grammatical needs of 
 > languages using CLDR's plural rules.
 > This might not be noticeable in the source language (particularly English), 
 > but can cause problems in target locales that the original developer is not considering.
 >
 > For example, a naive developer might use a special message for the value `1` without
-> considering other locale's need for a `one` plural:
+> considering a locale's need for a `one` plural:
 >
 >```
 > .match {$var}
@@ -550,7 +550,7 @@ If no rules match, return `other`.
 Number literals in the MessageFormat 2 syntax use the 
 [format defined for a JSON number](https://www.rfc-editor.org/rfc/rfc8259#section-6).
 The resolved value of an `operand` exactly matches a numeric literal `key`
-if, when the `operand` is serialized using the format for a JSON number
+if, when the `operand` is serialized using the format for a JSON number,
 the two strings are equal.
 
 > [!NOTE]
@@ -582,10 +582,6 @@ If no options are specified, each of the functions defaults to the following:
 - `{$t :time}` is the same as `{$t :time style=short}`
 
 > [!NOTE]
-> Pattern selection based on date/time values is a complex topic and no support for this
-> is required in this release.
-
-> [!NOTE]
 > The default formatting behavior of `:datetime` is inconsistent with `Intl.DateTimeFormat`
 > in JavaScript and with `{d,date}` in ICU MessageFormat 1.0.
 > This is because, unlike those implementations, `:datetime` is distinct from `:date` and `:time`.
@@ -595,8 +591,7 @@ If no options are specified, each of the functions defaults to the following:
 The _operand_ of a date/time function is either 
 an implementation-defined date/time type (passed in as an argument)
 or a _date/time literal value_, as defined below.
-All other _operand_ values produce a _Selection Error_ when evaluated for selection
-or a _Formatting Error_ when formatting the value.
+All other _operand_ values produce a _Selection Error_.
 
 A **_<dfn>date/time literal value</dfn>_** is a non-empty string consisting of 
 one of the following:

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -256,10 +256,10 @@ which only expects the `accord` option:
 > {{You see {$color :adjective article=indefinite accord=$object} {$object}!}}
 >```
 
-# Default Registry for LDML45
+# Default Registry
 
 This section describes the functions which each implementation MUST provide to be conformant with
-the LDML45 Technical Preview of MessageFormat v2.
+this specification.
 
 ## String Value Selection and Formatting
 
@@ -269,9 +269,7 @@ the LDML45 Technical Preview of MessageFormat v2.
 
 ### Functions
 
-The following functions use numeric selection:
-
-The function `:number` is the default selector for numeric values.
+The function `:number` is the default selector and formatter for numeric values.
 
 The function `:integer` provides a reduced set of options for selecting
 and formatting numeric values as integers.
@@ -279,7 +277,7 @@ and formatting numeric values as integers.
 ### Operands
 
 The _operand_ of a number function is either an implementation-defined type or
-a literal that matches the `number-literal` production in the [ABNF](/main/spec/message.abnf).
+a literal that matches the `number-literal` production in the [ABNF](/spec/message.abnf).
 All other values produce a _Selection Error_ when evaluated for selection
 or a _Formatting Error_ when attempting to format the value.
 
@@ -331,19 +329,19 @@ function `:number`:
 > This might not be noticeable in the source language (particularly English), 
 > but can cause problems in target locales that the original developer is not considering.
 >
-> > For example, a naive developer might use a special message for the value `1` without
-> > considering other locale's need for a `one` plural:
-> >
-> >```
-> > .match {$var}
-> > 1   {{You have one last chance}}
-> > one {{You have {$var} chance remaining}} // needed by languages such as Polish or Russian
-> >                                          // such locales typically require other keywords
-> >                                          // such as two, few, many, and so forth
-> > *   {{You have {$var} chances remaining}}
-> >```
+> For example, a naive developer might use a special message for the value `1` without
+> considering other locale's need for a `one` plural:
+>
+>```
+> .match {$var}
+> 1   {{You have one last chance}}
+> one {{You have {$var} chance remaining}} // needed by languages such as Polish or Russian
+>                                          // such locales typically require other keywords
+>                                          // such as two, few, many, and so forth
+> *   {{You have {$var} chances remaining}}
+>```
 
-- `compactDisplay` // this option only has meaning when combined with the option `notation=compact`
+- `compactDisplay` (this option only has meaning when combined with the option `notation=compact`)
    - `short` (default)
    - `long`
 - `notation`
@@ -370,7 +368,6 @@ function `:number`:
   - `min2`
 - `minimumIntegerDigits`
   - (non-negative integer, default: `1`)
-  - 
 > [!NOTE]
 > The following options do not have default values because they are only to be used
 > as overrides for an existing locale-and-value dependent implementation-defined
@@ -421,7 +418,7 @@ function `:integer`:
   - (non-negative integer)
 
 > [!NOTE]
-> The following options or option values are being developed during the Technical Preview
+> The following options and option values are being developed during the Technical Preview
 > period.
 
 The following values for the option `style` are _not_ part of the default registry.
@@ -469,7 +466,7 @@ Number selection has three modes:
 - `ordinal` selection matches the operand to explicit numeric keys exactly
   or to ordinal rule categories if there is no explicit match
 
-When implementing [`MatchSelectorKeys`](spec/formatting.md#resolve-preferences), 
+When implementing [`MatchSelectorKeys`](formatting.md#resolve-preferences), 
 numeric selectors perform as described below.
 
 - Let `return_value` be a new empty list of strings.
@@ -496,7 +493,7 @@ numeric selectors perform as described below.
 The _plural/ordinal keywords_ are: `zero`, `one`, `two`, `few`, `many`, and
 `other`.
 
-### Rule Selection
+#### Rule Selection
 
 If the option `select` is set to `exact`, rule-based selection is not used.
 Return the empty string.
@@ -570,7 +567,7 @@ the two strings are equal.
 This subsection describes the functions and options for date/time formatting.
 Selection based on date and time values is not required in this release.
 
-#### Functions
+### Functions
 
 Functions for formatting [date/time values](#operands) in the default registry are:
 
@@ -589,7 +586,7 @@ If no options are specified, each of the functions defaults to the following:
 
 > [!NOTE]
 > The default formatting behavior of `:datetime` is inconsistent with `Intl.DateTimeFormat`
-> in JavaScript and with `{d,date}` in MessageFormat v1.
+> in JavaScript and with `{d,date}` in ICU MessageFormat 1.0.
 > This is because, unlike those implementations, `:datetime` is distinct from `:date` and `:time`.
 
 #### Operands
@@ -612,7 +609,7 @@ When the offset is not present, implementations should use a floating time type
 For more information, see [Working with Timezones](https://w3c.github.io/timezone).
 
 > [!IMPORTANT]
-> The [ABNF](/spec/message.abnf) and [syntax](/spec/syntax.md) of MFv2
+> The [ABNF](/spec/message.abnf) and [syntax](/spec/syntax.md) of MF2
 > do not formally define date/time literals. 
 > This means that a _message_ can be syntactically valid but produce
 > an _Operand Mismatch Error_ at runtime.
@@ -637,7 +634,7 @@ For more information, see [Working with Timezones](https://w3c.github.io/timezon
 > Support for these extensions is expected to be required in the post-tech preview.
 > See: https://datatracker.ietf.org/doc/draft-ietf-sedate-datetime-extended/
 
-#### Options
+### Options
 
 A function can use either the appropriate _style_ options for that function
 or can use a collection of _field options_ (but not both) to control the formatted 
@@ -646,7 +643,7 @@ output.
 If both are specified, an _Invalid Expression_ error MUST be emitted
 and a _fallback value_ used as the resolved value of the _expression_.
 
-##### Style Options
+#### Style Options
 
 The function `:datetime` has these function-specific _style_ options.
 - `dateStyle`
@@ -674,7 +671,7 @@ The function `:time` has these function-specific _style_ options:
   - `medium`
   - `short` (default)
 
-##### Field Options
+#### Field Options
 
 Field options describe which fields to include in the formatted output
 and what format to use for that field.
@@ -738,7 +735,7 @@ The function `:datetime` has the following options:
 > The following options do not have default values because they are only to be used
 > as overrides for locale-and-value dependent implementation-defined defaults.
 
-The followind date/time options are *not* part of the default registry.
+The following date/time options are **not** part of the default registry.
 Implementations SHOULD avoid creating options that conflict with these, but
 are encouraged to track development of these options during Tech Preview:
 - `calendar` (default is locale-specific)
@@ -748,9 +745,9 @@ are encouraged to track development of these options during Tech Preview:
 - `timeZone` (default is system default time zone or UTC)
   - valid identifier per [BCP175](https://www.rfc-editor.org/rfc/rfc6557)
 
-#### Selection
+### Selection
 
-Selection based on date/time types is not required by MFv2.
+Selection based on date/time types is not required by MF2.
 Implementations should use care when defining selectors based on date/time types.
 The types of queries found in implementations such as `java.time.TemporalAccessor`
 are complex and user expectations may be inconsistent with good I18N practices.


### PR DESCRIPTION
This PR copies the number and date/time default functionality from design to the specification.

The copy was done verbatim, except:

- I moved some parts of number to make the structure logically consistent
- I added an example to the `style=percent` note
- I turned the information about the default selector into an "important" note
- I added the surrounding document structure