### PR TITLE
Remove tests that require non-integer matching

### DIFF
--- a/test/test-functions.json
+++ b/test/test-functions.json
@@ -88,17 +88,6 @@
       "src": ".match {$foo :integer} one {{one}} * {{other}}",
       "params": { "foo": 1.2 },
       "exp": "one"
-    },
-    {
-      "src": ".match {$foo :integer} 1.2 {{=1.2}} one {{one}} * {{other}}",
-      "params": { "foo": 1.2 },
-      "exp": "=1.2"
-    },
-    {
-      "src": ".match {$foo :integer} 1.2 {{=1.2}} |1,2| {{=1,2}} * {{other}}",
-      "locale": "fr",
-      "params": { "foo": 1.2 },
-      "exp": "=1.2"
     }
   ],
   "number": [


### PR DESCRIPTION
These tests may be able to be re-added after resolving https://github.com/unicode-org/message-format-wg/issues/675