### PR TITLE
Clarify that .match selectors are not declarations

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -490,8 +490,11 @@ When all of the _selectors_ have been processed,
 the earliest-sorted _variant_ in the remaining list of _variants_ is selected.
 
 > [!NOTE]
-> A _selector_ _expression_ is not a _declaration_,
-> and its _annotation_ has no effect on the value of its _operand_ during formatting.
+> A _selector_ is not a _declaration_.
+> Even when the same _function_ can be used for both formatting and selection
+> of a given _operand_
+> the _annotation_ that appears in a _selector_ has no effect on subsequent
+> _selectors_ nor on the formatting used in _placeholders_.
 > To use the same value for selection and formatting,
 > set its value with a `.input` or `.local` _declaration_.
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -489,6 +489,12 @@ Earlier _selectors_ in the _matcher_'s list of _selectors_ have a higher priorit
 When all of the _selectors_ have been processed,
 the earliest-sorted _variant_ in the remaining list of _variants_ is selected.
 
+> [!NOTE]
+> A _selector_ _expression_ is not a _declaration_,
+> and its _annotation_ has no effect on the value of its _operand_ during formatting.
+> To use the same value for selection and formatting,
+> set its value with a `.input` or `.local` _declaration_.
+
 This selection method is defined in more detail below.
 An implementation MAY use any pattern selection method,
 as long as its observable behavior matches the results of the method defined here.
@@ -692,10 +698,11 @@ and an `en` (English) locale,
 the pattern selection proceeds as follows for this message:
 
 ```
-.match {$count :number}
-one {{Category match}}
-1   {{Exact match}}
-*   {{Other match}}
+.input {$count :number}
+.match {$count}
+one {{Category match for {$count}}}
+1   {{Exact match for {$count}}}
+*   {{Other match for {$count}}}
 ```
 
 1. For the selector:<br>
@@ -716,7 +723,7 @@ one {{Category match}}
    This is then sorted as:<br>
    « ( 0, `1` ), ( 1, `one` ), ( 2, `*` ) »<br>
 
-4. The pattern `Exact match` of the most preferred `1` variant is selected.
+4. The pattern `Exact match for {$count}` of the most preferred `1` variant is selected.
 
 ## Formatting
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -409,8 +409,8 @@ There MAY be any number of additional _selectors_.
 > A message with two _selectors_:
 >
 > ```
-> .input {$numLikes :number}
-> .input {$numShares :number}
+> .input {$numLikes :integer}
+> .input {$numShares :integer}
 > .match {$numLikes} {$numShares}
 > 0   0   {{Your item has no likes and has not been shared.}}
 > 0   one {{Your item has no likes and has been shared {$numShares} time.}}

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -369,7 +369,8 @@ match-statement = match 1*([s] selector)
 > A _message_ with a _matcher_:
 >
 > ```
-> .match {$count :number}
+> .input {$count :number}
+> .match {$count}
 > one {{You have {$count} notification.}}
 > *   {{You have {$count} notifications.}}
 > ```
@@ -408,7 +409,9 @@ There MAY be any number of additional _selectors_.
 > A message with two _selectors_:
 >
 > ```
-> .match {$numLikes :number} {$numShares :number}
+> .input {$numLikes :number}
+> .input {$numShares :number}
+> .match {$numLikes} {$numShares}
 > 0   0   {{Your item has no likes and has not been shared.}}
 > 0   one {{Your item has no likes and has been shared {$numShares} time.}}
 > 0   *   {{Your item has no likes and has been shared {$numShares} times.}}


### PR DESCRIPTION
Closes #748

Adds a clarifying note about `.match` not acting as a declaration and updates misleading examples.