### PR TITLE
[DESIGN] Effect of selectors on placeholders

### DIFF
--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -156,7 +156,7 @@ _What other properties they have?_
 
 In this alternative, we modify the syntax to allow selectors to 
 annotate an input variable (as with `.input`)
-or assign a local variable (as with `.local`).
+or bind a local variable (as with `.local`).
 Either annotation is immutable and results in a Duplicate Declaration error
 if it attempts to annotate a variable previously annotated.
 

--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -176,6 +176,7 @@ Examples:
 - No changes required.
 - `.local` can be used to solve problems with variations in selection and formatting
 - Supports multiple selectors on the same operand
+
 **Cons**
 - May require the user to annotate the operand for both formatting and selection.
 - Can produce a mismatch between formatting and selection, since the operand's formatting

--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -1,0 +1,79 @@
+# Effect of Selectors on Subsequent Placeholders
+
+Status: **Proposed**
+
+<details>
+	<summary>Metadata</summary>
+	<dl>
+		<dt>Contributors</dt>
+		<dd>@aphillips</dd>
+		<dt>First proposed</dt>
+		<dd>2024-03-27</dd>
+		<dt>Pull Requests</dt>
+		<dd>#000</dd>
+	</dl>
+</details>
+
+## Objective
+
+_What is this proposal trying to achieve?_
+
+Define what effect (if any) the _annotation_ of a _selector_ has on subsequent _placeholders_
+that access the same _operand_ value.
+
+## Background
+
+_What context is helpful to understand this proposal?_
+
+In MFv2, we require that all _selectors_ have an _annotation_.
+
+Ideally, a _selector_ and a _formatter_ for the same _function_ operating on the same _operand_ 
+use the same options.
+
+```
+.input {$num :number minimumFractionDigits=2}
+.match {$num}
+one {{Unreachable in English locale}}
+*   {{This prints {$num} with two decimal places.}}
+```
+
+It is tempting to want to write this as a shorthand:
+
+```
+.match {$num :number minimumFractionDigits=2}
+one {{Unreachable...}}
+*   {{This prints {$num} with two decimal places.}}
+```
+
+## Use-Cases
+
+_What use-cases do we see? Ideally, quote concrete examples._
+
+**Multiple Selection Conflicts**
+If a user writes multiple selectors for the same operand, which one formats the placeholder?
+
+```
+.match {$num :integer} {$num :number minimumFractionDigits=2}
+* * {{What is printed for {$num}?}}
+
+.match {$num :number minimumFractionDigits=2} {$num :integer}
+* * {{What is printed for {$num}?}}
+```
+
+## Requirements
+
+_What properties does the solution have to manifest to enable the use-cases above?_
+
+## Constraints
+
+_What prior decisions and existing conditions limit the possible design?_
+
+## Proposed Design
+
+_Describe the proposed solution. Consider syntax, formatting, errors, registry, tooling, interchange._
+
+## Alternatives Considered
+
+_What other solutions are available?_
+_How do they compare against the requirements?_
+_What other properties they have?_

--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -25,24 +25,41 @@ that access the same _operand_ value.
 
 _What context is helpful to understand this proposal?_
 
-In MFv2, we require that all _selectors_ have an _annotation_.
+In MF2, we require that all _selectors_ have an _annotation_.
+The purpose of this requirement is to help ensure that a _selector_ on a given _operand_
+is working with the same value as the _formatter_ eventually used for presentation
+of that _operand_.
+This is needed because the format of a value can have an effect on the grammar used
+in the localized _message_.
 
-Ideally, a _selector_ and a _formatter_ for the same _function_ operating on the same _operand_ 
-use the same options.
+For example, in English:
+
+> You have 1 mile to go.
+> You have 1.0 miles to go.
+
+These messages might be written as:
 
 ```
-.input {$num :number minimumFractionDigits=2}
-.match {$num}
-one {{Unreachable in English locale}}
-*   {{This prints {$num} with two decimal places.}}
+.input {$togo :integer}
+.match {$togo}
+0   {{You have arrived.}}
+one {{You have {$togo} mile to go.}}
+*   {{You have {$togo} miles to go.}}
+
+.input {$togo :number minimumFractionDigits=1}
+.match {$togo}
+0   {{You have arrived.}}
+one {{Unreachable in an English locale.}}
+*   {{You have {$togo} miles to go.}}
 ```
 
-It is tempting to want to write this as a shorthand:
+It is tempting to want to write these as a shorthand, with the _annotation_ in the _selector_:
 
 ```
-.match {$num :number minimumFractionDigits=2}
-one {{Unreachable...}}
-*   {{This prints {$num} with two decimal places.}}
+.match {$togo :integer}
+0   {{You have arrived.}}
+one {{You have {$togo} mile to go.}}
+*   {{You have {$togo} miles to go.}}
 ```
 
 ## Use-Cases
