### PR TITLE
A few proposed tweaks to syntax.md.

### DIFF
--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -648,8 +648,10 @@ on the contents of these _annotations_.
 Implementations MUST NOT assign meaning or semantics to
 an _annotation_ starting with `reserved-annotation-start`:
 these are reserved for future standardization.
-Implementations MUST trim whitespace around a _reserved body_,
-but MUST NOT remove or alter the contents of a _reserved body_.
+Whitespace before or after a _reserved body_ is not part of the _reserved body_.
+Implementations MUST NOT remove or alter the contents of a _reserved body_,
+including any interior whitespace,
+but MAY remove or alter whitespace before or after the _reserved body_.
 
 While a reserved sequence is technically "well-formed",
 unrecognized _reserved-annotations_ or _private-use-annotations_ have no meaning.


### PR DESCRIPTION
This assumes that PR #731 is applied.

In detail:

* Since the reserved keywords start with a `.`, we need to talk about the keyword `.match`, not `match`.

* Saying that "A _reserved annotation_ starts with a reserved character" and "A _reserved annotation_ MAY be empty" is a contradiction. Therefore, we need to distinguish a _reserved annotation_ from a _reserved body_. This distinction is also useful because the _reserved body_ occurs in two other places as well.

* The statement that a _reserved body_ contains "arbitrary text" is not true, since we have now decided that (unless empty) it must start and end with a non-whitespace character.

* A nonterminal `reserved-start` does not exist. What is meant is `reserved-annotation-start`.

* The statement "Implementations MUST NOT remove or alter the contents of a _reserved annotation_." needs to be constrained, because now implementations are SUPPOSED to trim whitespace around the _reserved body_.