### PR TITLE
Fix "Allow immutable input declarative selectors" example

### DIFF
--- a/exploration/selection-declaration.md
+++ b/exploration/selection-declaration.md
@@ -329,7 +329,7 @@ This implies that multiple selecton on the same operand is pointless.
 .match {$num :number maximumFractionDigits=0}
 * {{This message produces a Duplicate Declaration error}}
 
-.input {$num :integer} {$num :number}
+.match {$num :integer} {$num :number}
 * * {{This message produces a Duplicate Declaration error}}
 ```
 


### PR DESCRIPTION
I believe this example mistakenly used `.input` instead of `.match` before its selectors