### PR TITLE
Add note to "Function Resolution" section about function argument and result types

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -267,7 +267,7 @@ the following steps are taken:
 > {{$n1}}
 > ```
 >
-> is implementation-dependent.
+> is currently implementation-dependent.
 > Depending on whether the options are preserved
 > between the resolution of the first `:number` _annotation_
 > and the resolution of the second `:number` _annotation_,

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -247,12 +247,8 @@ the following steps are taken:
    MAY define an interface for custom function implementations.
    Such an interface SHOULD define an implementation-specific
    argument type `T` and return type `U`
-   for implementations of formatting functions
+   for implementations of functions
    such that `U` can be coerced to `T` without loss of information.
-   The type `U`
-   (or a type that `U` can be coerced to without loss of information)
-   SHOULD also be the input type of implementations of
-   custom selector functions.
    Implementations of specific functions MAY
    signal errors if supplied an _operand_ that
    does not make sense for the particular function

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -274,9 +274,13 @@ the following steps are taken:
 > a conformant implementation
 > could produce either "001.000" or "1.000"
 >
-> Each function implementation MAY have
+> Each function **specification** MAY have
 > its own rules to preserve some options in the returned structure
-> and discard others.
+> and discard others. 
+> In instances where a function specification does not determine whether an option is preserved or discarded,
+> each function **implementation** of that specification MAY have
+> its own rules to preserve some options in the returned structure
+> and discard others. 
 >
 >
 > [!NOTE]

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -234,8 +234,13 @@ the following steps are taken:
    ```
    the second call to `:number` composes with the first call.
 
+   In addition, selector functions compose with formatting functions
+   in the sense that a selector function's _operand_
+   may be the output of any formatting function.
+
    Implementations SHOULD provide a means for formatting functions
-   to compose with each other.
+   to compose with each other
+   and for formatting functions to compose with selector functions.
    Implementations that provide a means for defining custom functions
    SHOULD provide a means for those functions to return values
    that contain enough information
@@ -245,8 +250,11 @@ the following steps are taken:
    For example, an implementation in a typed programming language
    MAY define an interface that custom functions implement.
    Such an interface SHOULD define an implementation-specific
-   argument type `T` and return type `U` for custom functions
+   argument type `T` and return type `U` for custom formatting functions
    such that `U` can be coerced to `T` without loss of information.
+   The type `U`
+   (or a type that `U` can be coerced to without loss of information)
+   SHOULD also be the input type of custom selector functions.
 
 > [!NOTE]
 > In the Tech Preview, the spec leaves the behavior of the previous

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -222,6 +222,11 @@ the following steps are taken:
 
    The form that resolved _operand_ and _option_ values take is implementation-defined.
 
+   Since the result of a function call can be bound to a _variable_,
+   the output of one _function_ may be the input of another _function_.
+   Thus, formatting functions SHOULD use a structure for the resolved _operand_ value
+   that is interconvertible with the structure for the result of the _function_.
+
    An implementation MAY pass additional arguments to the function,
    as long as reasonable precautions are taken to keep the function interface
    simple and minimal, and avoid introducing potential security vulnerabilities.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -230,7 +230,7 @@ the following steps are taken:
    For example, in
    ```
    .input {$n :number minIntegerDigits=3}
-   .local {$n1 :number maxFractionDigits=3}
+   .local $n1 = {$n :number maxFractionDigits=3}
    ```
    the second call to `:number` composes with the first call.
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -256,7 +256,7 @@ the following steps are taken:
 
 > [!NOTE]
 > The behavior of the previous example is
-> implementation-dependent. Supposing that
+> currently implementation-dependent. Supposing that
 > the external input variable `n` is bound to the string `"1"`,
 > and that the implementation formats to a string,
 > the formatted result of the following message:

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -225,40 +225,41 @@ the following steps are taken:
    A _local-declaration_ binds the resolved value of an _expression_
    to a _variable_.
    Thus, the output of one _function_ is potentially the _operand_
-   of another _function_. In other words, formatting functions
-   compose with each other.
+   of another _function_,
+   or the value of one of the _options_ for another function.
    For example, in
    ```
    .input {$n :number minIntegerDigits=3}
    .local $n1 = {$n :number maxFractionDigits=3}
    ```
-   the second call to `:number` composes with the first call.
+   the output of the first call to `:number`
+   is the input of the second call to `:number`.
 
-   In addition, selector functions compose with formatting functions
-   in the sense that a selector function's _operand_
-   may be the output of any formatting function.
-
-   Implementations SHOULD provide a means for formatting functions
-   to compose with each other
-   and for formatting functions to compose with selector functions.
    Implementations that provide a means for defining custom functions
-   SHOULD provide a means for those functions to return values
-   that contain enough information
+   SHOULD provide a means for function implementations
+   to return values that contain enough information
    (e.g. the resolved _operand_ and _option_ values
    that the function was called with)
