### PR TITLE
Define non-negative integer option

### DIFF
--- a/spec/registry.md
+++ b/spec/registry.md
@@ -631,7 +631,7 @@ Implementations MAY define an upper limit on the resolved value
 of a non-negative integer option consistent with that implementation's practical limits.
 
 The implementation MAY accept any implementation-defined type as the value.
-Implementations MUST accept the value as a _literal_.
+Implementations MUST accept a _literal_ as the value.
 When the value is a _literal_, it MUST match `non-negative` in this ABNF:
 >```abnf
 >non-negative = "0" / (("1"-"9") *DIGIT)

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -622,23 +622,39 @@ All other values produce an _Invalid Expression_ error.
 ### Non-Negative Integer Options
 
 Some _options_ of number _functions_ are defined to take a "non-negative integer".
-In this specification, these _options_ are used to control aspects of numeric display
+Implementations of number _functions_ use these _options_ to control aspects of numeric display
 such as the number of fraction, integer, or significant digits.
 
-A "non-negative integer" is a variable reference or literal whose value evaluates 
-as an integer greater than or equal to zero.
-If the value is passed as a literal
-it MUST contain only the ASCII digits U+0030 through U+0039.
-Implementations MAY define an upper limit on the length of such a literal.
+A "non-negative integer" is an _option_ value that the _function_ evaluates as an integer 
+greater than or equal to zero.
 Implementations MAY define an upper limit on the resolved value 
 of a non-negative integer option consistent with that implementation's practical limits.
 
-> **Examples of literal non-negative integer options**
+The implementation MAY accept any implementation-defined type as the value.
+Implementations MUST accept the value as a _literal_.
+When the value is a _literal_,
+it MUST consist of a sequence of ASCII digits in the range U+0030 through U+0039.
+
+> **Examples of  non-negative integer options**
+> 
+> Here are some examples of valid literals:
 > ```
 > {$n :number maximumFractionDigits=12}
 > {$n :number maximumFractionDigits=|12|}
 > {$n :number maximumFractionDigits=123456}
 > {$n :number maximumFractionDigits=|0123|}
