### PR TITLE
Do not allow null characters in message source

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -88,7 +88,7 @@ simple-start-char = content-char / s / "@" / "|"
 text-char         = content-char / s / "." / "@" / "|"
 quoted-char       = content-char / s / "." / "@" / "{" / "}"
 reserved-char     = content-char / "."
-content-char      = %x01-08        ; omit NUL (%x00), HTAB (%x09) and LF (%x0A)
+content-char      = %x01-08        ; omit NULL (%x00), HTAB (%x09) and LF (%x0A)
                   / %x0B-0C        ; omit CR (%x0D)
                   / %x0E-1F        ; omit SP (%x20)
                   / %x21-2D        ; omit . (%x2E)

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -88,7 +88,7 @@ simple-start-char = content-char / s / "@" / "|"
 text-char         = content-char / s / "." / "@" / "|"
 quoted-char       = content-char / s / "." / "@" / "{" / "}"
 reserved-char     = content-char / "."
-content-char      = %x00-08        ; omit HTAB (%x09) and LF (%x0A)
+content-char      = %x01-08        ; omit NUL (%x00), HTAB (%x09) and LF (%x0A)
                   / %x0B-0C        ; omit CR (%x0D)
                   / %x0E-1F        ; omit SP (%x20)
                   / %x21-2D        ; omit . (%x2E)

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -271,8 +271,8 @@ A _quoted pattern_ MAY be empty.
 ### Text
 
 **_<dfn>text</dfn>_** is the translateable content of a _pattern_.
-Any Unicode code point is allowed, except for surrogate code points U+D800
-through U+DFFF inclusive.
+Any Unicode code point is allowed, except for U+0000 NUL
+and the surrogate code points U+D800 through U+DFFF inclusive.
 The characters U+005C REVERSE SOLIDUS `\`,
 U+007B LEFT CURLY BRACKET `{`, and U+007D RIGHT CURLY BRACKET `}`
 MUST be escaped as `\\`, `\{`, and `\}` respectively.
@@ -291,7 +291,7 @@ simple-start-char = content-char / s / "@" / "|"
 text-char         = content-char / s / "." / "@" / "|"
 quoted-char       = content-char / s / "." / "@" / "{" / "}"
 reserved-char     = content-char / "."
-content-char      = %x00-08        ; omit HTAB (%x09) and LF (%x0A)
+content-char      = %x01-08        ; omit NUL (%x00), HTAB (%x09) and LF (%x0A)
                   / %x0B-0C        ; omit CR (%x0D)
                   / %x0E-1F        ; omit SP (%x20)
                   / %x21-2D        ; omit . (%x2E)
@@ -794,7 +794,7 @@ as a _key_ value,
 as the _operand_ of a _literal-expression_,
 or in the value of an _option_.
 A _literal_ MAY include any Unicode code point
-except for surrogate code points U+D800 through U+DFFF.
+except for U+0000 NUL or the surrogate code points U+D800 through U+DFFF.
 
 All code points are preserved.
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -271,7 +271,7 @@ A _quoted pattern_ MAY be empty.
 ### Text
 
 **_<dfn>text</dfn>_** is the translateable content of a _pattern_.
-Any Unicode code point is allowed, except for U+0000 NUL
+Any Unicode code point is allowed, except for U+0000 NULL
 and the surrogate code points U+D800 through U+DFFF inclusive.
 The characters U+005C REVERSE SOLIDUS `\`,
 U+007B LEFT CURLY BRACKET `{`, and U+007D RIGHT CURLY BRACKET `}`
@@ -291,7 +291,7 @@ simple-start-char = content-char / s / "@" / "|"
 text-char         = content-char / s / "." / "@" / "|"
 quoted-char       = content-char / s / "." / "@" / "{" / "}"
 reserved-char     = content-char / "."
-content-char      = %x01-08        ; omit NUL (%x00), HTAB (%x09) and LF (%x0A)
+content-char      = %x01-08        ; omit NULL (%x00), HTAB (%x09) and LF (%x0A)
                   / %x0B-0C        ; omit CR (%x0D)
                   / %x0E-1F        ; omit SP (%x20)
                   / %x21-2D        ; omit . (%x2E)
@@ -794,7 +794,7 @@ as a _key_ value,
 as the _operand_ of a _literal-expression_,
 or in the value of an _option_.
 A _literal_ MAY include any Unicode code point
-except for U+0000 NUL or the surrogate code points U+D800 through U+DFFF.
+except for U+0000 NULL or the surrogate code points U+D800 through U+DFFF.
 
 All code points are preserved.
 


### PR DESCRIPTION
Closes #669

As @bhaible points out, U+0000 NUL characters are challenging in null-terminated strings as well as XML. These are real concerns, but U+0000 should still be representable in MF2. Rather than requiring custom solutions that are likely to not be mutually compatible, we should make a specific affordance for U+0000, removing it from `content-char` and adding `\0` as an MF2 escape.