### PR TITLE
Fix #670: fix `content-char`

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -90,7 +90,7 @@ quoted-char       = content-char / s / "." / "@" / "{" / "}"
 reserved-char     = content-char / "."
 content-char      = %x00-08        ; omit HTAB (%x09) and LF (%x0A)
                   / %x0B-0C        ; omit CR (%x0D)
-                  / %x0E-19        ; omit SP (%x20)
+                  / %x0E-1F        ; omit SP (%x20)
                   / %x21-2D        ; omit . (%x2E)
                   / %x2F-3F        ; omit @ (%x40)
                   / %x41-5B        ; omit \ (%x5C)

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -293,7 +293,7 @@ quoted-char       = content-char / s / "." / "@" / "{" / "}"
 reserved-char     = content-char / "."
 content-char      = %x00-08        ; omit HTAB (%x09) and LF (%x0A)
                   / %x0B-0C        ; omit CR (%x0D)
-                  / %x0E-19        ; omit SP (%x20)
+                  / %x0E-1F        ; omit SP (%x20)
                   / %x21-2D        ; omit . (%x2E)
                   / %x2F-3F        ; omit @ (%x40)
                   / %x41-5B        ; omit \ (%x5C)


### PR DESCRIPTION
Fixes #670 

`content-char` wants to skip U+0020 (`SPACE`) but manages to skip U+001A through U+001F too...