+> ```
+> Note that the value can be passed as an input variable or defined via a declaration.
+> For example, the following _messages_ might be valid in an implementation that
+> accepted the type `int` and the variable `min` were passed as input:
+> ```
+> .local $max = {1 :integer}
+> {{You have {$n :number maximumFractionDigits=$max}}}
+>
+> {{{$n :number minimumFractionDigits=$min} where 'min' is an 'int' >= 0}}
+>
+> .local $max = {|2|}
+> {{{$n :number maximumFractionDigits=$max} where 'max' is a literal}}
 > ```
 
 ### Number Selection

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -630,10 +630,10 @@ as a small integer value greater than or equal to zero.
 Implementations MAY define an upper limit on the resolved value 
 of a digit size option option consistent with that implementation's practical limits.
 
-In most cases, the value of a digit size option will be a string literal that
+In most cases, the value of a digit size option will be a string that
 encodes the value as a decimal integer.
 Implementations MAY also accept implementation-defined types as the value.
-The _literal_ representation of a digit size option matches the following ABNF:
+When provided as a string, the representation of a digit size option matches the following ABNF:
 >```abnf
 > digit-size-option = "0" / (("1"-"9") [DIGIT])
 >```

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -398,15 +398,15 @@ The following options and their values are required to be available on the funct
   - `never`
   - `min2`
 - `minimumIntegerDigits`
-  - (non-negative integer, default: `1`)
+  - ([non-negative integer](#non-negative-integer-options), default: `1`)
 - `minimumFractionDigits`
-  - (non-negative integer)
+  - ([non-negative integer](#non-negative-integer-options))
 - `maximumFractionDigits`
-  - (non-negative integer)
+  - ([non-negative integer](#non-negative-integer-options))
 - `minimumSignificantDigits`
-  - (non-negative integer)
+  - ([non-negative integer](#non-negative-integer-options))
 - `maximumSignificantDigits`
-  - (non-negative integer)
+  - ([non-negative integer](#non-negative-integer-options))
 
 > [!NOTE]
 > The following options and option values are being developed during the Technical Preview
@@ -515,9 +515,9 @@ function `:integer`:
   - `always`
   - `min2`
 - `minimumIntegerDigits`
-  - (non-negative integer, default: `1`)
+  - ([non-negative integer](#non-negative-integer-options), default: `1`)
 - `maximumSignificantDigits`
-  - (non-negative integer)
+  - ([non-negative integer](#non-negative-integer-options))
 
 > [!NOTE]
 > The following options and option values are being developed during the Technical Preview
@@ -619,7 +619,17 @@ All other values produce an _Invalid Expression_ error.
 > or the type `com.ibm.icu.util.CurrencyAmount` can be used to set the currency and related
 > options (such as the number of fraction digits).
 
+### Non-Negative Integer Options
 
+Some _options_ of number _functions_ are defined to take a "non-negative integer".
+In most cases, these control the number of various kinds of digits.
+
+A "non-negative integer" is one of:
+- an implementation-defined integer numeric type where the value of the 
+  encoded number is not less than zero
+- a literal consisting only of ASCII digits U+0030 through U+0039;
+  An implementation MAY define an upper limit on the length of such a literal
+  or of the value encoded by such a literal.
 
 ### Number Selection
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -624,12 +624,21 @@ All other values produce an _Invalid Expression_ error.
 Some _options_ of number _functions_ are defined to take a "non-negative integer".
 In most cases, these control the number of various kinds of digits.
 
-A "non-negative integer" is one of:
-- an implementation-defined integer numeric type where the value of the 
-  encoded number is not less than zero
-- a literal consisting only of ASCII digits U+0030 through U+0039;
-  An implementation MAY define an upper limit on the length of such a literal
-  or of the value encoded by such a literal.
+A "non-negative integer" is a variable reference or literal whose value evaluates 
+as an integer greater than or equal to zero.
+If the value is passed as a literal
+it MUST contain only the ASCII digits U+0030 through U+0039.
+Implementations MAY define an upper limit on the length of such a literal.
+Implementations MAY define an upper limit on the resolved value 
+of a non-negative integer option consistent with that implementation's practical limits.
+
+> **Examples of literal non-negative integer options**
+> ```
+> {$n :number maximumFractionDigits=12}
+> {$n :number maximumFractionDigits=|12|}
+> {$n :number maximumFractionDigits=123456}
+> {$n :number maximumFractionDigits=|0123|}
+> ```
 
 ### Number Selection
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -632,8 +632,10 @@ of a non-negative integer option consistent with that implementation's practical
 
 The implementation MAY accept any implementation-defined type as the value.
 Implementations MUST accept the value as a _literal_.
-When the value is a _literal_,
-it MUST consist of a sequence of ASCII digits in the range U+0030 through U+0039.
+When the value is a _literal_, it MUST match `non-negative` in this ABNF:
+>```abnf
+>non-negative = "0" / (("1"-"9") *DIGIT)
+>```
 
 > **Examples of  non-negative integer options**
 > 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -622,7 +622,8 @@ All other values produce an _Invalid Expression_ error.
 ### Non-Negative Integer Options
 
 Some _options_ of number _functions_ are defined to take a "non-negative integer".
-In most cases, these control the number of various kinds of digits.
+In this specification, these _options_ are used to control aspects of numeric display
+such as the number of fraction, integer, or significant digits.
 
 A "non-negative integer" is a variable reference or literal whose value evaluates 
 as an integer greater than or equal to zero.

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -637,27 +637,6 @@ When the value is a _literal_, it MUST match `non-negative` in this ABNF:
 >non-negative = "0" / (("1"-"9") *DIGIT)
 >```
 
