### PR TITLE
Update contributing and joining info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,25 @@
 # Contributing to this project
 
-To join this Working Group, please read the information in the [README.md](./README.md) as well as the Contributor License Agreement information linked just below:
+To join this Working Group, please read the information in the [README.md](./README.md) as well as the Contributor License Agreement information just below:
+
+<!-- boilerplate follows - do not edit -->
 
 ## Contributor License Agreement
 
-In order to contribute to this project, the Unicode Consortium MUST have on file a Contributor License Agreement (CLA) covering your contributions, either an individual or a corporate CLA. 
+In order to contribute to this project, the Unicode Consortium must have on file a Contributor License Agreement (CLA) covering your contributions, either an individual or a corporate CLA. Pull Requests, issues, and other contributions will not be merged/accepted until the correct CLA is signed. Which version needs to be signed depends on who owns the contribution being made: you as the individual making the contribution or your employer. **It is your responsibility to determine whether your contribution is owned by your employer.** Please review the [Unicode Intellectual Property, Licensing, & Technical Contribution Policy][policies] for further guidance on which CLA to sign, as well as other information and guidelines regarding the Consortium’s licensing and technical contribution policies and procedures.
 
-Information on this can be found in [Unicode's CONTRIBUTING.md](https://github.com/unicode-org/.github/blob/main/.github/CONTRIBUTING.md)
+To sign the CLA in Github, open a Pull Request (a comment will be automatically added with a link to the CLA Form), or go directly to [the CLA Form][sign-cla]. You may need to sign in to Github to see the entire CLA Form.
+
+- **Individual CLA**: If you have determined that the Individual CLA is appropriate, then when you access the CLA Form, click the Individual CLA and complete the Form.
+
+- **Corporate CLA**: If you have determined that a Corporate CLA is appropriate, please first check the [public list of Corporate CLAs][unicode-corporate-clas] that the Consortium has on file. If your employer is listed, then when you access the CLA Form, you can click the box indicating that you are covered by your employer’s corporate CLA. If your employer is not on the list, then it has not already signed a CLA and you will need to arrange for your employer to do so before you contribute, as described in [How to Sign a Unicode CLA][signing].
+
+Unless otherwise noted in the [`LICENSE`](./LICENSE) file, this project is released under the [OSI-approved][osi-Unicode-License-3.0] free and open-source [Unicode License v3][unicode-license].
+
+
+[policies]: https://www.unicode.org/policies/licensing_policy.html
+[unicode-corporate-clas]: https://www.unicode.org/policies/corporate-cla-list/
+[signing]: https://www.unicode.org/policies/licensing_policy.html#signing
+[unicode-license]: https://www.unicode.org/license.txt
+[sign-cla]: https://cla-assistant.io/unicode-org/.github
+[osi-Unicode-License-3.0]: https://opensource.org/license/unicode-license-v3/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to this project
 
+To join this Working Group, please read the information in the [README.md](./README.md) as well as the Contributor License Agreement information linked just below:
+
 ## Contributor License Agreement
 
 In order to contribute to this project, the Unicode Consortium MUST have on file a Contributor License Agreement (CLA) covering your contributions, either an individual or a corporate CLA. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,32 +1,7 @@
 # Contributing to this project
 
-## Joining the Working Group
-
-We are looking for participation from software developers, localization engineers and others with experience
-in Internationalization (I18N) and Localization (L10N). If you wish to contribute to this work, please review
-the information on the Contributor License Agreement below. In addition, you should:
-
-1. Apply to join our [mailing list](https://groups.google.com/a/chromium.org/forum/#!forum/message-format-wg)
-2. Watch this repository (use the "Watch" button in the upper right corner)
-
-<!-- boilerplate follows - do not edit -->
-
 ## Contributor License Agreement
 
-In order to contribute to this project, the Unicode Consortium must have on file a Contributor License Agreement (CLA) covering your contributions, either an individual or a corporate CLA. Pull Requests, issues, and other contributions will not be merged/accepted until the correct CLA is signed. Which version needs to be signed depends on who owns the contribution being made: you as the individual making the contribution or your employer. **It is your responsibility to determine whether your contribution is owned by your employer.** Please review the [Unicode Intellectual Property, Licensing, & Technical Contribution Policy][policies] for further guidance on which CLA to sign, as well as other information and guidelines regarding the Consortium’s licensing and technical contribution policies and procedures.
+In order to contribute to this project, the Unicode Consortium MUST have on file a Contributor License Agreement (CLA) covering your contributions, either an individual or a corporate CLA. 
 
-To sign the CLA in Github, open a Pull Request (a comment will be automatically added with a link to the CLA Form), or go directly to [the CLA Form][sign-cla]. You may need to sign in to Github to see the entire CLA Form.
-
-- **Individual CLA**: If you have determined that the Individual CLA is appropriate, then when you access the CLA Form, click the Individual CLA and complete the Form.
-
-- **Corporate CLA**: If you have determined that a Corporate CLA is appropriate, please first check the [public list of Corporate CLAs][unicode-corporate-clas] that the Consortium has on file. If your employer is listed, then when you access the CLA Form, you can click the box indicating that you are covered by your employer’s corporate CLA. If your employer is not on the list, then it has not already signed a CLA and you will need to arrange for your employer to do so before you contribute, as described in [How to Sign a Unicode CLA][signing].
-
-Unless otherwise noted in the [`LICENSE`](./LICENSE) file, this project is released under the [OSI-approved][osi-Unicode-License-3.0] free and open-source [Unicode License v3][unicode-license].
-
-
-[policies]: https://www.unicode.org/policies/licensing_policy.html
-[unicode-corporate-clas]: https://www.unicode.org/policies/corporate-cla-list/
-[signing]: https://www.unicode.org/policies/licensing_policy.html#signing
-[unicode-license]: https://www.unicode.org/license.txt
-[sign-cla]: https://cla-assistant.io/unicode-org/.github
-[osi-Unicode-License-3.0]: https://opensource.org/license/unicode-license-v3/
+Information on this can be found in [Unicode's CONTRIBUTING.md](https://github.com/unicode-org/.github/blob/main/.github/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -137,13 +137,22 @@ We invite feedback about the current syntax draft, as well as the real-life use-
 - General questions and thoughts → [post a discussion thread](https://github.com/unicode-org/message-format-wg/discussions).
 - Actionable feedback (bugs, feature requests) → [file a new issue](https://github.com/unicode-org/message-format-wg/issues).
 
-## Participation
+## Participation / Joining the Working Group
 
-To join in:
+We are looking for participation from software developers, localization engineers and others with experience
+in Internationalization (I18N) and Localization (L10N). 
+If you wish to contribute to this work, please review the information about the Contributor License Agreement below. 
 
-1. Review [CONTRIBUTING.md](./CONTRIBUTING.md)
-2. Apply to join our [mailing list](https://groups.google.com/a/chromium.org/forum/#!forum/message-format-wg)
-3. Watch this repository (use the "Watch" button in the upper right corner)
+To follow this work:
+1. Apply to join our [mailing list](https://groups.google.com/a/chromium.org/forum/#!forum/message-format-wg)
+2. Watch this repository (use the "Watch" button in the upper right corner)
+
+To contribute to this work, in addition to the above:
+1. Each individual MUST have a copy of the CLA on file. See below.
+2. Individuals who are employees of Unicode Member organizations SHOULD contact their member representative.
+   Individuals who are not employees of Unicode Member organizations MUST contact the chair to request Invited Expert status.
+   Employees of Unicode Member organizations MAY also apply for Invited Expert status,
+   subject to approval from their member representative.
 
 ### Copyright & Licenses
 


### PR DESCRIPTION
This PR is intended to work in tandem with @srl295's PR #875 

- change the contributing page to point to Unicode's contributing page
- change the contributing page to point to the README.md file for joining instructions
- change the README.md to include joining instructions consistent with Unicode's actual policy. Previously we just asked people to join our mailing list and watch the repo. That's good for _following_ the work.