### PR TITLE
Default to medium rather than short dateStyle

### DIFF
--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -81,8 +81,8 @@ Functions for formatting [date/time values](#operands) in the default registry a
 - `:time`
 
 If no options are specified, each of the functions defaults to the following:
-- `{$d :datetime}` is the same as `{$d :datetime dateStyle=short timeStyle=short}`
-- `{$d :date}` is the same as `{$d :date style=short}`
+- `{$d :datetime}` is the same as `{$d :datetime dateStyle=long timeStyle=short}`
+- `{$d :date}` is the same as `{$d :date style=long}`
 - `{$t :time}` is the same as `{$t :time style=short}`
 
 > [!NOTE]
@@ -165,9 +165,9 @@ The function `:datetime` has these function-specific _style_ options.
 The function `:date` has these function-specific _style_ options:
 - `style`
   - `full`
-  - `long`
+  - `long` (default)
   - `medium`
-  - `short` (default)
+  - `short`
 
 The function `:time` has these function-specific _style_ options:
 - `style`
@@ -300,7 +300,7 @@ How to write an MF1 format or selector in MF2:
 | Plural (selector)  | `{num,plural, ...}`            | `.match {$num :plural}`<br/>`.match {$num :number}`                 |                                 |
 | Ordinal (selector) | `{num,selectordinal, ...}`     | `.match {$num :ordinal}`<br/>`.match {$num :number select=ordinal}` |                                 |
 | Ordinal (format)   | `{num,ordinal}`                |                                                                     | missing                         |
-| Date               | `{date,date}`                  | `{$date :date}`<br/>`{$date :datetime}`                             | short date is default           |
+| Date               | `{date,date}`                  | `{$date :date}`<br/>`{$date :datetime}`                             | long date is default           |
 | Date               | `{date,date,short}`            | `{$date :date style=short}`<br/>`{$date :datetime dateStyle=short}` | also medium,long,full           |
 | Time               | `{date,time}`                  | `{$date :time}`<br/>`{$date :datetime timeStyle=short}`             | shorthand or timeStyle required |
 | Date               | `{date,time,short}`            | `{$date :time style=short}`<br/>`{$date :datetime timeStyle=short}` | also medium,long,full           |

--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -81,8 +81,8 @@ Functions for formatting [date/time values](#operands) in the default registry a
 - `:time`
 
 If no options are specified, each of the functions defaults to the following:
-- `{$d :datetime}` is the same as `{$d :datetime dateStyle=long timeStyle=short}`
-- `{$d :date}` is the same as `{$d :date style=long}`
+- `{$d :datetime}` is the same as `{$d :datetime dateStyle=medium timeStyle=short}`
+- `{$d :date}` is the same as `{$d :date style=medium}`
 - `{$t :time}` is the same as `{$t :time style=short}`
 
 > [!NOTE]
@@ -165,8 +165,8 @@ The function `:datetime` has these function-specific _style_ options.
 The function `:date` has these function-specific _style_ options:
 - `style`
   - `full`
-  - `long` (default)
-  - `medium`
+  - `long`
+  - `medium` (default)
   - `short`
 
 The function `:time` has these function-specific _style_ options:
@@ -300,7 +300,7 @@ How to write an MF1 format or selector in MF2:
 | Plural (selector)  | `{num,plural, ...}`            | `.match {$num :plural}`<br/>`.match {$num :number}`                 |                                 |
 | Ordinal (selector) | `{num,selectordinal, ...}`     | `.match {$num :ordinal}`<br/>`.match {$num :number select=ordinal}` |                                 |
 | Ordinal (format)   | `{num,ordinal}`                |                                                                     | missing                         |
-| Date               | `{date,date}`                  | `{$date :date}`<br/>`{$date :datetime}`                             | long date is default           |
+| Date               | `{date,date}`                  | `{$date :date}`<br/>`{$date :datetime}`                             | medium date is default          |
 | Date               | `{date,date,short}`            | `{$date :date style=short}`<br/>`{$date :datetime dateStyle=short}` | also medium,long,full           |
 | Time               | `{date,time}`                  | `{$date :time}`<br/>`{$date :datetime timeStyle=short}`             | shorthand or timeStyle required |
 | Date               | `{date,time,short}`            | `{$date :time style=short}`<br/>`{$date :datetime timeStyle=short}` | also medium,long,full           |

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -773,7 +773,7 @@ The function `:datetime` is used to format date/time values, including
 the ability to compose user-specified combinations of fields.
 
 If no options are specified, this function defaults to the following:
-- `{$d :datetime}` is the same as `{$d :datetime dateStyle=short timeStyle=short}`
+- `{$d :datetime}` is the same as `{$d :datetime dateStyle=long timeStyle=short}`
 
 > [!NOTE]
 > The default formatting behavior of `:datetime` is inconsistent with `Intl.DateTimeFormat`
@@ -903,7 +903,7 @@ are encouraged to track development of these options during Tech Preview:
 The function `:date` is used to format the date portion of date/time values.
 
 If no options are specified, this function defaults to the following:
-- `{$d :date}` is the same as `{$d :date style=short}`
+- `{$d :date}` is the same as `{$d :date style=long}`
 
 #### Operands
 
@@ -917,9 +917,9 @@ All other _operand_ values produce a _Bad Operand_ error.
 The function `:date` has these _options_:
 - `style`
   - `full`
-  - `long`
+  - `long` (default)
   - `medium`
-  - `short` (default)
+  - `short`
 
 ### The `:time` function
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -773,7 +773,7 @@ The function `:datetime` is used to format date/time values, including
 the ability to compose user-specified combinations of fields.
 
 If no options are specified, this function defaults to the following:
-- `{$d :datetime}` is the same as `{$d :datetime dateStyle=long timeStyle=short}`
+- `{$d :datetime}` is the same as `{$d :datetime dateStyle=medium timeStyle=short}`
 
 > [!NOTE]
 > The default formatting behavior of `:datetime` is inconsistent with `Intl.DateTimeFormat`
@@ -903,7 +903,7 @@ are encouraged to track development of these options during Tech Preview:
 The function `:date` is used to format the date portion of date/time values.
 
 If no options are specified, this function defaults to the following:
-- `{$d :date}` is the same as `{$d :date style=long}`
+- `{$d :date}` is the same as `{$d :date style=medium}`
 
 #### Operands
 
@@ -917,8 +917,8 @@ All other _operand_ values produce a _Bad Operand_ error.
 The function `:date` has these _options_:
 - `style`
   - `full`
-  - `long` (default)
-  - `medium`
+  - `long`
+  - `medium` (default)
   - `short`
 
 ### The `:time` function


### PR DESCRIPTION
I can't remember why/how we ended up with `short` being the default value for the `:datetime` `dateStyle` and `timeStyle`, and their `:time` and `:date` equivalents. Given how dates and times tend to be placed within text, I think that while `short` is a good default for time, `long` is better for dates.

In a JS en-US environment, we get:

`short`
- 7/1/24
- 4:20 PM
- 7/1/24, 4:20 PM

`medium`
- Jul 1, 2024
- 4:20:00 PM
- Jul 1, 2024, 4:20:00 PM

`long`
- July 1, 2024
- 4:20:00 PM GMT+3
- July 1, 2024, at 4:20:00 PM GMT+3

So the overall default for `:datetime` would be `dateStyle=long timeStyle=short`:
- July 1, 2024 at 4:20 PM