### PR TITLE
Use mappings for data model options and attributes

### DIFF
--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -180,34 +180,31 @@ interface LiteralExpression {
   type: "expression";
   arg: Literal;
   annotation?: FunctionAnnotation | UnsupportedAnnotation;
-  attributes: Attribute[];
+  attributes: Attributes;
 }
 
 interface VariableExpression {
   type: "expression";
   arg: VariableRef;
   annotation?: FunctionAnnotation | UnsupportedAnnotation;
-  attributes: Attribute[];
+  attributes: Attributes;
 }
 
 interface FunctionExpression {
   type: "expression";
   arg?: never;
   annotation: FunctionAnnotation;
-  attributes: Attribute[];
+  attributes: Attributes;
 }
 
 interface UnsupportedExpression {
   type: "expression";
   arg?: never;
   annotation: UnsupportedAnnotation;
-  attributes: Attribute[];
+  attributes: Attributes;
 }
 
-interface Attribute {
-  name: string;
-  value?: Literal | VariableRef;
-}
+type Attributes = Map<string, Literal | VariableRef | true>;
 ```
 
 ## Expressions
@@ -237,19 +234,16 @@ interface VariableRef {
 A `FunctionAnnotation` represents a _function_ _annotation_.
 The `name` does not include the `:` starting sigil.
 
-Each _option_ is represented by an `Option`.
+Each _option_ is represented by an `Options` key-value mapping.
 
 ```ts
 interface FunctionAnnotation {
   type: "function";
   name: string;
-  options: Option[];
+  options: Options;
 }
 
-interface Option {
-  name: string;
-  value: Literal | VariableRef;
-}
+type Options = Map<string, Literal | VariableRef>;
 ```
 
 An `UnsupportedAnnotation` represents a
@@ -276,15 +270,15 @@ A `Markup` object has a `kind` of either `"open"`, `"standalone"`, or `"close"`,
 each corresponding to _open_, _standalone_, and _close_ _markup_.
 The `name` in these does not include the starting sigils `#` and `/` 
 or the ending sigil `/`.
-The optional `options` for markup use the same `Option` as `FunctionAnnotation`.
+The optional `options` for markup use the same key-value mapping as `FunctionAnnotation`.
 
 ```ts
 interface Markup {
   type: "markup";
   kind: "open" | "standalone" | "close";
   name: string;
-  options: Option[];
-  attributes: Attribute[];
+  options: Options;
+  attributes: Attributes;
 }
 ```
 

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -234,7 +234,8 @@ interface VariableRef {
 A `FunctionAnnotation` represents a _function_ _annotation_.
 The `name` does not include the `:` starting sigil.
 
-Each _option_ is represented by an `Options` key-value mapping.
+`Options` is a key-value mapping containing options,
+and is used to represent the _annotation_ and _markup_ _options_.
 
 ```ts
 interface FunctionAnnotation {
@@ -270,7 +271,7 @@ A `Markup` object has a `kind` of either `"open"`, `"standalone"`, or `"close"`,
 each corresponding to _open_, _standalone_, and _close_ _markup_.
 The `name` in these does not include the starting sigils `#` and `/` 
 or the ending sigil `/`.
-The optional `options` for markup use the same key-value mapping as `FunctionAnnotation`.
+The `options` for markup use the same key-value mapping as `FunctionAnnotation`.
 
 ```ts
 interface Markup {

--- a/spec/data-model/message.json
+++ b/spec/data-model/message.json
@@ -21,36 +21,18 @@
       },
       "required": ["type", "name"]
     },
+    "literal-or-variable": {
+      "oneOf": [{ "$ref": "#/$defs/literal" }, { "$ref": "#/$defs/variable" }]
+    },
+
     "options": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": { "type": "string" },
-          "value": {
-            "oneOf": [
-              { "$ref": "#/$defs/literal" },
-              { "$ref": "#/$defs/variable" }
-            ]
-          }
-        },
-        "required": ["name", "value"]
-      }
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/literal-or-variable" }
     },
     "attributes": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": { "type": "string" },
-          "value": {
-            "oneOf": [
-              { "$ref": "#/$defs/literal" },
-              { "$ref": "#/$defs/variable" }
-            ]
-          }
-        },
-        "required": ["name"]
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [{ "$ref": "#/$defs/literal-or-variable" }, { "const": true }]
       }
     },
 
@@ -129,7 +111,7 @@
       "type": "object",
       "properties": {
         "type": { "const": "markup" },
-        "kind": { "oneOf": [ "open", "standalone", "close" ] },
+        "kind": { "oneOf": ["open", "standalone", "close"] },
         "name": { "type": "string" },
         "options": { "$ref": "#/$defs/options" },
         "attributes": { "$ref": "#/$defs/attributes" }


### PR DESCRIPTION
Closes #716

As discussed in the parent issue and its other follow-up #751, the order of options and attributes should not matter for their formatting or other processing. Reflecting this in the data model by making these use a mapping makes it clearer that e.g. `{:foo one=13 two=42}` and `{:foo two=42 one=13}` should be considered equivalent.

Note, though, that the order isn't completely lost here. The TS data model uses an ordered `Map` for these, and numerous JSON processors provide guarantees about retaining the order, even though the JSON spec does not require that. So making this change does not in practice make it harder for message syntax serialisers to retain the order that options or attributes may have had originally.