### PR TITLE
Fix comment about `name`

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -72,7 +72,7 @@ reserved-body-part        = reserved-char / escaped-char / quoted
 
 ; Names and identifiers
 ; identifier matches https://www.w3.org/TR/REC-xml-names/#NT-QName
-; name matches https://www.w3.org/TR/REC-xml-names/#NT-NCName
+; name matches https://www.w3.org/TR/REC-xml-names/#NT-NCName but excludes U+FFFD
 identifier = [namespace ":"] name
 namespace  = name
 name       = name-start *name-char


### PR DESCRIPTION
Fixes #720 

The `name` production matches NCName except that we exclude U+FFFD. This updates the comment in the ABNF.