### PR TITLE
Add table of errors to test README (#706)

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -26,22 +26,22 @@ A [JSON schema](./schemas/) is included for the test files in this repository.
 The following table relates the error names used in the [JSON schema](./schemas/)
 to the error names used in ["MessageFormat 2.0 Errors"](../spec/errors.md) in the spec.
 
-| Schema                      | Spec                        |
+| Spec                        | Schema                      |
 | --------------------------- | --------------------------- |
-| bad-operand                 | Bad Operand                 |
-| bad-option                  | Bad Option                  |
-| bad-selector                | Bad Selector                |
-| bad-variant-key             | Bad Variant Key             |
-| duplicate-declaration       | Duplicate Declaration       |
-| duplicate-option-name       | Duplicate Option Name       |
-| missing-fallback-variant    | Missing Fallback Variant    |
-| missing-selector-annotation | Missing Selector Annotation |
-| syntax-error                | Syntax Error                |
-| unknown-function            | Unknown Function            |
-| unresolved-variable         | Unresolved Variable         |
-| unsupported-expression      | Unsupported Expression      |
-| unsupported-statement       | Unsupported Statement       |
-| variant-key-mismatch        | Variant Key Mismatch        |
+| Bad Operand                 | bad-operand                 |
+| Bad Option                  | bad-option                  |
+| Bad Selector                | bad-selector                |
+| Bad Variant Key             | bad-variant-key             |
+| Duplicate Declaration       | duplicate-declaration       |
+| Duplicate Option Name       | duplicate-option-name       |
+| Missing Fallback Variant    | missing-fallback-variant    |
+| Missing Selector Annotation | missing-selector-annotation |
+| Syntax Error                | syntax-error                |
+| Unknown Function            | unknown-function            |
+| Unresolved Variable         | unresolved-variable         |
+| Unsupported Expression      | unsupported-expression      |
+| Unsupported Statement       | unsupported-statement       |
+| Variant Key Mismatch        | variant-key-mismatch        |
 
 The "Message Function Error" error name used in the spec
 is not included in the schema,

--- a/test/README.md
+++ b/test/README.md
@@ -7,7 +7,7 @@ These test files are intended to be useful for testing multiple different messag
 
 - `syntax-errors.json` — Strings that should produce a Syntax Error when parsed.
 
-- `data-model-errors.json` - Strings that should produce Data Model Error when processed.
+- `data-model-errors.json` - Strings that should produce a Data Model Error when processed.
   Error names are defined in ["MessageFormat 2.0 Errors"](../spec/errors.md) in the spec.
 
 - `functions/` — Test cases that correspond to built-in functions.
@@ -23,6 +23,33 @@ Some examples of test harnesses using these tests, from the source repository:
 A [JSON schema](./schemas/) is included for the test files in this repository.
 
 For users of Visual Studio Code, a [settings file](./.vscode/settings.json) is included that enables schema validation while editing the test files.
+
+## Error Codes
+
+The following table relates the error names used in the [JSON schema](./schemas/)
+to the error names used in ["MessageFormat 2.0 Errors"](../spec/errors.md) in the spec.
+
+| Schema                      | Spec                        |
+| --------------------------- | --------------------------- |
+| bad-operand                 | Bad Operand                 |
+| bad-option                  | Bad Option                  |
+| bad-selector                | Bad Selector                |
+| bad-variant-key             | Bad Variant Key             |
+| duplicate-declaration       | Duplicate Declaration       |
+| duplicate-option-name       | Duplicate Option Name       |
+| missing-fallback-variant    | Missing Fallback Variant    |
+| missing-selector-annotation | Missing Selector Annotation |
+| syntax-error                | Syntax Error                |
+| unknown-function            | Unknown Function            |
+| unresolved-variable         | Unresolved Variable         |
+| unsupported-expression      | Unsupported Expression      |
+| unsupported-statement       | Unsupported Statement       |
+| variant-key-mismatch        | Variant Key Mismatch        |
+
+The "Message Function Error" error name used in the spec
+is not included in the schema,
+as it is intended to be an umbrella category
+for implementation-specific errors.
 
 ## Test Functions
 

--- a/test/README.md
+++ b/test/README.md
@@ -21,9 +21,6 @@ Some examples of test harnesses using these tests, from the source repository:
 - [Formatting tests](https://github.com/messageformat/messageformat/blob/11c95dab2b25db8454e49ff4daadb817e1d5b770/packages/mf2-messageformat/src/messageformat.test.ts)
 
 A [JSON schema](./schemas/) is included for the test files in this repository.
-
-For users of Visual Studio Code, a [settings file](./.vscode/settings.json) is included that enables schema validation while editing the test files.
-
 ## Error Codes
 
 The following table relates the error names used in the [JSON schema](./schemas/)


### PR DESCRIPTION
Update README for tests directory to include a table relating error names in the test schema to error names in the spec.