### PR TITLE
Clarify error & fallback handling

### DIFF
--- a/spec/errors.md
+++ b/spec/errors.md
@@ -32,7 +32,7 @@ Some examples include throwing an exception,
 returning an error code, 
 or providing a function or method for enumerating any errors.
 
-For all _messages_ without _Syntax Errors_ or _Data Model Errors_,
+For all _valid_ _messages_,
 an implementation MUST enable a user to get a formatted result.
 The formatted result might include _fallback values_ 
 such as when a _placeholder_'s _expression_ produced an error
@@ -52,7 +52,7 @@ and a _Resolution Error_ or a _Message Function Error_ MUST be emitted.
 
 ## Syntax Errors
 
-**_<dfn>Syntax Errors</dfn>_** occur when the syntax representation of a message is not well-formed.
+**_<dfn>Syntax Errors</dfn>_** occur when the syntax representation of a message is not _well-formed_.
 
 > Example invalid messages resulting in a _Syntax Error_:
 >
@@ -74,7 +74,7 @@ and a _Resolution Error_ or a _Message Function Error_ MUST be emitted.
 
 ## Data Model Errors
 
-**_<dfn>Data Model Errors</dfn>_** occur when a message is invalid due to
+**_<dfn>Data Model Errors</dfn>_** occur when a message is not _valid_ due to
 violating one of the semantic requirements on its structure.
 
 ### Variant Key Mismatch

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -10,8 +10,7 @@ or created from a data model description.
 If the resulting _message_ is not _well-formed_, a _Syntax Error_ is emitted.
 If the resulting _message_ is _well-formed_ but is not _valid_, a _Data Model Error_ is emitted.
 
-The formatting of a _message_ is defined by the following operations,
-starting with _Pattern Selection_:
+The formatting of a _message_ is defined by the following operations:
 
 - **_<dfn>Pattern Selection</dfn>_** determines which of a message's _patterns_ is formatted.
   For a message with no _selectors_, this is simple as there is only one _pattern_.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -40,7 +40,7 @@ as long as the final _formatting_ result is made available to users
 and the observable behavior of the _formatting_ matches that described here.
 
 _Attributes_ MUST NOT have any effect on the formatted output of a _message_,
-or be made available to function implementations.
+nor be made available to function implementations.
 
 > [!IMPORTANT]
 >

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -39,7 +39,8 @@ or even use them in their internal processing,
 as long as the final _formatting_ result is made available to users
 and the observable behavior of the _formatting_ matches that described here.
 
-_Attributes_ MUST NOT affect the processing or output of a _message_.
+_Attributes_ MUST NOT have any effect on the formatted output of a _message_,
+or be made available to function implementations.
 
 > [!IMPORTANT]
 >

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -34,11 +34,11 @@ starting with _Pattern Selection_:
   The resolution of _text_ is rather straightforward,
   and is detailed under _literal resolution_.
 
-Formatter implementations are not required to expose
+Implementations are not required to expose
 the _expression resolution_ and _pattern selection_ operations to their users,
 or even use them in their internal processing,
 as long as the final _formatting_ result is made available to users
-and the observable behavior of the formatter matches that described here.
+and the observable behavior of the _formatting_ matches that described here.
 
 _Attributes_ MUST NOT affect the processing or output of a _message_.
 
@@ -188,7 +188,7 @@ If a _declaration_ exists for the _variable_, its resolved value is used.
 Otherwise, the _variable_ is an implicit reference to an input value,
 and its value is looked up from the _formatting context_ _input mapping_.
 
-The resolution of a _variable_ MAY fail if no value is identified for its _name_.
+The resolution of a _variable_ fails if no value is identified for its _name_.
 If this happens, an _Unresolved Variable_ error is emitted.
 If a _variable_ would resolve to a _fallback value_,
 this MUST also be considered a failure.
@@ -431,8 +431,7 @@ _Pattern selection_ is not supported for _fallback values_.
 
 ## Pattern Selection
 
-At the start of _pattern selection_,
-if the _message_ contains any _reserved statements_,
+If the _message_ contains any _reserved statements_,
 emit an _Unsupported Statement_ error.
 
 If the _message_ being formatted is not _well-formed_ and _valid_,
@@ -791,7 +790,8 @@ and a U+007D RIGHT CURLY BRACKET `}`.
 
 > For example,
 > a _message_ that is not _well-formed_ would format to a string as `{�}`,
-> if no fallback string is defined in the _formatting context_.
+> unless a fallback string is defined in the _formatting context_,
+> in which case that string would be used instead.
 
 ### Handling Bidirectional Text
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -757,7 +757,7 @@ Multiple _attributes_ are permitted in an _expression_ or _markup_.
 Each _attribute_ is separated by whitespace.
 
 Each _attribute_'s _identifier_ SHOULD be unique within the _expression_ or _markup_:
