### PR TITLE
Fix a typo in an example

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -262,7 +262,7 @@ the following steps are taken:
 > ```
 > .input {$n :number minimumIntegerDigits=3}
 > .local $n1 = {$n :number maximumFractionDigits=3}
-> {{$n1}}
+> {{What is the value of: {$n1}}}
 > ```
 >
 > is currently implementation-dependent.


### PR DESCRIPTION
The upcoming work to implement resolved value might make this patch unnecessary or obsolete, but fixing the typo (missing `{`/`}` around the variable in the pattern) just in case