### PR TITLE
Miscellaneous test fixes

### DIFF
--- a/test/tests/data-model-errors.json
+++ b/test/tests/data-model-errors.json
@@ -180,6 +180,10 @@
           "type": "duplicate-variant"
         }
       ]
+    },
+    {
+      "src": ".match {star :string} |*| {{Literal star}} * {{The default}}",
+      "exp": "The default"
     }
   ]
 }

--- a/test/tests/syntax-errors.json
+++ b/test/tests/syntax-errors.json
@@ -123,6 +123,9 @@
       "src": "bad {:placeholder @attribute=@foo}"
     },
     {
+      "src": "bad {:placeholder @attribute=$foo}"
+    },
+    {
       "src": "{ @misplaced = attribute }"
     },
     {

--- a/test/tests/syntax.json
+++ b/test/tests/syntax.json
@@ -27,6 +27,11 @@
       "exp": "\\"
     },
     {
+      "description": "message -> simple-message -> simple-start pattern -> 1*escaped-char",
+      "src": "\\\\\\{\\|\\}",
+      "exp": "\\{|}"
+    },
+    {
       "description": "message -> simple-message -> simple-start pattern -> simple-start-char pattern -> ... -> simple-start-char *text-char placeholder",
       "src": "hello {world}",
       "exp": "hello world"
@@ -448,9 +453,9 @@
       "exp": "\\"
     },
     {
-      "description": "... quoted-literal -> \"|\" quoted-char escaped-char \"|\"",
-      "src": "{|a\\\\|}",
-      "exp": "a\\"
+      "description": "... quoted-literal -> \"|\" quoted-char 1*escaped-char \"|\"",
+      "src": "{|a\\\\\\{\\|\\}|}",
+      "exp": "a\\{|}"
     },
     {
       "description": "... unquoted-literal -> number-literal -> %x30",

--- a/test/tests/syntax.json
+++ b/test/tests/syntax.json
@@ -426,8 +426,8 @@
       "exp": "a"
     },
     {
-      "description": "... attribute -> \"@\" identifier s \"=\" s variable ...",
-      "src": "{42 @foo=$bar}",
+      "description": "... attribute -> \"@\" identifier s \"=\" s quoted-literal ...",
+      "src": "{42 @foo=|bar|}",
       "exp": "42",
       "expParts": [
         {
@@ -859,7 +859,7 @@
       ]
     },
     {
-      "src": "foo {?reserved @a @b=$c}",
+      "src": "foo {?reserved @a @b=c}",
       "exp": "foo {?}",
       "expParts": [
         {

--- a/test/tests/syntax.json
+++ b/test/tests/syntax.json
@@ -908,12 +908,7 @@
     {
       "src": ".l $y = {|bar|} {{}}",
       "exp": "",
-      "expParts": [
-        {
-          "type": "literal",
-          "value": "bar"
-        }
-      ],
+      "expParts": [],
       "expErrors": [
         {
           "type": "unsupported-statement"

--- a/test/tests/syntax.json
+++ b/test/tests/syntax.json
@@ -174,7 +174,7 @@
       "description": "message -> complex-message -> complex-body -> matcher -> match-statement variant -> match selector key quoted-pattern -> \".match\" expression literal quoted-pattern",
       "src": ".match{a :f}a{{}}*{{}}",
       "exp": "",
-      "expErrors": [ { "type": "unknown-function" } ]
+      "expErrors": [{ "type": "unknown-function" }, { "type": "bad-selector" }]
     },
     {
       "description": "... input-declaration -> input s variable-expression ...",
@@ -200,31 +200,41 @@
       "description": "... matcher -> match-statement [s] variant -> match 1*([s] selector) variant -> match selector selector variant -> match selector selector variant key s key quoted-pattern",
       "src": ".match{a :f}{b :f}a b{{}}* *{{}}",
       "exp": "",
-      "expErrors": [ { "type": "unknown-function" } ]
+      "expErrors": [
+        { "type": "unknown-function" },
+        { "type": "bad-selector" },
+        { "type": "unknown-function" },
+        { "type": "bad-selector" }
+      ]
     },
     {
       "description": "... matcher -> match-statement [s] variant -> match 1*([s] selector) variant -> match selector variant variant ...",
       "src": ".match{a :f}a{{}}b{{}}*{{}}",
       "exp": "",
-      "expErrors": [ { "type": "unknown-function" } ]
+      "expErrors": [{ "type": "unknown-function" }, { "type": "bad-selector" }]
     },
     {
       "description": "... variant -> key s quoted-pattern -> ...",
       "src": ".match{a :f}a {{}}*{{}}",
       "exp": "",
-      "expErrors": [ { "type": "unknown-function" } ]
+      "expErrors": [{ "type": "unknown-function" }, { "type": "bad-selector" }]
     },
     {
       "description": "... variant -> key s key s quoted-pattern -> ...",
       "src": ".match{a :f}{b :f}a b {{}}* *{{}}",
       "exp": "",
-      "expErrors": [ { "type": "unknown-function" } ]
+      "expErrors": [
+        { "type": "unknown-function" },
+        { "type": "bad-selector" },
+        { "type": "unknown-function" },
+        { "type": "bad-selector" }
+      ]
     },
     {
       "description": "... key -> \"*\" ...",
       "src": ".match{a :f}*{{}}",
       "exp": "",
-      "expErrors": [ { "type": "unknown-function" } ]
+      "expErrors": [{ "type": "unknown-function" }, { "type": "bad-selector" }]
     },
     {
       "description": "simple-message -> simple-start pattern -> placeholder -> expression -> literal-expression -> \"{\" s literal \"}\"",

--- a/test/tests/syntax.json
+++ b/test/tests/syntax.json
@@ -197,6 +197,18 @@
       "exp": ""
     },
     {
+      "description": "input-declaration-like content in complex-message",
+      "src": "{{.input {$x}}}",
+      "params": [{ "name": "x", "value": "X" }],
+      "exp": ".input X"
+    },
+    {
+      "description": "local-declaration-like content in complex-message with leading whitespace",
+      "src": "{{ .local $x = {$y}}}",
+      "params": [{ "name": "y", "value": "Y" }],
+      "exp": " .local $x = Y"
+    },
+    {
       "description": "... matcher -> match-statement [s] variant -> match 1*([s] selector) variant -> match selector selector variant -> match selector selector variant key s key quoted-pattern",
       "src": ".match{a :f}{b :f}a b{{}}* *{{}}",
       "exp": "",


### PR DESCRIPTION
A few things noticed while updating my implementation:
- Some of the new syntax tests were missing expected errors (in particular, bad-selector) beyond the first.
- An unsupported-statement error has an incorrect expected-parts value
- We should test that declaration-like content in quoted patterns is fine, and that `*` and `|*|` are distinguished for duplicate-variant errors.