### PR TITLE
Clarify that calling MatchSelectorKeys always returns a list

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -549,6 +549,10 @@ The returned list MAY be empty.
 The most-preferred key is first,
 with each successive key appearing in order by decreasing preference.
 
+If calling MatchSelectorKeys encounters any error,
+a _Bad Selector_ error is emitted
+and an empty list is returned.
+
 ### Filter Variants
 
 Then, using the preferential key orders `pref`,


### PR DESCRIPTION
Follow-up to https://github.com/unicode-org/message-format-wg/pull/816#discussion_r1677961448, as it was not previously clear that MatchSelectorKeys never fails.