### PR TITLE
Collapse all escape sequence rules into one

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -1,8 +1,8 @@
 message           = simple-message / complex-message
 
 simple-message    = [simple-start pattern]
-simple-start      = simple-start-char / text-escape / placeholder
-pattern           = *(text-char / text-escape / placeholder)
+simple-start      = simple-start-char / escaped-char / placeholder
+pattern           = *(text-char / escaped-char / placeholder)
 placeholder       = expression / markup
 
 complex-message   = *(declaration [s]) complex-body
@@ -43,7 +43,7 @@ attribute      = "@" identifier [[s] "=" [s] (literal / variable)]
 
 variable       = "$" name
 literal        = quoted / unquoted
-quoted         = "|" *(quoted-char / quoted-escape) "|"
+quoted         = "|" *(quoted-char / escaped-char) "|"
 unquoted       = name / number-literal
 ; number-literal matches JSON number (https://www.rfc-editor.org/rfc/rfc8259#section-6)
 number-literal = ["-"] (%x30 / (%x31-39 *DIGIT)) ["." 1*DIGIT] [%i"e" ["-" / "+"] 1*DIGIT]
@@ -67,7 +67,7 @@ reserved-annotation-start = "!" / "%" / "*" / "+" / "<" / ">" / "?" / "~"
 ; Reserve sigils for private-use by implementations.
 private-use-annotation    = private-start reserved-body
 private-start             = "^" / "&"
-reserved-body             = *([s] 1*(reserved-char / reserved-escape / quoted))
+reserved-body             = *([s] 1*(reserved-char / escaped-char / quoted))
 
 ; Names and identifiers
 ; identifier matches https://www.w3.org/TR/REC-xml-names/#NT-QName
@@ -100,10 +100,8 @@ content-char      = %x01-08        ; omit NULL (%x00), HTAB (%x09) and LF (%x0A)
                   / %xE000-10FFFF
 
 ; Character escapes
-text-escape     = backslash ( backslash / "{" / "}" )
-quoted-escape   = backslash ( backslash / "|" )
-reserved-escape = backslash ( backslash / "{" / "|" / "}" )
-backslash       = %x5C ; U+005C REVERSE SOLIDUS "\"
+escaped-char = backslash ( backslash / "{" / "|" / "}" )
+backslash    = %x5C ; U+005C REVERSE SOLIDUS "\"
 
 ; Whitespace
 s = 1*( SP / HTAB / CR / LF / %x3000 )

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -149,7 +149,7 @@ An empty string is a valid _simple message_.
 
 ```abnf
 simple-message = [simple-start pattern]
-simple-start   = simple-start-char / text-escape / placeholder
+simple-start   = simple-start-char / escaped-char / placeholder
 ```
 
 A **_<dfn>complex message</dfn>_** is any _message_ that contains _declarations_,
@@ -255,7 +255,7 @@ Unless there is an error, resolving a _message_ always results in the formatting
 of a single _pattern_.
 
 ```abnf
-pattern = *(text-char / text-escape / placeholder)
+pattern = *(text-char / escaped-char / placeholder)
 ```
 A _pattern_ MAY be empty.
 
@@ -291,7 +291,7 @@ U+007B LEFT CURLY BRACKET `{`, and U+007D RIGHT CURLY BRACKET `}`
 MUST be escaped as `\\`, `\{`, and `\}` respectively.
 
 In the ABNF, _text_ is represented by non-empty sequences of
-`simple-start-char`, `text-char`, and `text-escape`.
+`simple-start-char`, `text-char`, and `escaped-char`.
 The first of these is used at the start of a _simple message_,
 and matches `text-char` except for not allowing U+002E FULL STOP `.`.
 The ABNF uses `content-char` as a shared base for _text_ and _quoted literal_ characters.
@@ -656,7 +656,7 @@ unrecognized _reserved-annotations_ or _private-use-annotations_ have no meaning
 reserved-annotation       = reserved-annotation-start reserved-body
 reserved-annotation-start = "!" / "%" / "*" / "+" / "<" / ">" / "?" / "~"
 
-reserved-body             = *([s] 1*(reserved-char / reserved-escape / quoted))
+reserved-body             = *([s] 1*(reserved-char / escaped-char / quoted))
 ```
 
 ## Markup
@@ -830,7 +830,7 @@ of number values in _operands_ or _options_, or as _keys_ for _variants_.
 
 ```abnf
 literal        = quoted / unquoted
-quoted         = "|" *(quoted-char / quoted-escape) "|"
+quoted         = "|" *(quoted-char / escaped-char) "|"
 unquoted       = name / number-literal
 number-literal = ["-"] (%x30 / (%x31-39 *DIGIT)) ["." 1*DIGIT] [%i"e" ["-" / "+"] 1*DIGIT]
 ```
@@ -912,14 +912,13 @@ An **_<dfn>escape sequence</dfn>_** is a two-character sequence starting with
 U+005C REVERSE SOLIDUS `\`.
 
 An _escape sequence_ allows the appearance of lexically meaningful characters
-in the body of _text_, _quoted_, or _reserved_ (which includes, in this case,
-_private-use_) sequences respectively:
+in the body of _text_, _quoted_, or _reserved_
+(which includes, in this case, _private-use_) sequences.
+Each _escape sequence_ represents the literal character immediately following the initial `\`.
 
 ```abnf
-text-escape     = backslash ( backslash / "{" / "}" )
-quoted-escape   = backslash ( backslash / "|" )
-reserved-escape = backslash ( backslash / "{" / "|" / "}" )
-backslash       = %x5C ; U+005C REVERSE SOLIDUS "\"
+escaped-char = backslash ( backslash / "{" / "|" / "}" )
+backslash    = %x5C ; U+005C REVERSE SOLIDUS "\"
 ```
 
 ### Whitespace


### PR DESCRIPTION
Currently, we are very strict about which characters may be escaped, and where. This means that in the syntax we have https://github.com/unicode-org/message-format-wg/blob/6d7b4ba213e686ff2d403d3025d38d76b42b75f7/spec/message.abnf#L103-L105

As discussed in #635 and during the 2024-03-18 call, this could be simplified by allowing each of the characters `\`, `{`, `|`, `}` to be escaped in all the positions we allow for any of them to be escaped. Doing so would simplify the syntax, make escaping easier to understand for users, and simplify implementations.

This relaxation would come with the small cost of making the messages `this|that` and `this\|that` synonymous, much like we already allow for `hello` and `{{hello}}` to be synonymous.

This PR is not intended for consideration for the LDML 45 release of MF2, but after that.