### PR TITLE
Move test with options on closing markup out of "syntax error" tests

### DIFF
--- a/test/syntax-errors.json
+++ b/test/syntax-errors.json
@@ -7,7 +7,6 @@
   "{{}",
   "{{}}}",
   "{|foo| #markup}",
-  "{/tag foo=bar}",
   "{{missing end brace}",
   "{{missing end braces",
   "{{missing end {$braces",

--- a/test/test-core.json
+++ b/test/test-core.json
@@ -115,6 +115,19 @@
     ]
   },
   {
+    "src": "{/tag foo=bar}",
+    "exp": "",
+    "parts": [
+      {
+        "type": "markup",
+        "kind": "close",
+        "name": "tag",
+        "options": { "foo": "bar" }
+      }
+    ]
+  },
+
+  {
     "src": "{#tag a:foo=|foo| b:bar=$bar}",
     "params": { "bar": "b a r" },
     "exp": "",


### PR DESCRIPTION
This test is now valid as of #649 