### PR TITLE
Add new selection-declaration alternative: Require annotation of selector variables in placeholders

### DIFF
--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -195,17 +195,27 @@ is expanded to also require later uses of a variable that's used as a selector t
 > each _placeholder_ _expression_ using the same _operand_ as a _selector_ MUST have an _annotation_,
 > or contain a _variable_ that directly or indirectly references a _declaration_ with an _annotation_.
 
-Example valid message:
+Example invalid message with this alternative:
 ```
+.match {$n :number minimumFractionDigits=2}
+* {{Data model error: {$n}}}
+```
+
+Valid, recommended form for the above message:
+```
+.input {$n :number minimumFractionDigits=2}
+.match {$n}
+* {{Formats '$n' as a number with fraction digits: {$n}}}
+```
+
+Technically valid but not recommended:
+```
+.match {$n :number minimumFractionDigits=2}
+* {{Formats '$n' as an integer: {$n :integer}}}
+
 .input {$n :integer}
 .match {$n :number minimumFractionDigits=2}
 * {{Formats '$n' as an integer: {$n}}}
-```
-
-Example invalid message:
-```
-.match {$n :integer}
-* {{If $n==1.2 formats {$n} as 1.2 in en-US}}
 ```
 
 **Pros**

--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -182,6 +182,42 @@ Examples:
 - Can produce a mismatch between formatting and selection, since the operand's formatting
   isn't visible to the selector.
 
+### Require annotation of selector variables in placeholders
+
+In this alternative, the pre-existing validity requirement
+
+> Each _selector_ MUST have an _annotation_,
+> or contain a _variable_ that directly or indirectly references a _declaration_ with an _annotation_.
+
+is expanded to also require later uses of a variable that's used as a selector to be annotated:
+
+> In a _complex message_,
+> each _placeholder_ _expression_ using the same _operand_ as a _selector_ MUST have an _annotation_,
+> or contain a _variable_ that directly or indirectly references a _declaration_ with an _annotation_.
+
+Example valid message:
+```
+.input {$n :integer}
+.match {$n :number minimumFractionDigits=2}
+* {{Formats '$n' as an integer: {$n}}}
+```
+
+Example invalid message:
+```
+.match {$n :integer}
+* {{If $n==1.2 formats {$n} as 1.2 in en-US}}
+```
+
+**Pros**
+- No syntax changes required.
+- `.local` can be used to solve problems with variations in selection and formatting
+- Supports multiple selectors on the same operand
+- Avoids mismatches between formatting and selection by requiring their annotation.
+
+**Cons**
+- May require the user to annotate the operand for both formatting and selection,
+  unless they use a declaration.
+
 ### Allow both local and input declarative selectors with immutability
 
 In this alternative, we modify the syntax to allow selectors to 

--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -210,12 +210,12 @@ Valid, recommended form for the above message:
 
 Technically valid but not recommended:
 ```
-.match {$n :number minimumFractionDigits=2}
-* {{Formats '$n' as an integer: {$n :integer}}}
-
 .input {$n :integer}
 .match {$n :number minimumFractionDigits=2}
 * {{Formats '$n' as an integer: {$n}}}
+
+.match {$n :number minimumFractionDigits=2}
+* {{Formats '$n' as an integer: {$n :integer}}}
 ```
 
 **Pros**


### PR DESCRIPTION
As discussed in this week's call, I'd like to add a new alternative to the design doc. My own preferences as expressed in #824 have not changed, but this is a viable candidate for consideration.