@@ -54,11 +71,14 @@ If a user writes multiple selectors for the same operand, which one formats the 
 
 ```
 .match {$num :integer} {$num :number minimumFractionDigits=2}
-* * {{What is printed for {$num}?}}
+* * {{Which selector formats {$num}?}}
 
 .match {$num :number minimumFractionDigits=2} {$num :integer}
-* * {{What is printed for {$num}?}}
+* * {{Which selector formats {$num}?}}
 ```
+
+If both formats are needed in the message, how does one reference one or the other?
+
 
 ## Requirements
 

--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -152,6 +152,53 @@ _What other solutions are available?_
 _How do they compare against the requirements?_
 _What other properties they have?_
 
+### Allow both local and input declarative selectors with immutability
+
+In this alternative, we modify the syntax to allow selectors to 
+annotate an input variable (as with `.input`)
+or assign a local variable (as with `.local`).
+Either annotation is immutable and results in a Duplicate Declaration error
+if it attempts to annotate a variable previously annotated.
+
+Example:
+```
+.match {$input :function} $local = {$input :function}
+* * {{This annotates {$input} and assigns {$local} a value.}}
+
+.match $local1 = {$input :function} $local2 = {$input :function2}
+* * {{This assigns two locals}}
+
+.input {$input :function}
+.local $local = {$input :function}
+.match {$input :function} {$local :function}
+* * {{This produces two duplicate declaration errors.}}
+```
+
+The ABNF change looks like:
+```abnf
+selector          = expression / declaration
+declaration       = s variable [s] "=" [s] expression
+```
+
+**Pros**
+- Shorthand is consistent with the rest of the syntax
+- Shorthand version works intuitively with minimal input
+- Preserves immutability
+- Produces an error when users inappropriately annotate some items
+
+**Cons**
+- Selectors can't provide additional selection-specific options
+  if the value has already been annotated
+- Doesn't allow multiple selection on the same operand, e.g.
+  ```
+  .input {$date :datetime skeleton=yMdjm}
+  .match {$date :datetime field=month} {$date :datetime field=dayOfWeek}
+  * * {{This message produces a Duplicate Declaration error
+        even though selection is separate from formatting.}}
+  ```
+  However, this design does allow for a local variable to be easily created
+  for the purpose of selection.
+
 #### Allow "Declarative" Selectors with _Mutability_
 
 In this alternative, selectors are treated as declaration-selectors.

--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -217,7 +217,7 @@ declaration       = s variable [s] "=" [s] expression
 
 **Cons**
 - Selectors can't provide additional selection-specific options
-  if the value has already been annotated
+  if the variable name is already in scope
 - Doesn't allow multiple selection on the same operand, e.g.
   ```
   .input {$date :datetime skeleton=yMdjm}

--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -104,7 +104,7 @@ _What use-cases do we see? Ideally, quote concrete examples._
    > Note that this is currently provided for by the spec.
 
 
-**Multiple Selection Conflicts**
+### Multiple Selection Conflicts
 If a user writes multiple selectors for the same operand, which one formats the placeholder?
 
 ```
@@ -118,7 +118,7 @@ If a user writes multiple selectors for the same operand, which one formats the 
 If both formats are needed in the message (presumably they are or why the selector), 
 how does one reference one or the other?
 
-**Selection Different From Format**
+### Selection Is Different From Format
 If a user wants to separate selection and formatting, 
 but selectors have a formatting side-effect,
 how do I write a selector that doesn't interfere with the formatting of the _same_ operand?
@@ -130,7 +130,7 @@ How can a user write a _selector_ that doesn't mess up a _formatter_?
 ```
 .input {$d :datetime skeleton=yMMMdjm}
 .match {$d :datetime month=numeric}
-1 {{Today is {$d} in cold cold January}}
+1 {{Today is {$d} in cold cold {$d :datetime month=long}}}
 * {{Today is {$d}}}
 ```
 
@@ -152,9 +152,14 @@ _What other solutions are available?_
 _How do they compare against the requirements?_
 _What other properties they have?_
 
-#### Do What Comes Last
+#### Allow "Declarative" Selectors with _Mutability_
 
-In this alternative, selectors override declarations.
+In this alternative, selectors are treated as declaration-selectors.
+That is, an annotation in a selector works like a `.input`.
+This permits `.match` selectors to be a shorthand when no declarations exist.
+
+It is not an error to overwrite a previous annotation.
+Instead the selector's annotation replaces what came before.
 
 ```
 .input {$num :integer}
@@ -163,12 +168,12 @@ In this alternative, selectors override declarations.
 ```
 
 **Pros**
