### PR TITLE
Remove registry.dtd and registry.xml from Tech Preview

### DIFF
--- a/spec/registry.dtd
+++ b/spec/registry.dtd
@@ -1,3 +1,7 @@
+<!-- 
+     This DTD is not part of the LDML45 Tech Preview of MessageFormat 2
+     Comments on this DTD are welcome. 
+-->
 <!ELEMENT registry (function|validationRule)*>
 <!ATTLIST registry
     xml:lang       NMTOKEN  #IMPLIED

--- a/spec/registry.dtd
+++ b/spec/registry.dtd
@@ -1,5 +1,5 @@
 <!-- 
-     This DTD is not part of the LDML45 Tech Preview of MessageFormat 2
+     This DTD is not part of the LDML45 Tech Preview of MessageFormat 2.
      Comments on this DTD are welcome. 
 -->
 <!ELEMENT registry (function|validationRule)*>

--- a/spec/registry.xml
+++ b/spec/registry.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="registry.dtd" type="application/xml-dtd"?>
+<!--
+     This registry is not part of the LDML45 Tech Preview of MessageFormat 2.
+     Comments on the contents of this registry are welcome as we seek to 
+     finalize the registry descriptions as part of the stable release
+     in LDML46.
+-->
 <registry xml:lang="en">
   <!-- All regex here are to be seen as provisory. See issue #422. -->
   <validationRule id="anyNumber" regex="-?(0|([1-9]\d*))(\.\d*)?([eE][-+]?\d+)?"/>


### PR DESCRIPTION
Add comments to make clear that the DTD and XML forms of the default registry are not part of the tech preview, but that comments are welcome.

Note that we still need to do #596 