### PR TITLE
Docs: fix confusing formatting in `why_mf_next.md`

### DIFF
--- a/docs/why_mf_next.md
+++ b/docs/why_mf_next.md
@@ -7,18 +7,15 @@ why MessageFormat is important and why MessageFormat 2.0 is needed.
 
 ## Intro
 
-The `MessageFormat` API and syntax have been around for a long time.
-
-Intro
+The `MessageFormat` API and syntax have been around for a long time:
 
 - `MessageFormat` is the Unicode API for software localization
-- It is 20 years old, well designed, proven solution
-  Its design was optimized for the software development model
-  of twenty years ago.
-  Implementers, developers, and translators struggle with its shortcomings.
+- It is 20 years old and is a well-designed, proven solution
 
-The current wave of software development uses dynamic languages, modern UI
-frameworks and new forms of user interactions (voice, VR etc.).
+However, its design was optimized for the software development model of twenty
+years ago. Implementers, developers, and translators struggle with its
+shortcomings. The current wave of software development uses dynamic languages,
+modern UI frameworks, and new forms of user interactions (voice, VR etc.).
 
 Considering these new challenges, combined with the lessons learned from using
 `MessageFormat`, we aim to design the next iteration of `MessageFormat`


### PR DESCRIPTION
Rendered markdown output before (highlight added):

![image](https://github.com/unicode-org/message-format-wg/assets/26078826/2a12022a-e5aa-491c-941f-9619a6506c71)

After:

![image](https://github.com/unicode-org/message-format-wg/assets/26078826/cb153ce2-4d49-4ba2-9059-4e066ced6bfa)
