### PR TITLE
Fix formatting of a note

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -282,7 +282,7 @@ the following steps are taken:
 > its own rules to preserve some options in the returned structure
 > and discard others. 
 >
->
+
 > [!NOTE]
 > During the Technical Preview,
 > feedback on how the registry describes


### PR DESCRIPTION
One of the notes in yesterday's merge was formatted incorrectly. This one character fix restores proper formatting.