### PR TITLE
Add note about XML C0 characters adding restrictions

### DIFF
--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -48,11 +48,12 @@ declarations, options, and attributes to be optional rather than required proper
 
 > [!NOTE]
 > Users relying on XML representations of messages should note that
-> XML 1.0 does not allow for the representation of all C0 control characters (U+0000-U+0019),
+> XML 1.0 does not allow for the representation of all C0 control characters (U+0000-U+001F)
 > and XML 1.1 does not allow for the representation of a U+0000 NULL character.
 > These characters are allowed in MessageFormat 2 messages,
 > so systems and users relying on XML as a resource format might need to
-> apply additional restrictions on message characters.
+> apply additional restrictions on message characters
+> or provide an alternative escape mechanism for these characters.
 
 > [!IMPORTANT]
 > The data model uses the field name `name` to denote various interface identifiers.

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -46,6 +46,14 @@ the JSON and DTD definitions are intended for interchange between systems and pr
 To that end, they relax some aspects of the data model, such as allowing
 declarations, options, and attributes to be optional rather than required properties.
 
+> [!NOTE]
+> Users relying on XML representations of messages should note that
+> XML 1.0 does not allow for the representation of all C0 control characters (U+0000-U+0019),
+> and XML 1.1 does not allow for the representation of a U+0000 NULL character.
+> These characters are allowed in MessageFormat 2 messages,
+> so systems and users relying on XML as a resource format might need to
+> apply additional restrictions on message characters.
+
 > [!IMPORTANT]
 > The data model uses the field name `name` to denote various interface identifiers.
 > In the MessageFormat 2 [syntax](/spec/syntax.md), the source for these `name` fields

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -50,9 +50,9 @@ declarations, options, and attributes to be optional rather than required proper
 > Users relying on XML representations of messages should note that
 > XML 1.0 does not allow for the representation of all C0 control characters (U+0000-U+001F).
 > Except for U+0000 NULL , these characters are allowed in MessageFormat 2 messages,
-> so systems and users relying on XML as a resource format might need to
-> apply additional restrictions on message characters
-> or provide an alternative escape mechanism for these characters.
+> so systems and users relying on this XML representation for interchange
+> might need to supply an alternate escape mechanism to support messages
+> that contain these characters.
 
 > [!IMPORTANT]
 > The data model uses the field name `name` to denote various interface identifiers.

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -48,9 +48,8 @@ declarations, options, and attributes to be optional rather than required proper
 
 > [!NOTE]
 > Users relying on XML representations of messages should note that
-> XML 1.0 does not allow for the representation of all C0 control characters (U+0000-U+001F)
-> and XML 1.1 does not allow for the representation of a U+0000 NULL character.
-> These characters are allowed in MessageFormat 2 messages,
+> XML 1.0 does not allow for the representation of all C0 control characters (U+0000-U+001F).
+> Except for U+0000 NULL , these characters are allowed in MessageFormat 2 messages,
 > so systems and users relying on XML as a resource format might need to
 > apply additional restrictions on message characters
 > or provide an alternative escape mechanism for these characters.


### PR DESCRIPTION
See #669, CC @bhaible

I agree with @aphillips that we should not restrict `content-char` characters because they're not all representable in XML. But we should explicitly note to readers that there is a concern here, and that they may need to add restrictions for their own message validation if they rely on XML.