### PR TITLE
Fix test result for "hello {0.42e+1 :integer}"

### DIFF
--- a/test/tests/functions/integer.json
+++ b/test/tests/functions/integer.json
@@ -15,7 +15,7 @@
     },
     {
       "src": "hello {0.42e+1 :integer}",
-      "exp": "hello 4"
+      "exp": "hello 0"
     },
     {
       "src": ".match {$foo :integer} one {{one}} * {{other}}",


### PR DESCRIPTION
The spec doesn't say whether `:integer` should round down or up, so maybe this test should be removed entirely, but 4 is definitely wrong.