### PR TITLE
Update design docs and their status

### DIFF
--- a/exploration/code-mode-introducer.md
+++ b/exploration/code-mode-introducer.md
@@ -1,6 +1,6 @@
 # Design Proposal: Choosing a Code Mode Introducer
 
-Status: **Proposed**
+Status: **Accepted**
 
 <details>
 	<summary>Metadata</summary>
@@ -77,10 +77,9 @@ private-start  = "^" / "&"
 
 _Describe the proposed solution. Consider syntax, formatting, errors, registry, tooling, interchange._
 
-We need to choose one of these (or another option not yet considered).
-Presentation at UTW did not produce any opinions.
-
-Based on the pro/cons below, I would suggest Option D is possibly the best option?
+A modified version of Option D was chosen.
+The keyword `when` was dropped after this design was completed.
+"Simple" messages do not require the `pattern` to be quoted.
 
 ## Alternatives Considered
 

--- a/exploration/exact-match-selector-options.md
+++ b/exploration/exact-match-selector-options.md
@@ -1,4 +1,4 @@
-# Design Proposal Template
+# Name of the "Exact Match" selector function
 
 Status: **Accepted**
 

--- a/exploration/quoted-literals.md
+++ b/exploration/quoted-literals.md
@@ -1,6 +1,6 @@
 # Quoted Literals
 
-Status: **Proposed**
+Status: **Accepted**
 
 <details>
 	<summary>Metadata</summary>

--- a/exploration/selection-matching-options.md
+++ b/exploration/selection-matching-options.md
@@ -1,5 +1,20 @@
 # Selection Matching Options
 
+Status: **Obsolete**
+
+<details>
+	<summary>Metadata</summary>
+	<dl>
+		<dt>Contributors</dt>
+		<dd>@aphillips</dd>
+	</dl>
+</details>
+
+> [!NOTE]
+> This document was used as part of the discussion for choosing the type of matching.
+> It is preserved for historical reasons, but does not conform to the format of a
+> normal design document.
+
 ## Recommendation
 
 We are discussing whether to change First-Match to another value. Currently voting looks like:

--- a/exploration/string-selection-formatting.md
+++ b/exploration/string-selection-formatting.md
@@ -1,6 +1,6 @@
 # Selection and Formatting on String Values
 
-Status: **Proposed**
+Status: **Accepted**
 
 <details>
 	<summary>Metadata</summary>

--- a/exploration/variable-mutability.md
+++ b/exploration/variable-mutability.md
@@ -1,4 +1,4 @@
-# Design Proposal Template
+# Variable Mutability
 
 Status: **Accepted**
 

--- a/exploration/variable-mutability.md
+++ b/exploration/variable-mutability.md
@@ -1,4 +1,4 @@
-# Variable Mutability
+# Variable Namespacing and Mutability
 
 Status: **Accepted**
 

--- a/exploration/variants.md
+++ b/exploration/variants.md
@@ -3,6 +3,10 @@
 This is a collection of message examples which require a branching logic to
 handle grammatical variations of the copy.
 
+> [!NOTE]
+> This document contains examples used during design discussions.
+> It is not a formal design document and is preserved for historical reasons.
+
 ## Regular plurals
 
 ### English


### PR DESCRIPTION
This PR updates the status of various design docs and otherwise fixes minor issues (mainly that the title wasn't set). It also adds notes to non-standard docs kept for historical purposes.