### PR TITLE
Address #575: say that data model uses `name` for `identifier`

### DIFF
--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -48,6 +48,16 @@ declarations, options, and attributes to be optional rather than required proper
 
 ## Messages
 
+> [!IMPORTANT]
+> The data model uses the field name `name` to denote various interface identifiers.
+> In the MessageFormat 2 syntax, the source for these `name` fields sometimes uses
+> the production `identifier`.
+> This happens when the named item, such as a _function_, supports namespacing.
+>
+> In the Tech Preview, feedback on whether to separate the `namespace` from the `name`
+> and represent both separately, or just, as here, use an opaque single field `name`
+> is desired.
+
 A `SelectMessage` corresponds to a syntax message that includes _selectors_.
 A message without _selectors_ and with a single _pattern_ is represented by a `PatternMessage`.
 
@@ -87,7 +97,7 @@ starting after the keyword and up to the first _expression_,
 not including leading or trailing whitespace.
 The non-empty `expressions` correspond to the trailing _expressions_ of the _reserved statement_.
 
-> **Note**
+> [!NOTE]
 > Be aware that future versions of this specification
 > might assign meaning to _reserved statement_ values.
 > This would result in new interfaces being added to

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -48,8 +48,8 @@ declarations, options, and attributes to be optional rather than required proper
 
 > [!IMPORTANT]
 > The data model uses the field name `name` to denote various interface identifiers.
-> In the MessageFormat 2 syntax, the source for these `name` fields sometimes uses
-> the production `identifier`.
+> In the MessageFormat 2 [syntax](/spec/syntax.md), the source for these `name` fields
+> sometimes uses the production `identifier`.
 > This happens when the named item, such as a _function_, supports namespacing.
 >
 > In the Tech Preview, feedback on whether to separate the `namespace` from the `name`

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -46,8 +46,6 @@ the JSON and DTD definitions are intended for interchange between systems and pr
 To that end, they relax some aspects of the data model, such as allowing
 declarations, options, and attributes to be optional rather than required properties.
 
-## Messages
-
 > [!IMPORTANT]
 > The data model uses the field name `name` to denote various interface identifiers.
 > In the MessageFormat 2 syntax, the source for these `name` fields sometimes uses
@@ -57,6 +55,8 @@ declarations, options, and attributes to be optional rather than required proper
 > In the Tech Preview, feedback on whether to separate the `namespace` from the `name`
 > and represent both separately, or just, as here, use an opaque single field `name`
 > is desired.
+
+## Messages
 
 A `SelectMessage` corresponds to a syntax message that includes _selectors_.
 A message without _selectors_ and with a single _pattern_ is represented by a `PatternMessage`.


### PR DESCRIPTION
Per our discussion of #575, we want to say that the field `name` in the data model encompasses the production `identifier` in cases where the name is an identifier.

Fixes #575.