### PR TITLE
Do not promise stability with all options

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -82,7 +82,8 @@ A reference to a _term_ looks like this.
 Updates to this specification will not change
 the syntactical meaning, the runtime output, or other behaviour
 of valid messages written for earlier versions of this specification
-that only use functions defined in this specification.
+that only use functions defined in this specification
+and options explicitly defined for them.
 Updates to this specification will not remove any syntax provided in this version.
 Future versions MAY add additional structure or meaning to existing syntax.
 


### PR DESCRIPTION
This is a follow-up to https://github.com/unicode-org/message-format-wg/pull/798#discussion_r1678006811, and it's intended to solve the following issue: We should allow for the 2.0 set of default function options to be extensible by later versions of the specification. To take one example, we currently explicitly leave out `currency` from the `:number` options, and only say that implementations "SHOULD avoid" creating an option that conflicts with its possible meaning.

This means that an expression `{42 :number currency=dollaridoos}` is currently technically valid, and does not emit any errors -- the "dollaridoos" value is ignored. This severely restricts what can be done in the future, as the [Stability Policy](https://github.com/unicode-org/message-format-wg/tree/main/spec#stability-policy) promises that:
> Updates to this specification will not change the syntactical meaning, the runtime output, or other behaviour of valid messages written for earlier versions of this specification that only use functions defined in this specification.

I propose that we relax this promise to only apply to messages that use default function option values that we actually define, and not any other option values.