-   to be used as inputs to subsequent function calls.
-   For example, an implementation in a typed programming language
-   MAY define an interface that custom functions implement.
+   to be used as arguments to subsequent calls
+   to the function implementations.
+   For example, a MessageFormat implementation in a typed programming language
+   MAY define an interface for custom function implementations.
    Such an interface SHOULD define an implementation-specific
-   argument type `T` and return type `U` for custom formatting functions
+   argument type `T` and return type `U`
+   for implementations of formatting functions
    such that `U` can be coerced to `T` without loss of information.
    The type `U`
    (or a type that `U` can be coerced to without loss of information)
-   SHOULD also be the input type of custom selector functions.
+   SHOULD also be the input type of implementations of
+   custom selector functions.
+   Implementations of specific functions MAY
+   signal errors if supplied an _operand_ that
+   does not make sense for the particular function
+   being implemented.
 
 > [!NOTE]
-> In the Tech Preview, the spec leaves the behavior of the previous
-> example implementation-dependent. Supposing that
+> The behavior of the previous example is
+> implementation-dependent. Supposing that
 > the external input variable `n` is bound to the string `"1"`,
 > and that the implementation formats to a string,
 > the formatted result of the following message:
@@ -270,12 +271,24 @@ the following steps are taken:
 > ```
 >
 > is implementation-dependent.
-> Depending on whether the options are preserved across
-> the two calls to `:number`, a conformant implementation
+> Depending on whether the options are preserved
+> between the resolution of the first `:number` _annotation_
+> and the resolution of the second `:number` _annotation_,
+> a conformant implementation
 > could produce either "001.000" or "1.000"
-> Feedback from users and implementers is desired
-> about whether to require one interpretation or the other
-> in the spec.
+>
+> Each function implementation MAY have
+> its own rules to preserve some options in the returned structure
+> and discard others.
+>
+>
+> [!NOTE]
+> During the Technical Preview,
+> feedback on how the registry describes
+> the flow of _resolved values_ and _options_
+> from one _function_ to another,
+> and on what requirements this specification should impose,
+> is highly desired.
 
    An implementation MAY pass additional arguments to the function,
    as long as reasonable precautions are taken to keep the function interface

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -245,8 +245,7 @@ the following steps are taken:
    that the function was called with)
    to be used as arguments to subsequent calls
    to the function implementations.
-   For example, a MessageFormat implementation in a typed programming language
-   MAY define an interface for custom function implementations.
+   For example, an implementation might define an interface that allows custom function implementation.
    Such an interface SHOULD define an implementation-specific
    argument type `T` and return type `U`
    for implementations of functions

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -238,7 +238,8 @@ the following steps are taken:
    Implementations that provide a means for defining custom functions
    SHOULD provide a means for function implementations
    to return values that contain enough information
-   (e.g. the resolved _operand_ and _option_ values
+   (e.g. a representation of
+   the resolved _operand_ and _option_ values
    that the function was called with)
    to be used as arguments to subsequent calls
    to the function implementations.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -225,9 +225,49 @@ the following steps are taken:
    A _local-declaration_ binds the resolved value of an _expression_
    to a _variable_.
    Thus, the output of one _function_ is potentially the _operand_
-   of another _function_.
-   Thus, formatting functions SHOULD use a structure for the resolved _operand_ value
-   that is interconvertible with the structure for the result of the _function_.
+   of another _function_. In other words, formatting functions
+   compose with each other.
+   For example, in
+   ```
+   .input {$n :number minIntegerDigits=3}
+   .local {$n1 :number maxFractionDigits=3}
+   ```
+   the second call to `:number` composes with the first call.
+
+   Implementations SHOULD provide a means for formatting functions
+   to compose with each other.
+   Implementations that provide a means for defining custom functions
+   SHOULD provide a means for those functions to return values
+   that contain enough information
+   (e.g. the resolved _operand_ and _option_ values
+   that the function was called with)
+   to be used as inputs to subsequent function calls.
+   For example, an implementation in a typed programming language
+   MAY define an interface that custom functions implement.
+   Such an interface SHOULD define an implementation-specific
+   argument type `T` and return type `U` for custom functions
+   such that `U` can be coerced to `T` without loss of information.
+
+> [!NOTE]
+> In the Tech Preview, the spec leaves the behavior of the previous
+> example implementation-dependent. Supposing that
+> the external input variable `n` is bound to the string `"1"`,
+> and that the implementation formats to a string,
+> the formatted result of the following message:
+>
+> ```
+> .input {$n :number minIntegerDigits=3}
+> .local {$n1 :number maxFractionDigits=3}
+> {{$n1}}
+> ```
+>
+> is implementation-dependent.
+> Depending on whether the options are preserved across
+> the two calls to `:number`, a conformant implementation
+> could produce either "001.000" or "1.000"
+> Feedback from users and implementers is desired
+> about whether to require one interpretation or the other
+> in the spec.
 
    An implementation MAY pass additional arguments to the function,
    as long as reasonable precautions are taken to keep the function interface

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -250,10 +250,9 @@ the following steps are taken:
    argument type `T` and return type `U`
    for implementations of functions
    such that `U` can be coerced to `T` without loss of information.
-   Implementations of specific functions MAY
-   signal errors if supplied an _operand_ that
-   does not make sense for the particular function
-   being implemented.
+   Implementations of a _function_ SHOULD emit an 
+   _Invalid Expression_ error for _operands_ whose resolved value
+   or type is not supported.
 
 > [!NOTE]
 > The behavior of the previous example is

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -249,7 +249,7 @@ the following steps are taken:
    Such an interface SHOULD define an implementation-specific
    argument type `T` and return type `U`
    for implementations of functions
-   such that `U` can be coerced to `T` without loss of information.
+   such that `U` can be coerced to `T`.
    Implementations of a _function_ SHOULD emit an 
    _Invalid Expression_ error for _operands_ whose resolved value
    or type is not supported.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -224,7 +224,7 @@ the following steps are taken:
 
    A _declaration_ binds the resolved value of an _expression_
    to a _variable_.
-   Thus, the output of one _function_ is potentially the _operand_
+   Thus, the result of one _function_ is potentially the _operand_
    of another _function_,
    or the value of one of the _options_ for another function.
    For example, in
@@ -232,8 +232,10 @@ the following steps are taken:
    .input {$n :number minIntegerDigits=3}
    .local $n1 = {$n :number maxFractionDigits=3}
    ```
