### PR TITLE
Remove expected output from date/time formatter tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -19,11 +19,15 @@ These test files are intended to be useful for testing multiple different messag
   - `parts: object[]` — The expected result of formatting the message to parts.
   - `cleanSrc: string` — A normalixed form of `src`, for testing stringifiers.
   - `errors: { type: string }[]` — The runtime errors expected to be emitted when formatting the message.
+     If `errors` is either absent or empty, the message must be formatted without errors.
   - `only: boolean` — Normally not set. A flag to use during development to only run one or more specific tests.
 
 - `test-function.json` — An object with string keys and arrays of test cases as values,
   using the same definition as for `test-core.json`.
   The keys each correspond to a function that is used in the tests.
+  Since the behavior of built-in formatters is implementation-specific,
+  the `exp` field should generally be omitted,
+  except for error cases.
 
 TypeScript `.d.ts` files are included for `test-core.json` and `test-function.json` with the above definition.
 

--- a/test/test-functions.json
+++ b/test/test-functions.json
@@ -6,16 +6,14 @@
       "exp": "{|horse|}",
       "errors": [{ "type": "bad-input" }]
     },
-    { "src": "{|2006-01-02| :date}", "exp": "1/2/06" },
-    { "src": "{|2006-01-02T15:04:06| :date}", "exp": "1/2/06" },
-    { "src": "{|2006-01-02| :date style=long}", "exp": "January 2, 2006" },
+    { "src": "{|2006-01-02| :date}" },
+    { "src": "{|2006-01-02T15:04:06| :date}" },
+    { "src": "{|2006-01-02| :date style=long}" },
     {
-      "src": ".local $d = {|2006-01-02| :date style=long} {{{$d :date}}}",
-      "exp": "January 2, 2006"
+      "src": ".local $d = {|2006-01-02| :date style=long} {{{$d :date}}}"
     },
     {
-      "src": ".local $t = {|2006-01-02T15:04:06| :time} {{{$t :date}}}",
-      "exp": "1/2/06"
+      "src": ".local $t = {|2006-01-02T15:04:06| :time} {{{$t :date}}}"
     }
   ],
   "time": [
@@ -25,18 +23,15 @@
       "exp": "{|horse|}",
       "errors": [{ "type": "bad-input" }]
     },
-    { "src": "{|2006-01-02T15:04:06| :time}", "exp": "3:04 PM" },
+    { "src": "{|2006-01-02T15:04:06| :time}" },
     {
-      "src": "{|2006-01-02T15:04:06| :time style=medium}",
-      "exp": "3:04:06 PM"
+      "src": "{|2006-01-02T15:04:06| :time style=medium}"
     },
     {
-      "src": ".local $t = {|2006-01-02T15:04:06| :time style=medium} {{{$t :time}}}",
-      "exp": "3:04:06 PM"
+      "src": ".local $t = {|2006-01-02T15:04:06| :time style=medium} {{{$t :time}}}"
     },
     {
-      "src": ".local $d = {|2006-01-02T15:04:06| :date} {{{$d :time}}}",
-      "exp": "3:04 PM"
+      "src": ".local $d = {|2006-01-02T15:04:06| :date} {{{$d :time}}}"
     }
   ],
   "datetime": [
@@ -56,23 +51,19 @@
       "exp": "{|horse|}",
       "errors": [{ "name": "RangeError" }]
     },
-    { "src": "{|2006-01-02T15:04:06| :datetime}", "exp": "1/2/06, 3:04 PM" },
+    { "src": "{|2006-01-02T15:04:06| :datetime}" },
     {
-      "src": "{|2006-01-02T15:04:06| :datetime year=numeric month=|2-digit|}",
-      "exp": "01/2006"
+      "src": "{|2006-01-02T15:04:06| :datetime year=numeric month=|2-digit|}"
     },
     {
-      "src": "{|2006-01-02T15:04:06| :datetime dateStyle=long}",
-      "exp": "January 2, 2006"
+      "src": "{|2006-01-02T15:04:06| :datetime dateStyle=long}"
     },
     {
-      "src": "{|2006-01-02T15:04:06| :datetime timeStyle=medium}",
-      "exp": "3:04:06 PM"
+      "src": "{|2006-01-02T15:04:06| :datetime timeStyle=medium}"
     },
     {
       "src": "{$dt :datetime}",
-      "params": { "dt": "2006-01-02T15:04:06" },
-      "exp": "1/2/06, 3:04 PM"
+      "params": { "dt": "2006-01-02T15:04:06" }
     }
   ],
   "integer": [


### PR DESCRIPTION
Per discussion on #759 , this PR removes expected output for `:date`, `:time`, and `:datetime`, except for error cases (since fallback handling is part of the spec).

Also added a note in the README to explain that.

I didn't remove the expected output for `:number`/`:integer` test cases, since that seems less likely to vary? But perhaps that should be done as well.