### PR TITLE
Add use case for `source` expression attribute

### DIFF
--- a/exploration/expression-attributes.md
+++ b/exploration/expression-attributes.md
@@ -9,8 +9,9 @@ Status: **Proposed**
 		<dd>@eemeli</dd>
 		<dt>First proposed</dt>
 		<dd>2023-08-27</dd>
-		<dt>Pull Request</dt>
+		<dt>Pull Requests</dt>
 		<dd><a href="https://github.com/unicode-org/message-format-wg/pull/458">#458</a></dd>
+		<dd><a href="https://github.com/unicode-org/message-format-wg/pull/772">#772</a></dd>
 	</dl>
 </details>
 

--- a/exploration/expression-attributes.md
+++ b/exploration/expression-attributes.md
@@ -96,6 +96,17 @@ At least the following expression attributes should be considered:
   - `canCopy`, `canDelete`, `canOverlap`, `canReorder`, etc. — Flags supported by
     XLIFF 2 inline elements
 
+- Attributes used to represent features of other localization syntaxes
+  when parsed to a MessageFormat 2 data model.
+
+  - `source` — A literal value representing the source syntax of an expression.
+
+    > Example selector representing an Xcode strinsdict `NSStringLocalizedFormatKey` value:
+    >
+    > ```
+    > .match {$count :number @source=|%#@count@|}
+    > ```
+
 ## Requirements
 
 Attributes can be assigned to any expression,

--- a/exploration/expression-attributes.md
+++ b/exploration/expression-attributes.md
@@ -102,7 +102,7 @@ At least the following expression attributes should be considered:
 
   - `source` — A literal value representing the source syntax of an expression.
 
-    > Example selector representing an Xcode strinsdict `NSStringLocalizedFormatKey` value:
+    > Example selector representing an Xcode stringsdict `NSStringLocalizedFormatKey` value:
     >
     > ```
     > .match {$count :number @source=|%#@count@|}


### PR DESCRIPTION
While working on [moz.l10n](https://github.com/mozilla/moz-l10n/), a new Python localization library that uses the MF2 message and [resource data model](https://github.com/eemeli/message-resource-wg/pull/16) to represent messages from a number of different current syntaxes, I've come across at least the following use cases for [expression attributes](https://github.com/unicode-org/message-format-wg/blob/main/exploration/expression-attributes.md):

- In addition to supporting a limited set of HTML elements, Android String Resources may use `<xliff:g>` to wrap [nontranslatable content](https://developer.android.com/guide/topics/resources/localization#mark-message-parts). This is best represented in MF2 with a `@translate=no` attribute.
- Web extension `messages.json` files allow for named [placeholders](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference#placeholders) that are mapped to indexed arguments. These may include an example, which is best represented in MF2 as an `@example=...` attribute.
- Apple's Xcode supports localization of plural messages via `.stringsdict` XML files, which encode the plural variable's name as a `NSStringLocalizedFormatKey` value, where it appears as e.g. `%#@countOfFoo@` or similar. To display only the relevant "countOfFoo" name of this variable to localizers as context, it's best to use a `@source=...` attribute on the selector.

The first two use cases are already documented, but the last one is not; it's added by this PR.

The overall use case of the underlying work is to make use of the MF2 data model to provide a unified representation of messages in many different syntaxes, so that e.g. validation and a UI for plural message editing can be applied to all formats, rather than needing separate parsing and handling for each.