### PR TITLE
Rename <key default> as <key catchall> in message.dtd

### DIFF
--- a/spec/data-model/message.dtd
+++ b/spec/data-model/message.dtd
@@ -19,7 +19,7 @@
 <!ELEMENT selectors (expression)+>
 <!ELEMENT variant (key+,pattern)>
 <!ELEMENT key (#PCDATA)>
-<!ATTLIST key default (true | false) "false">
+<!ATTLIST key catchall (true | false) "false">
 
 <!ELEMENT pattern (#PCDATA | expression | markup)*>
 


### PR DESCRIPTION
Fixes #676

This resolves the naming inconsistency in the data model DTD.

The further recommendation by @bhaible
> Maybe also by changing the `value` in the CatchallKey to `identifier`, and adding an attribute `identifier` to the XML DTD element (instead of overloading the meaning of the XML element's contents).

is not included here, as it would potentially add more confusion. In the MF2 syntax, the non-default variant keys are _literal_ values, rather than _identifiers_, and the data model's catchall `value` is not used when representing MF2 syntax. It's there to support the lossless representation of other syntaxes, which may assign a literal value to their catchall variants.