### PR TITLE
Tests for invalid number literals

### DIFF
--- a/test/test-functions.json
+++ b/test/test-functions.json
@@ -95,6 +95,31 @@
       "errors": [{ "type": "bad-input" }]
     },
     {
+      "src": "invalid number literal {.1 :number}",
+      "exp": "invalid number literal {|.1|}",
+      "errors": [{ "type": "bad-input" }]
+    },
+    {
+      "src": "invalid number literal {1. :number}",
+      "exp": "invalid number literal {|1.|}",
+      "errors": [{ "type": "bad-input" }]
+    },
+    {
+      "src": "invalid number literal {01 :number}",
+      "exp": "invalid number literal {|01|}",
+      "errors": [{ "type": "bad-input" }]
+    },
+    {
+      "src": "invalid number literal {|+1| :number}",
+      "exp": "invalid number literal {|+1|}",
+      "errors": [{ "type": "bad-input" }]
+    },
+    {
+      "src": "invalid number literal {0x1 :number}",
+      "exp": "invalid number literal {|0x1|}",
+      "errors": [{ "type": "bad-input" }]
+    },
+    {
       "src": "hello {:number}",
       "exp": "hello {:number}",
       "errors": [{ "type": "bad-input" }]


### PR DESCRIPTION
Fixes #662 

Add tests for invalid number literals as required by the default registry.