-- ... thinking, thinking...
+- Shorthand version works intuitively with minimal typing.
 
 **Cons**
 - Violates immutability that we've established everywhere else
 
-#### Declaring Selectors with Immutability
+#### Allow "Declarative" Selectors with _Immutability_
 
 In this alternative, selectors are treated as declaration-selectors.
 That is, an annotation in a selector works like a `.input`.
@@ -176,7 +181,8 @@ However, it is an error for the selector to try to modify a previous declaration
 (just as it is an error for a declaration to try to modify a previous declaration).
 This permits `.match` selectors to be a shorthand when no declarations exist.
 
-It is also an error for a selector to modify a previous selector
+It is also an error for a selector to modify a previous selector.
+This implies that multiple selecton on the same operand is pointless.
 
 ```
 .match {$num :integer}
@@ -192,6 +198,8 @@ It is also an error for a selector to modify a previous selector
 
 **Pros**
 - Shorthand version works intuitively with minimal typing
+- Preserves immutability
+- Produces an error when users inappropriately annotate some items
 
 **Cons**
 - Selectors can't provide additional selection-specific options

--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -103,7 +103,7 @@ _What use-cases do we see? Ideally, quote concrete examples._
    ```
    > Note that this is currently provided for by the spec.
 
-5. As a user, I want to write multiple selectors for the same operand.
+5. As a user, I want to write multiple selectors using the same variable with different annotations.
    How do I know which one will format the placeholder later?
    ```
    .match {$num :integer} {$num :number minimumFractionDigits=2}

--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -259,6 +259,37 @@ This implies that multiple selecton on the same operand is pointless.
         even though selection is separate from formatting.}}
   ```
 
+#### Match on variables instead of expressions
+
+In this alternative, the `.match` syntax is simplified
+to work on variable references rather than expressions:
+
+```
+.input {$count :number}
+.match $count
+one {{You have {$count} apple}}
+* {{You have {$count} apples}}
+
+.local $empty = {$theList :isEmpty}
+.match $empty
+true {{You bought nothing}}
+* {{You bought {$theList}!}}
+```
+
+The ABNF change would look like:
+```diff
+ match-statement   = match 1*([s] selector)
+-selector          = expression
++selector          = variable
+```
+
+**Pros**
+- Overall the syntax is simplified.
+- Preserves immutability.
+
+**Cons**
+- A separate declaration is required for each selector.
+
 #### Provide a `#`-like Feature
 
 (Copy-pasta adapted from @eemeli's proposal in #736)

--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -186,7 +186,7 @@ Examples:
 In this alternative, we modify the syntax to allow selectors to 
 annotate an input variable (as with `.input`)
 or bind a local variable (as with `.local`).
-Either annotation is immutable and results in a Duplicate Declaration error
+Either variable binding is immutable and results in a Duplicate Declaration error
 if it attempts to annotate a variable previously annotated.
 
 Example:

--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -199,7 +199,7 @@ It is also an error for a selector to modify a previous selector
 - Doesn't allow multiple selection on the same operand, e.g.
   ```
   .input {$date :datetime skeleton=yMdjm}
-  .match {$date :datetime field=month} {{$date ::datetime field=dayOfWeek}
+  .match {$date :datetime field=month} {$date :datetime field=dayOfWeek}
   * * {{This message produces a Duplicate Declaration error
         even though selection is separate from formatting.}}
   ```

--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -79,6 +79,16 @@ If a user writes multiple selectors for the same operand, which one formats the 
 
 If both formats are needed in the message, how does one reference one or the other?
 
+**Selection Different From Format**
+We don't support selection on dates in LDML45, but it's easy to conceptualize.
+How can a user write a _selector_ that doesn't mess up a _formatter_?
+
+```
+.input {$d :datetime skeleton=yMMMdjm}
+.match {$d :datetime month=numeric}
+1 {{Today is {$d} in cold cold January}}
+* {{Today is {$d}}}
+```
 
 ## Requirements
 

--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -235,7 +235,7 @@ That is, an annotation in a selector works like a `.input`.
 This permits `.match` selectors to be a shorthand when no declarations exist.
 The option does not permit local variable declaration.
 
-It is not an error to overwrite a previous annotation.
+It is not an error to re-declare a variable that is in scope.
 Instead the selector's annotation replaces what came before.
 
 ```


### PR DESCRIPTION
Fixes #736, Works on #747 

This design document describes the effect of selectors on subsequent pattern placeholders of the same operand. It presents several alternatives.

This is still in "DRAFT" form and not yet ready for the WG as a whole.