### PR TITLE
Remove inappropriate normative statement from errors

### DIFF
--- a/spec/errors.md
+++ b/spec/errors.md
@@ -1,9 +1,12 @@
 # MessageFormat 2.0 Errors
 
-Errors in messages and their formatting MAY occur and be detected
-at different stages of processing.
-Where available,
-the use of validation tools is recommended,
+Errors can occur during the processing of a _message_.
+Some errors can be detected statically, 
+such as those due to problems with _message_ syntax,
+violations of requirements in the data model,
+or requirements defined by a _function_.
+Other errors might be detected during selection or formatting of a given _message_.
+Where available,the use of validation tools is recommended,
 as early detection of errors makes their correction easier.
 
 ## Error Handling

--- a/spec/errors.md
+++ b/spec/errors.md
@@ -6,7 +6,7 @@ such as those due to problems with _message_ syntax,
 violations of requirements in the data model,
 or requirements defined by a _function_.
 Other errors might be detected during selection or formatting of a given _message_.
-Where available,the use of validation tools is recommended,
+Where available, the use of validation tools is recommended,
 as early detection of errors makes their correction easier.
 
 ## Error Handling


### PR DESCRIPTION
Fixes #763 

The "MAY" statement being replaced is untestable and, indeed, is inconsistent with some of the MUSTard that occurs later.