-   the output of the first call to `:number`
-   is the input of the second call to `:number`.
+   the value bound to `$n` is the
+   resolved value used as the _operand_
+   of the `:number` _function_
+   when resolving the value of the _variable_ `$n1`.
 
    Implementations that provide a means for defining custom functions
    SHOULD provide a means for function implementations

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -266,7 +266,7 @@ the following steps are taken:
 >
 > ```
 > .input {$n :number minIntegerDigits=3}
-> .local {$n1 :number maxFractionDigits=3}
+> .local $n1 = {$n :number maxFractionDigits=3}
 > {{$n1}}
 > ```
 >

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -222,7 +222,7 @@ the following steps are taken:
 
    The form that resolved _operand_ and _option_ values take is implementation-defined.
 
-   A _local-declaration_ binds the resolved value of an _expression_
+   A _declaration_ binds the resolved value of an _expression_
    to a _variable_.
    Thus, the output of one _function_ is potentially the _operand_
    of another _function_,

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -222,8 +222,10 @@ the following steps are taken:
 
    The form that resolved _operand_ and _option_ values take is implementation-defined.
 
-   Since the result of a function call can be bound to a _variable_,
-   the output of one _function_ may be the input of another _function_.
+   A _local-declaration_ binds the resolved value of an _expression_
+   to a _variable_.
+   Thus, the output of one _function_ is potentially the _operand_
+   of another _function_.
    Thus, formatting functions SHOULD use a structure for the resolved _operand_ value
    that is interconvertible with the structure for the result of the _function_.
 


### PR DESCRIPTION
Currently, the introduction to the spec states:

>   The form of the resolved value is implementation defined and the
>  value might not be evaluated or formatted yet.
> However, it needs to be "formattable", i.e. it contains everything required
> by the eventual formatting.

And the "Expression and Markup Resolution" section says:

> Since a _variable_ can be referenced in different ways later,
> implementations SHOULD NOT immediately fully format the value for output.

However, the "Function Resolution" section is not as clear as it could be about the implications of these requirements for the interface with formatting functions.


I added some text that effectively implies that functions have the same operand type and result type. If this wasn't the case, it wouldn't make sense to bind the result of a function to a variable and use that result as an operand for another function call.

I think it's useful guidance for implementors to state this explicitly rather than letting it be inferred from the two existing passages that I quoted.

This relates to #515; some version of #645 would make this much more precise, but it's a start.

The reason this came up was that I was discussing the API for custom functions with members of the ICU TC, who were puzzled at first about why formatting functions take and return the same type (in my implementation). 

If an implementor instead requires custom functions to take a "formattable" thing as an argument, and return a "formatted" thing, examples like the first use case in #515 (with the two calls to `:number`) wouldn't work. In my opinion, the current spec doesn't say that you can't do this -- it could be read as saying that a "resolved _operand_ value" as mentioned in step 4, and the value referred to by the text "resolve the value of the _expression_ as the result of that function call", might refer to different kinds of "resolved values".

(Taking and returning the same type makes formatting functions seem more like "transformers" than "formatters" -- and that's in line with the text in [syntax.md](https://github.com/unicode-org/message-format-wg/blob/main/spec/syntax.md) saying, "Functions are used to evaluate, format, select, or otherwise process data values during formatting." -- but changing the name might be more controversial.)