### PR TITLE
Remove references to "RangeError" in spec tests

### DIFF
--- a/test/test-functions.json
+++ b/test/test-functions.json
@@ -4,7 +4,7 @@
     {
       "src": "{horse :date}",
       "exp": "{|horse|}",
-      "errors": [{ "name": "RangeError" }]
+      "errors": [{ "name": "bad-input" }]
     },
     { "src": "{|2006-01-02| :date}", "exp": "1/2/06" },
     { "src": "{|2006-01-02T15:04:06| :date}", "exp": "1/2/06" },
@@ -23,7 +23,7 @@
     {
       "src": "{horse :time}",
       "exp": "{|horse|}",
-      "errors": [{ "name": "RangeError" }]
+      "errors": [{ "name": "bad-input" }]
     },
     { "src": "{|2006-01-02T15:04:06| :time}", "exp": "3:04 PM" },
     {

--- a/test/test-functions.json
+++ b/test/test-functions.json
@@ -23,7 +23,7 @@
     {
       "src": "{horse :time}",
       "exp": "{|horse|}",
-      "errors": [{ "name": "bad-input" }]
+      "errors": [{ "type": "bad-input" }]
     },
     { "src": "{|2006-01-02T15:04:06| :time}", "exp": "3:04 PM" },
     {

--- a/test/test-functions.json
+++ b/test/test-functions.json
@@ -4,7 +4,7 @@
     {
       "src": "{horse :date}",
       "exp": "{|horse|}",
-      "errors": [{ "name": "bad-input" }]
+      "errors": [{ "type": "bad-input" }]
     },
     { "src": "{|2006-01-02| :date}", "exp": "1/2/06" },
     { "src": "{|2006-01-02T15:04:06| :date}", "exp": "1/2/06" },


### PR DESCRIPTION
I'm presuming that `RangeError` is supposed to be `bad-input`.

In general #706 is still needed: e.g. it's not clear that `bad-input` refers to an ["Operand Mismatch Error"](https://github.com/unicode-org/message-format-wg/blob/main/spec/errors.md#invalid-expression), but I'm assuming so. For now, this PR just tries to make the test suite internally consistent.

