### PR TITLE
Match date/time formatter output to ICU formatting

### DIFF
--- a/test/test-functions.json
+++ b/test/test-functions.json
@@ -25,18 +25,18 @@
       "exp": "{|horse|}",
       "errors": [{ "type": "bad-input" }]
     },
-    { "src": "{|2006-01-02T15:04:06| :time}", "exp": "3:04 PM" },
+    { "src": "{|2006-01-02T15:04:06| :time}", "exp": "3:04\u202FPM" },
     {
       "src": "{|2006-01-02T15:04:06| :time style=medium}",
-      "exp": "3:04:06 PM"
+      "exp": "3:04:06\u202FPM"
     },
     {
       "src": ".local $t = {|2006-01-02T15:04:06| :time style=medium} {{{$t :time}}}",
-      "exp": "3:04:06 PM"
+      "exp": "3:04:06\u202FPM"
     },
     {
       "src": ".local $d = {|2006-01-02T15:04:06| :date} {{{$d :time}}}",
-      "exp": "3:04 PM"
+      "exp": "3:04\u202FPM"
     }
   ],
   "datetime": [
@@ -56,7 +56,7 @@
       "exp": "{|horse|}",
       "errors": [{ "name": "RangeError" }]
     },
-    { "src": "{|2006-01-02T15:04:06| :datetime}", "exp": "1/2/06, 3:04 PM" },
+    { "src": "{|2006-01-02T15:04:06| :datetime}", "exp": "1/2/06, 3:04\u202FPM" },
     {
       "src": "{|2006-01-02T15:04:06| :datetime year=numeric month=|2-digit|}",
       "exp": "01/2006"
@@ -67,12 +67,12 @@
     },
     {
       "src": "{|2006-01-02T15:04:06| :datetime timeStyle=medium}",
-      "exp": "3:04:06 PM"
+      "exp": "3:04:06\u202FPM"
     },
     {
       "src": "{$dt :datetime}",
       "params": { "dt": "2006-01-02T15:04:06" },
-      "exp": "1/2/06, 3:04 PM"
+      "exp": "1/2/06, 3:04\u202FPM"
     }
   ],
   "integer": [


### PR DESCRIPTION
In trying to integrate the spec tests directly into the ICU4C tests (without modifying the JSON files), I noticed an inconsistency between the `time` and `datetime` functions' output as specified in the test, and what ICU outputs. (I'd noticed this before, but as I was importing the tests manually, I changed the expected output manually.)

ICU puts a narrow non-breaking space (0x202F) before the "AM" or "PM" in formatted date/time strings, which is a requirement from CLDR. I did a quick test that JS (at least running in Node) does the same thing, and it does:

```
$ node
Welcome to Node.js v18.13.0.
Type ".help" for more information.
> s = (Intl.DateTimeFormat("en-us", { timeStyle: "long" }).format(Date.now()))
'5:28:32 PM PDT'
> s.charCodeAt(7).toString(16)
'202f'
```

This change makes the expected output for time and datetime match what ICU outputs in these cases.