### PR TITLE
Clarify (again) that Duplicate Option Name is a data model error

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -324,8 +324,6 @@ The result of resolving _option_ values is a mapping of string identifiers to va
 For each _option_:
 
 - Resolve the _identifier_ of the _option_.
-- If the _option_'s _identifier_ already exists in the resolved mapping of _options_,
-   emit a _Duplicate Option Name_ error.
 - If the _option_'s right-hand side successfully resolves to a value,
    bind the _identifier_ of the _option_ to the resolved value in the mapping.
 - Otherwise, bind the _identifier_ of the _option_ to an unresolved value in the mapping.


### PR DESCRIPTION
As noted in https://github.com/unicode-org/message-format-wg/pull/704#pullrequestreview-1921417562, this was already fixed once in #577, but mistakenly reverted in the merge of #593.

