### PR TITLE
Remove tests that rely on nonexistent bad-option error

### DIFF
--- a/test/test-functions.json
+++ b/test/test-functions.json
@@ -128,12 +128,6 @@
       "exp": "bar 4.20"
     },
     {
-      "src": ".local $foo = {$bar :number minimumFractionDigits=foo} {{bar {$foo}}}",
-      "params": { "bar": 4.2 },
-      "exp": "bar {$bar}",
-      "errors": [{ "type": "bad-option" }]
-    },
-    {
       "src": ".local $foo = {$bar :number} {{bar {$foo}}}",
       "params": { "bar": "foo" },
       "exp": "bar {$bar}",
@@ -148,12 +142,6 @@
       "src": ".input {$foo :number minimumFractionDigits=2} {{bar {$foo}}}",
       "params": { "foo": 4.2 },
       "exp": "bar 4.20"
-    },
-    {
-      "src": ".input {$foo :number minimumFractionDigits=foo} {{bar {$foo}}}",
-      "params": { "foo": 4.2 },
-      "exp": "bar {$foo}",
-      "errors": [{ "type": "bad-option" }]
     },
     {
       "src": ".input {$foo :number} {{bar {$foo}}}",


### PR DESCRIPTION
I suggest we remove these two tests for now, because the property that they are testing is actually underspecified. There is nothing in errors.md corresponding to the `bad-option` error, and what's more, the spec doesn't require `:number` to signal an error for a non-integer `minimumFractionDigits` value.

I filed #738 and #739 to clarify those issues in the spec, but I think the tests should be removed in the meantime, and re-added once the behavior is fully specified.