-> **Examples of  non-negative integer options**
-> 
-> Here are some examples of valid literals:
-> ```
-> {$n :number maximumFractionDigits=12}
-> {$n :number maximumFractionDigits=|12|}
-> {$n :number maximumFractionDigits=123456}
-> {$n :number maximumFractionDigits=|0123|}
-> ```
-> Note that the value can be passed as an input variable or defined via a declaration.
-> For example, the following _messages_ might be valid in an implementation that
-> accepted the type `int` and the variable `min` were passed as input:
-> ```
-> .local $max = {1 :integer}
-> {{You have {$n :number maximumFractionDigits=$max}}}
->
-> {{{$n :number minimumFractionDigits=$min} where 'min' is an 'int' >= 0}}
->
-> .local $max = {|2|}
-> {{{$n :number maximumFractionDigits=$max} where 'max' is a literal}}
-> ```
 
 ### Number Selection
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -398,15 +398,15 @@ The following options and their values are required to be available on the funct
   - `never`
   - `min2`
 - `minimumIntegerDigits`
-  - ([non-negative integer](#non-negative-integer-options), default: `1`)
+  - ([digit size option](#digit-size-options), default: `1`)
 - `minimumFractionDigits`
-  - ([non-negative integer](#non-negative-integer-options))
+  - ([digit size option](#digit-size-options))
 - `maximumFractionDigits`
-  - ([non-negative integer](#non-negative-integer-options))
+  - ([digit size option](#digit-size-options))
 - `minimumSignificantDigits`
-  - ([non-negative integer](#non-negative-integer-options))
+  - ([digit size option](#digit-size-options))
 - `maximumSignificantDigits`
-  - ([non-negative integer](#non-negative-integer-options))
+  - ([digit size option](#digit-size-options))
 
 > [!NOTE]
 > The following options and option values are being developed during the Technical Preview
@@ -515,9 +515,9 @@ function `:integer`:
   - `always`
   - `min2`
 - `minimumIntegerDigits`
-  - ([non-negative integer](#non-negative-integer-options), default: `1`)
+  - ([digit size option](#digit-size-options), default: `1`)
 - `maximumSignificantDigits`
-  - ([non-negative integer](#non-negative-integer-options))
+  - ([digit size option](#digit-size-options))
 
 > [!NOTE]
 > The following options and option values are being developed during the Technical Preview
@@ -619,22 +619,23 @@ All other values produce an _Invalid Expression_ error.
 > or the type `com.ibm.icu.util.CurrencyAmount` can be used to set the currency and related
 > options (such as the number of fraction digits).
 
-### Non-Negative Integer Options
+### Digit Size Options
 
-Some _options_ of number _functions_ are defined to take a "non-negative integer".
+Some _options_ of number _functions_ are defined to take a "digit size option".
 Implementations of number _functions_ use these _options_ to control aspects of numeric display
 such as the number of fraction, integer, or significant digits.
 
-A "non-negative integer" is an _option_ value that the _function_ evaluates as an integer 
-greater than or equal to zero.
+A "digit size option" is an _option_ value that the _function_ interprets
+as a small integer value greater than or equal to zero.
 Implementations MAY define an upper limit on the resolved value 
-of a non-negative integer option consistent with that implementation's practical limits.
+of a digit size option option consistent with that implementation's practical limits.
 
-The implementation MAY accept any implementation-defined type as the value.
-Implementations MUST accept a _literal_ as the value.
-When the value is a _literal_, it MUST match `non-negative` in this ABNF:
+In most cases, the value of a digit size option will be a string literal that
+encodes the value as a decimal integer.
+Implementations MAY also accept implementation-defined types as the value.
+The _literal_ representation of a digit size option matches the following ABNF:
 >```abnf
->non-negative = "0" / (("1"-"9") *DIGIT)
+> digit-size-option = "0" / (("1"-"9") [DIGIT])
 >```
 
 


### PR DESCRIPTION
@catamorphism identified this as a gap in e.g. #739. 

This PR defines what a non-negative integer option value is for `:number` and `:integer`. It does not attempt to address the larger question raised in 738/739.