-_attributes_ beyond the first with the same _identifier_ are ignored.
+all but the last _attribute_ with the same _identifier_ are ignored.
 The order of _attributes_ is not otherwise significant.
 
 ```abnf

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -90,7 +90,7 @@ Attempting to parse a _message_ that is not _well-formed_ will result in a _Synt
 A _message_ is **_<dfn>valid</dfn>_** if it is _well-formed_ and
 **also** meets the additional content restrictions
 and semantic requirements about its structure defined below for
-_declarations_, _matcher_, _options_, and _attributes_.
+_declarations_, _matcher_, and _options_.
 Attempting to parse a _message_ that is not _valid_ will result in a _Data Model Error_.
 
 ## The Message
@@ -368,14 +368,18 @@ and at least one _variant_.
 When the _matcher_ is processed, the result will be a single _pattern_ that serves
 as the template for the formatting process.
 
-A _message_ can only be considered _valid_ if the following requirements are
-satisfied:
+A _message_ can only be considered _valid_ if the following requirements are satisfied;
+otherwise, a corresponding _Data Model Error_ will be produced during processing:
 
-- The number of _keys_ on each _variant_ MUST be equal to the number of _selectors_.
-- At least one _variant_ MUST exist whose _keys_ are all equal to the "catch-all" key `*`.
-- Each _selector_ MUST have an _annotation_,
+- _Variant Key Mismatch_:
+  The number of _keys_ on each _variant_ MUST be equal to the number of _selectors_.
+- _Missing Fallback Variant_:
+  At least one _variant_ MUST exist whose _keys_ are all equal to the "catch-all" key `*`.
+- _Missing Selector Annotation_:
+  Each _selector_ MUST have an _annotation_,
   or contain a _variable_ that directly or indirectly references a _declaration_ with an _annotation_.
-- Each _variant_ MUST use a list of _keys_ that is unique from that
+- _Duplicate Variant_:
+  Each _variant_ MUST use a list of _keys_ that is unique from that
   of all other _variants_ in the _message_.
   _Literal_ _keys_ are compared by their contents, not their syntactical appearance.
 
@@ -587,7 +591,8 @@ Multiple _options_ are permitted in an _annotation_.
 _Options_ are separated from the preceding _function_ _identifier_
 and from each other by whitespace.
 Each _option_'s _identifier_ MUST be unique within the _annotation_:
-an _annotation_ with duplicate _option_ _identifiers_ is not _valid_.
+an _annotation_ with duplicate _option_ _identifiers_ is not _valid_
+and will produce a _Duplicate Option Name_ error during processing.
 
 The order of _options_ is not significant.
 
@@ -750,10 +755,10 @@ by an U+003D EQUALS SIGN `=` along with optional whitespace.
 
 Multiple _attributes_ are permitted in an _expression_ or _markup_.
 Each _attribute_ is separated by whitespace.
-Each _attribute_'s _identifier_ MUST be unique within the _expression_ or _markup_:
-an _expression_ or _markup_ with duplicate _attribute_ _identifiers_ is not _valid_.
 
-The order of _attributes_ is not significant.
+Each _attribute_'s _identifier_ SHOULD be unique within the _expression_ or _markup_:
+_attributes_ beyond the first with the same _identifier_ are ignored.
+The order of _attributes_ is not otherwise significant.
 
 ```abnf
 attribute = "@" identifier [[s] "=" [s] literal]


### PR DESCRIPTION
This PR is seeking to fulfill the following [Things That Need Doing](https://github.com/unicode-org/message-format-wg/wiki/Things-That-Need-Doing#error-handling):

- Ensure that a complete enumeration and error types is in place (also discussed on [2024-07-22](https://github.com/unicode-org/message-format-wg/blob/main/meetings/2024/notes-2024-07-22.md#topic-result-of-balloting-for-error-handling-830))
- Ensure that error requirements are defined in the specification
- Ensure that error fallback format is defined for each error state

After a somewhat thorough review, the changes needed for the above are mostly but not completely editorial, adding explicit references, moving text around, removing unnecessary MUSTard, and making better use of our _well-formed_ and _valid_ definitions.

The one place where I'm proposing an actual change is in the treatment of attributes, about which we currently problematically say both https://github.com/unicode-org/message-format-wg/blob/aa8d29329a66a7e1399cf955a95c0b582cc1b0d5/spec/syntax.md?plain=1#L753-L754 and https://github.com/unicode-org/message-format-wg/blob/aa8d29329a66a7e1399cf955a95c0b582cc1b0d5/spec/formatting.md?plain=1#L61

To resolve this without needing to add something like a _Duplicate Attribute_ error or adding support for multiple attributes with the same identifier, I propose that we ignore all after the first. This removes a requirement for attributes to be included in the consideration of a message's validity, and allows for the statement in the Formatting section to hold more true.