### PR TITLE
Disallow "whitespace or special char" prefixed `.` in reserved-statement's body

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -55,11 +55,15 @@ local = %s".local"
 match = %s".match"
 
 ; Reserve additional .keywords for use by future versions of this specification.
-reserved-statement = reserved-keyword [s reserved-body] 1*([s] expression)
+reserved-statement = reserved-keyword [s reserved-statement-body] 1*([s] expression)
 ; Note that the following production is a simplification,
 ; as this rule MUST NOT be considered to match existing keywords
 ; (`.input`, `.local`, and `.match`).
 reserved-keyword   = "." name
+
+reserved-statement-body      = reserved-statement-body-part *([s] reserved-statement-body-part)
+reserved-statement-body-part = (name-char 1*".") / content-char
+                             / escaped-char / quoted-literal
 
 ; Reserve additional sigils for use by future versions of this specification.
 reserved-annotation       = reserved-annotation-start [[s] reserved-body]
@@ -76,13 +80,13 @@ reserved-body-part        = reserved-char / escaped-char / quoted-literal
 ; name matches https://www.w3.org/TR/REC-xml-names/#NT-NCName but excludes U+FFFD
 identifier = [namespace ":"] name
 namespace  = name
-name       = name-start *name-char
+name       = name-start *(name-char / ".")
 name-start = ALPHA / "_"
            / %xC0-D6 / %xD8-F6 / %xF8-2FF
            / %x370-37D / %x37F-1FFF / %x200C-200D
            / %x2070-218F / %x2C00-2FEF / %x3001-D7FF
            / %xF900-FDCF / %xFDF0-FFFC / %x10000-EFFFF
-name-char  = name-start / DIGIT / "-" / "."
+name-char  = name-start / DIGIT / "-"
            / %xB7 / %x300-36F / %x203F-2040
 
 ; Restrictions on characters in various contexts

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -939,8 +939,8 @@ name-start = ALPHA / "_"
            / %x370-37D / %x37F-1FFF / %x200C-200D
            / %x2070-218F / %x2C00-2FEF / %x3001-D7FF
            / %xF900-FDCF / %xFDF0-FFFC / %x10000-EFFFF
-name-char  = name-start / DIGIT / "-" / %xB7 / %x300-36F
-           / %x203F-2040
+name-char  = name-start / DIGIT / "-"
+           / %xB7 / %x300-36F / %x203F-2040
 ```
 
 ### Escape Sequences

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -227,16 +227,16 @@ Any such future keyword must start with `.`,
 followed by two or more lower-case ASCII characters.
 
 The rest of the statement supports
-a similarly wide range of content as _reserved annotations_ (with the exception
-of U+002E FULL STOP `.`, which is only allowed following characters that are
-permissible in _name_), but it MUST end with one or more _expressions_.
+a similarly wide range of content as _reserved annotations_
+(with the exception of U+002E FULL STOP `.`,
+which is only allowed following characters that are permissible in _name_), but it MUST end with one or more _expressions_.
 
 ```abnf
 reserved-statement = reserved-keyword [s reserved-statement-body] 1*([s] expression)
 reserved-keyword   = "." name
 
 reserved-statement-body      = reserved-statement-body-part *([s] reserved-statement-body-part)
-reserved-statement-body-part = (name-char-no-dot 1*".") / content-char
+reserved-statement-body-part = (name-char 1*".") / content-char
                              / escaped-char / quoted-literal
 ```
 
@@ -246,10 +246,11 @@ reserved-statement-body-part = (name-char-no-dot 1*".") / content-char
 > `.input`, `.local`, or `.match`.
 
 > [!NOTE]
-> Only dots that are preceded by a valid name character are allowed in a
-> `reserved-statement-body`. This enables better parser error recovery for tools in the
-> case of incomplete reserved statements, like in the following example:
-> ```mf2
+> Only dots that are preceded by a valid name character are allowed in a  `reserved-statement-body`.
+> This enables better parser error recovery for tools
+> in the case of incomplete reserved statements,
+> like in the following example:
+> ```
 > .invalid $foo.bar =
 > .local $bar = {|baz|}
 > {{This is a message.}}
@@ -930,17 +931,16 @@ in this release.
 variable   = "$" name
 option     = identifier [s] "=" [s] (literal / variable)
 
-identifier       = [namespace ":"] name
-namespace        = name
-name             = name-start *name-char
-name-start       = ALPHA / "_"
-                 / %xC0-D6 / %xD8-F6 / %xF8-2FF
-                 / %x370-37D / %x37F-1FFF / %x200C-200D
-                 / %x2070-218F / %x2C00-2FEF / %x3001-D7FF
-                 / %xF900-FDCF / %xFDF0-FFFC / %x10000-EFFFF
-name-char-no-dot = name-start / DIGIT / "-" / %xB7 / %x300-36F
-                 / %x203F-2040
-name-char        = name-char-no-dot / "."
+identifier = [namespace ":"] name
+namespace  = name
+name       = name-start *(name-char / ".")
+name-start = ALPHA / "_"
+           / %xC0-D6 / %xD8-F6 / %xF8-2FF
+           / %x370-37D / %x37F-1FFF / %x200C-200D
+           / %x2070-218F / %x2C00-2FEF / %x3001-D7FF
+           / %xF900-FDCF / %xFDF0-FFFC / %x10000-EFFFF
+name-char  = name-start / DIGIT / "-" / %xB7 / %x300-36F
+           / %x203F-2040
 ```
 
 ### Escape Sequences


### PR DESCRIPTION
This commit disallows using dots inside of `reserved-statement` bodies, outside of name-like strings.

This enables tools to perform better error recovery in case of incomplete reserved-statements.

## Background

Take for example the following incomplete message:

```mf2
.foobar $var =
.local $count = {1}
{{The count is {$count}.}}
```

It is relatively obvious here that the user did not intend to write a reserved-statement with keyword `.foobar` and body `$var = \n.local $count =` and expression `{1}`, but two declarations: a reserved statement and a `.local` declaration.

A parser that does error recovery, like is needed for in-editor tooling should be able to recover from the above message into the users' intended form: a local decl, a reserved statement, and a quoted body. But right now the syntax prohibits this error recovery, because the above message _is_ already valid, but parses into a single reserved-statement.

This PR attempts to resolve this behaviour by disallowing `.` in reserved-statement when it is not preceded by a `name-char`. The `.` is not banned outright, because I think that all valid declarations right now, should be valid reserved-statements, and we allow `.` in `.local` declarations inside of names: `.local $foo.bar = {123}`.
