### PR TITLE
Fix "unsupported expression" example

### DIFF
--- a/spec/errors.md
+++ b/spec/errors.md
@@ -226,7 +226,7 @@ or for private implementation use that is not supported by the current implement
 > would always result in an _Unsupported Expression_ error:
 >
 > ```
-> The value is {@horse}.
+> The value is {!horse}.
 > ```
 >
 > Attempting to format this message would result in an _Unsupported Expression_ error


### PR DESCRIPTION
This example is now a syntax error, because of attributes. Changed to an example that would be an "unsupported expression" error.