### PR TITLE
Change format of test/data-model-errors.json file

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -5,9 +5,8 @@ These test files are intended to be useful for testing multiple different messag
 
 - `syntax-errors.json` — An array of strings that should produce a Syntax Error when parsed.
 
-- `data-model-errors.json` - An array of objects.
-   Each object has exactly one key, which is the name of the error, `error`.
-   The key's value is an array of strings that
+- `data-model-errors.json` - An object with string keys and arrays of strings as values,
+     where each key is the name of an error and its value is an array of strings that
      should produce `error` when processed.
      Error names are defined in ["MessageFormat 2.0 Errors"](../spec/errors.md) in the spec.
 

--- a/test/README.md
+++ b/test/README.md
@@ -5,8 +5,9 @@ These test files are intended to be useful for testing multiple different messag
 
 - `syntax-errors.json` — An array of strings that should produce a Syntax Error when parsed.
 
-- `data-model-errors.json` - An object with string keys and arrays of strings as values,
-     where each key is the name of an error and its value is array of strings that
+- `data-model-errors.json` - An array of objects.
+   Each object has exactly one key, which is the name of the error, `error`.
+   The key's value is an array of strings that
      should produce `error` when processed.
      Error names are defined in ["MessageFormat 2.0 Errors"](../spec/errors.md) in the spec.
 

--- a/test/data-model-errors.json
+++ b/test/data-model-errors.json
@@ -1,19 +1,23 @@
 [
-    "Variant Key Mismatch": [
+    {
+        "Variant Key Mismatch": [
         ".match {$foo :x} * * {{foo}}",
         ".match {$foo :x} {$bar :x} * {{foo}}"
-    ],
-    "Missing Fallback Variant": [
+    ]},
+    {
+        "Missing Fallback Variant": [
         ".match {:foo} 1 {{_}}",
         ".match {:foo} other {{_}}",
         ".match {:foo} {:bar} * 1 {{_}} 1 * {{_}}"
-    ],
-    "Missing Selector Annotation": [
+    ]},
+    {
+        "Missing Selector Annotation": [
         ".match {$foo} one {{one}} * {{other}}",
         ".input {$foo} .match {$foo} one {{one}} * {{other}}",
         ".local $foo = {$bar} .match {$foo} one {{one}} * {{other}}"
-    ],
-    "Duplicate Declaration": [
+    ]},
+    {
+        "Duplicate Declaration": [
         ".input {$foo} .input {$foo} {{_}}",
         ".input {$foo} .local $foo = {42} {{_}}",
         ".local $foo = {42} .input {$foo} {{_}}",
@@ -23,10 +27,11 @@
         ".local $foo = {$bar} .local $bar = {$baz} {{_}}",
         ".local $foo = {$bar :func} .local $bar = {$baz} {{_}}",
         ".local $foo = {42 :func opt=$foo} {{_}}",
-        ".local $foo = {42 :func opt=$bar} .local $bar = {42} {{_}}",
-    ],
+        ".local $foo = {42 :func opt=$bar} .local $bar = {42} {{_}}"
+    ]},
+    {
     "Duplicate Option Name": [
             "bad {:placeholder option=x option=x}",
             "bad {:placeholder ns:option=x ns:option=y}"
-    ]
+    ]}
 ]

--- a/test/data-model-errors.json
+++ b/test/data-model-errors.json
@@ -1,23 +1,19 @@
-[
-    {
-        "Variant Key Mismatch": [
+{
+    "Variant Key Mismatch": [
         ".match {$foo :x} * * {{foo}}",
         ".match {$foo :x} {$bar :x} * {{foo}}"
-    ]},
-    {
-        "Missing Fallback Variant": [
+    ],
+    "Missing Fallback Variant": [
         ".match {:foo} 1 {{_}}",
         ".match {:foo} other {{_}}",
         ".match {:foo} {:bar} * 1 {{_}} 1 * {{_}}"
-    ]},
-    {
-        "Missing Selector Annotation": [
+    ],
+    "Missing Selector Annotation": [
         ".match {$foo} one {{one}} * {{other}}",
         ".input {$foo} .match {$foo} one {{one}} * {{other}}",
         ".local $foo = {$bar} .match {$foo} one {{one}} * {{other}}"
-    ]},
-    {
-        "Duplicate Declaration": [
+    ],
+    "Duplicate Declaration": [
         ".input {$foo} .input {$foo} {{_}}",
         ".input {$foo} .local $foo = {42} {{_}}",
         ".local $foo = {42} .input {$foo} {{_}}",
@@ -28,10 +24,9 @@
         ".local $foo = {$bar :func} .local $bar = {$baz} {{_}}",
         ".local $foo = {42 :func opt=$foo} {{_}}",
         ".local $foo = {42 :func opt=$bar} .local $bar = {42} {{_}}"
-    ]},
-    {
+    ],
     "Duplicate Option Name": [
             "bad {:placeholder option=x option=x}",
             "bad {:placeholder ns:option=x ns:option=y}"
-    ]}
-]
+    ]
+}


### PR DESCRIPTION
While modifying ICU4C tests to read JSON directly from the test files in this repo, I noticed that the data-model-errors.json file I'd previously contributed is not actually valid JSON. 

Added braces to make it valid, and updated README file accordingly.