### PR TITLE
Drop "quoted" remnants from JSON Schema & DTD data models

### DIFF
--- a/spec/data-model/message.dtd
+++ b/spec/data-model/message.dtd
@@ -29,7 +29,6 @@
 )>
 
 <!ELEMENT literal (#PCDATA)>
-<!ATTLIST literal quoted (true | false) #REQUIRED>
 
 <!ELEMENT variable (EMPTY)>
 <!ATTLIST variable name NMTOKEN #REQUIRED>

--- a/spec/data-model/message.json
+++ b/spec/data-model/message.json
@@ -9,10 +9,9 @@
       "type": "object",
       "properties": {
         "type": { "const": "literal" },
-        "quoted": { "type": "boolean" },
         "value": { "type": "string" }
       },
-      "required": ["type", "quoted", "value"]
+      "required": ["type", "value"]
     },
     "variable": {
       "type": "object",


### PR DESCRIPTION
Fixes #667, CC @bhaible.

This was missed out in #443.