### PR TITLE
Drop obsolete mention of "kind" in function-annotation JSON Schema definition

### DIFF
--- a/spec/data-model/message.json
+++ b/spec/data-model/message.json
@@ -61,7 +61,7 @@
         "name": { "type": "string" },
         "options": { "$ref": "#/$defs/options" }
       },
-      "required": ["type", "kind", "name"]
+      "required": ["type", "name"]
     },
     "unsupported-annotation": {
       "type": "object",


### PR DESCRIPTION
Fixes #698, CC @bhaible

This was missed in #574.