### PR TITLE
Allow trailing whitespace for complex messages

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -5,7 +5,7 @@ simple-start      = simple-start-char / escaped-char / placeholder
 pattern           = *(text-char / escaped-char / placeholder)
 placeholder       = expression / markup
 
-complex-message   = *(declaration [s]) complex-body
+complex-message   = *(declaration [s]) complex-body [s]
 declaration       = input-declaration / local-declaration / reserved-statement
 complex-body      = quoted-pattern / matcher
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -168,9 +168,10 @@ and consists of:
 
 1. an optional list of _declarations_, followed by
 2. a _complex body_
+3. optional trailing whitespace
 
 ```abnf
-complex-message = *(declaration [s]) complex-body
+complex-message = *(declaration [s]) complex-body [s]
 ```
 
 ### Declarations

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -168,7 +168,6 @@ and consists of:
 
 1. an optional list of _declarations_, followed by
 2. a _complex body_
-3. optional trailing whitespace
 
 ```abnf
 complex-message = *(declaration [s]) complex-body [s]

--- a/test/tests/syntax.json
+++ b/test/tests/syntax.json
@@ -409,6 +409,11 @@
           "type": "unsupported-statement"
         }
       ]
+    },
+    {
+      "src": "{{trailing whitespace}} \n",
+      "expCleanSrc": "trailing whitespace",
+      "exp": "trailing whitespace"
     }
   ]
 }


### PR DESCRIPTION
Fix for a part of #809, CC @lucacasonato

When parsing a complex message, we should be lenient about trailing whitespace, and silently ignore it. It has no meaning, and should not be considered an error.

None of the parser complexity concerns around leading whitespace apply here.