### PR TITLE
Reserve the "u" namespace

### DIFF
--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -831,7 +831,7 @@ When present, the _namespace_ is separated from the _name_ by a
 U+003A COLON `:`.
 Built-in _functions_ and their _options_ do not have a _namespace_ identifier.
 
-The single-character U+0075 LATIN SMALL LETTER U `u` _namespace_
+The _namespace_ `u` (U+0075 LATIN SMALL LETTER U)
 is reserved for future standardization.
 
 _Function_ _identifiers_ are prefixed with `:`.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -831,6 +831,9 @@ When present, the _namespace_ is separated from the _name_ by a
 U+003A COLON `:`.
 Built-in _functions_ and their _options_ do not have a _namespace_ identifier.
 
+The single-character U+0075 LATIN SMALL LETTER U `u` _namespace_
+is reserved for future standardization.
+
 _Function_ _identifiers_ are prefixed with `:`.
 _Markup_ _identifiers_ are prefixed with `#` or `/`.
 _Option_ _identifiers_ have no prefix.


### PR DESCRIPTION
This was discussed on [2024-02-15](https://github.com/unicode-org/message-format-wg/blob/main/meetings/2024/notes-2024-02-15.md#topic-registry-maintenance), and is mentioned in the #634 design doc.