### PR TITLE
Refine error handling text

### DIFF
--- a/spec/errors.md
+++ b/spec/errors.md
@@ -24,10 +24,13 @@ or _Message Function Errors_ in _expressions_ that are not otherwise used by the
 such as _placeholders_ in unselected _patterns_
 or _declarations_ that are never referenced during _formatting_.
 
-When formatting a message with one or more errors:
-- An implementation MUST provide a way for a user to be informed
-  of the name of at least one of the errors,
-  either directly or via an identifying error code.
+When formatting a _message_ with one or more errors:
+- An implementation MUST provide a mechanism to discover and identify
+  at least one of the errors. 
+  The exact form of error signaling is implementation defined.
+  Some examples include throwing an exception,
+  returning an error code, 
+  or providing a function or method for enumerating any errors.
 - An implementation MUST provide a way for a message with one or more
   _Resolution Errors_ or _Message Function Errors_ to be formatted
   using a fallback representation.

--- a/spec/errors.md
+++ b/spec/errors.md
@@ -34,7 +34,9 @@ or providing a function or method for enumerating any errors.
 
 For all _messages_ without _Syntax Errors_ or _Data Model Errors_,
 an implementation MUST enable a user to get a formatted result.
-This result MAY include formatted _fallback values_.
+The formatted result might include _fallback values_ 
+such as when a _placeholder_'s _expression_ produced an error
+during formatting.
 
 The two above requirements MAY be fulfilled by a single formatting method,
 or separately by more than one such method.

--- a/spec/errors.md
+++ b/spec/errors.md
@@ -24,9 +24,16 @@ or _Message Function Errors_ in _expressions_ that are not otherwise used by the
 such as _placeholders_ in unselected _patterns_
 or _declarations_ that are never referenced during _formatting_.
 
-In all cases, when encountering a runtime error,
-a message formatter MUST provide some representation of the message.
-An informative error or errors MUST also be separately provided.
+When formatting a message with one or more errors:
+- An implementation MUST provide a way for a user to be informed
+  of the name of at least one of the errors,
+  either directly or via an identifying error code.
+- An implementation MUST provide a way for a message with one or more
+  _Resolution Errors_ or _Message Function Errors_ to be formatted
+  using a fallback representation.
+
+The two above requirements MAY be fulfilled by a single formatting method,
+or separately by more than one such method.
 
 When a message contains more than one error,
 or contains some error which leads to further errors,

--- a/spec/errors.md
+++ b/spec/errors.md
@@ -31,9 +31,9 @@ When formatting a _message_ with one or more errors:
   Some examples include throwing an exception,
   returning an error code, 
   or providing a function or method for enumerating any errors.
-- An implementation MUST provide a way for a message with one or more
-  _Resolution Errors_ or _Message Function Errors_ to be formatted
-  using a fallback representation.
+- For all messages without _Syntax Errors_ or _Data Model Errors_,
+  an implementation MUST enable a user to get a formatted result.
+  This result MAY include formatted _fallback values_.
 
 The two above requirements MAY be fulfilled by a single formatting method,
 or separately by more than one such method.

--- a/spec/errors.md
+++ b/spec/errors.md
@@ -24,16 +24,17 @@ or _Message Function Errors_ in _expressions_ that are not otherwise used by the
 such as _placeholders_ in unselected _patterns_
 or _declarations_ that are never referenced during _formatting_.
 
-When formatting a _message_ with one or more errors:
-- An implementation MUST provide a mechanism to discover and identify
-  at least one of the errors. 
-  The exact form of error signaling is implementation defined.
-  Some examples include throwing an exception,
-  returning an error code, 
-  or providing a function or method for enumerating any errors.
-- For all messages without _Syntax Errors_ or _Data Model Errors_,
-  an implementation MUST enable a user to get a formatted result.
-  This result MAY include formatted _fallback values_.
+When formatting a _message_ with one or more errors,
+an implementation MUST provide a mechanism to discover and identify
+at least one of the errors. 
+The exact form of error signaling is implementation defined.
+Some examples include throwing an exception,
+returning an error code, 
+or providing a function or method for enumerating any errors.
+
+For all _messages_ without _Syntax Errors_ or _Data Model Errors_,
+an implementation MUST enable a user to get a formatted result.
+This result MAY include formatted _fallback values_.
 
 The two above requirements MAY be fulfilled by a single formatting method,
 or separately by more than one such method.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -735,9 +735,8 @@ each _text_ and _placeholder_ part of the selected _pattern_ is resolved and for
 
 Resolved values cannot always be formatted by a given implementation.
 When such an error occurs during _formatting_,
-an implementation SHOULD emit an appropriate _Message Function Error_ and produce a
-_fallback value_ for the _placeholder_ that produced the error.
-A formatting function MAY substitute a value to use instead of a _fallback value_.
+an implementation MUST emit an appropriate _Message Function Error_ and use a
+_fallback value_ for the _placeholder_ with the error.
 
 Implementations MAY represent the result of _formatting_ using the most
 appropriate data type or structure. Some examples of these include:


### PR DESCRIPTION
Updates to the spec that implement the design doc introduced in #804.

Filed initially as a draft pending the [previously discussed](https://github.com/unicode-org/message-format-wg/blob/main/meetings/2024/notes-2024-06-24.md#804) updates to the design doc, but happy to accept reviews and recommendations for the text already.