### PR TITLE
Recommend not escaping all the things

### DIFF
--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -948,9 +948,10 @@ backslash    = %x5C ; U+005C REVERSE SOLIDUS "\"
 > they do not need to be escaped, such as braces in a _quoted_ _literal_.
 > For example, `|foo {bar}|` and `|foo \{bar\}|` are synonymous.
 
-When programmatically emitting message syntax,
-only characters that are lexically meaningful in the current context
-SHOULD be escaped.
+When writing or generating a _message_, escape sequences SHOULD NOT be used
+unless required by the syntax.
+That is, inside _literals_ only escape `|` 
+and inside _patterns_ only escape `{` and `}`.
 
 ### Whitespace
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -943,6 +943,15 @@ escaped-char = backslash ( backslash / "{" / "|" / "}" )
 backslash    = %x5C ; U+005C REVERSE SOLIDUS "\"
 ```
 
+> [!NOTE]
+> The `escaped-char` rule allows escaping some characters in places where
+> they do not need to be escaped, such as braces in a _quoted_ _literal_.
+> For example, `|foo {bar}|` and `|foo \{bar\}|` are synonymous.
+
+When programmatically emitting message syntax,
+only characters that are lexically meaningful in the current context
+SHOULD be escaped.
+
 ### Whitespace
 
 **_<dfn>Whitespace</dfn>_** is defined as one or more of


### PR DESCRIPTION
As [discussed](https://github.com/unicode-org/message-format-wg/blob/main/meetings/2024/notes-2024-05-13.md#743) on yesterday's call, we should instruct processors to only escape as necessary.

This adds a new normative SHOULD for "when programmatically emitting message syntax", which is novel for the spec.