### PR TITLE
Address name and literal equality

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -474,11 +474,6 @@ This selection method is defined in more detail below.
 An implementation MAY use any pattern selection method,
 as long as its observable behavior matches the results of the method defined here.
 
-The resolved value of each _key_ MUST be in Unicode Normalization Form C ("NFC"),
-even if the _literal_ for the _key_ is not.
-All comparisons of _keys_ MUST be done on the canonical, normalized values
-and the normalized value MUST be the value that is passed in the steps below.
-
 ### Resolve Selectors
 
 First, resolve the values of each _selector_:
@@ -520,6 +515,9 @@ The returned list MUST contain only unique elements of the input list `keys`.
 The returned list MAY be empty.
 The most-preferred key is first,
 with each successive key appearing in order by decreasing preference.
+
+The resolved value of each _key_ MUST be in Unicode Normalization Form C ("NFC"),
+even if the _literal_ for the _key_ is not.
 
 If calling MatchSelectorKeys encounters any error,
 a _Bad Selector_ error is emitted

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -474,6 +474,11 @@ This selection method is defined in more detail below.
 An implementation MAY use any pattern selection method,
 as long as its observable behavior matches the results of the method defined here.
 
+The resolved value of each _key_ MUST be in Unicode Normalization Form C ("NFC"),
+even if the _literal_ for the _key_ is not.
+All comparisons of _keys_ MUST be done on the canonical, normalized values
+and the normalized value MUST be the value that is passed in the steps below.
+
 ### Resolve Selectors
 
 First, resolve the values of each _selector_:
@@ -502,7 +507,7 @@ Next, using `res`, resolve the preferential order for all message keys:
       1. Let `key` be the `var` key at position `i`.
       1. If `key` is not the catch-all key `'*'`:
          1. Assert that `key` is a _literal_.
-         1. Let `ks` be the resolved value of `key`.
+         1. Let `ks` be the resolved value of `key` in Unicode Normalization Form C.
          1. Append `ks` as the last element of the list `keys`.
    1. Let `rv` be the resolved value at index `i` of `res`.
    1. Let `matches` be the result of calling the method MatchSelectorKeys(`rv`, `keys`)

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -753,7 +753,7 @@ that is, if they consist of the same sequence of Unicode code points after
 has been applied to both.
 
 > [!NOTE]
-> Implementations are not required to normalize _names_.
+> Implementations are not required to normalize all _names_.
 > Comparisons of _name_ values only need be done "as-if" normalization
 > has occured.
 > Since most text in the wild is already in NFC

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -684,7 +684,7 @@ except for U+0000 NULL or the surrogate code points U+D800 through U+DFFF.
 
 All code points are preserved.
 
-Two literals are considered equal if the consist of the same sequence of Unicode
+Two _literals_ are considered equal if they consist of the same sequence of Unicode
 code points.
 
 > [!IMPORTANT]

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -684,6 +684,17 @@ except for U+0000 NULL or the surrogate code points U+D800 through U+DFFF.
 
 All code points are preserved.
 
+Two literals are considered equal if the consist of the same sequence of Unicode
+code points.
+
+> [!IMPORTANT]
+> _Literal_ equality is different from _name_ equality in that
+> Unicode Normalization is not applied to _literal_ values before comparison.
+> Users are cautioned to ensure that they use the same character sequences
+> for equivalent values.
+> The use of [Normalization Form C]((https://unicode.org/reports/tr15/) for all
+> _literal_ values is RECOMMENDED.
+
 A **_<dfn>quoted literal</dfn>_** begins and ends with U+005E VERTICAL BAR `|`.
 The characters `\` and `|` within a _quoted literal_ MUST be
 escaped as `\\` and `\|`.
@@ -708,6 +719,28 @@ number-literal   = ["-"] (%x30 / (%x31-39 *DIGIT)) ["." 1*DIGIT] [%i"e" ["-" / "
 
 ### Names and Identifiers
 
+A **_<dfn>name</dfn>_** is a character sequence used in an _identifier_ 
+or as the name for a _variable_
+or the value of an _unquoted literal_.
+
+A _name_ is identical to another name if both consist of the same sequence of
+Unicode code points after 
+[Unicode Normalization Form C](https://unicode.org/reports/tr15/) (NFC)
+has been applied to both.
+
+_Variable_ names are prefixed with `$`.
+
+Valid content for _names_ is based on <cite>Namespaces in XML 1.0</cite>'s 
+[NCName](https://www.w3.org/TR/xml-names/#NT-NCName).
+This is different from XML's [Name](https://www.w3.org/TR/xml/#NT-Name)
+in that it MUST NOT contain a U+003A COLON `:`.
+Otherwise, the set of characters allowed in a _name_ is large.
+
+> [!NOTE]
+> _External variables_ can be passed in that are not valid _names_.
+> Such variables cannot be referenced in a _message_,
+> but are not otherwise errors.
+
 An **_<dfn>identifier</dfn>_** is a character sequence that
 identifies a _function_, _markup_, or _option_.
 Each _identifier_ consists of a _name_ optionally preceeded by
@@ -722,23 +755,6 @@ is reserved for future standardization.
 _Function_ _identifiers_ are prefixed with `:`.
 _Markup_ _identifiers_ are prefixed with `#` or `/`.
 _Option_ _identifiers_ have no prefix.
-
-A **_<dfn>name</dfn>_** is a character sequence used in an _identifier_ 
-or as the name for a _variable_
-or the value of an _unquoted literal_.
-
-_Variable_ names are prefixed with `$`.
-
-Valid content for _names_ is based on <cite>Namespaces in XML 1.0</cite>'s 
-[NCName](https://www.w3.org/TR/xml-names/#NT-NCName).
-This is different from XML's [Name](https://www.w3.org/TR/xml/#NT-Name)
-in that it MUST NOT contain a U+003A COLON `:`.
-Otherwise, the set of characters allowed in a _name_ is large.
-
-> [!NOTE]
-> _External variables_ can be passed in that are not valid _names_.
-> Such variables cannot be referenced in a _message_,
-> but are not otherwise errors.
 
 Examples:
 > A variable:

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -723,12 +723,21 @@ A **_<dfn>name</dfn>_** is a character sequence used in an _identifier_
 or as the name for a _variable_
 or the value of an _unquoted literal_.
 
+_Variable_ names are prefixed with `$`.
+
 A _name_ is identical to another name if both consist of the same sequence of
 Unicode code points after 
 [Unicode Normalization Form C](https://unicode.org/reports/tr15/) (NFC)
 has been applied to both.
 
-_Variable_ names are prefixed with `$`.
+> [!NOTE]
+> Implementations are not required to normalize _names_.
+> Comparisons of _name_ values only need be done "as-if" normalization
+> has occured.
+> Since most text in the wild is already in NFC
+> and since checking for NFC is fast and efficient,
+> implementations can often substitute checking for actually applying normalization
+> to _name_ values.
 
 Valid content for _names_ is based on <cite>Namespaces in XML 1.0</cite>'s 
 [NCName](https://www.w3.org/TR/xml-names/#NT-NCName).

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -438,6 +438,14 @@ A _key_ can be either a _literal_ value or the "catch-all" key `*`.
 The **_<dfn>catch-all key</dfn>_** is a special key, represented by `*`,
 that matches all values for a given _selector_.
 
+The value of each _key_ MUST be treated as if it were in
+[Unicode Normalization Form C](https://unicode.org/reports/tr15/) ("NFC").
+When _keys_ are passed during _pattern selection_, the _key_ values MUST
+be normalized into NFC.
+Two _keys_ are considered equal if they are canonically equivalent strings,
+that is, if they consist of the same sequence of Unicode code points after
+Unicode Normalization Form C has been applied to both.
+
 ## Expressions
 
 An **_<dfn>expression</dfn>_** is a part of a _message_ that will be determined
@@ -684,16 +692,19 @@ except for U+0000 NULL or the surrogate code points U+D800 through U+DFFF.
 
 All code points are preserved.
 
-Two _literals_ are considered equal if they consist of the same sequence of Unicode
-code points.
-
 > [!IMPORTANT]
-> _Literal_ equality is different from _name_ equality in that
-> Unicode Normalization is not applied to _literal_ values before comparison.
-> Users are cautioned to ensure that they use the same character sequences
-> for equivalent values.
-> The use of [Normalization Form C]((https://unicode.org/reports/tr15/) for all
-> _literal_ values is RECOMMENDED.
+> Most text, including that produced by common keyboards and input methods,
+> is already encoded in the canonical form known as
+> [Unicode Normalization Form C](https://unicode.org/reports/tr15) ("NFC").
+> A few languages, legacy character encoding conversions, or operating environments
+> can result in _literal_ values that are not in this form.
+> Some uses of _literals_ in MessageFormat,
+> notably as the value of _keys_,
+> apply NFC to the _literal_ value during processing or comparison.
+> While there is no requirement that the _literal_ value actually be entered
+> in a normalized form,
+> users are cautioned to employ the same character sequences
+> for equivalent values and, whenever possible, ensure _literals_ are in NFC.
 
 A **_<dfn>quoted literal</dfn>_** begins and ends with U+005E VERTICAL BAR `|`.
 The characters `\` and `|` within a _quoted literal_ MUST be
@@ -725,9 +736,9 @@ or the value of an _unquoted literal_.
 
 _Variable_ names are prefixed with `$`.
 
-A _name_ is identical to another name if both consist of the same sequence of
-Unicode code points after 
-[Unicode Normalization Form C](https://unicode.org/reports/tr15/) (NFC)
+Two _names_ are considered equal if they are canonically equivalent strings,
+that is, if they consist of the same sequence of Unicode code points after
+[Unicode Normalization Form C](https://unicode.org/reports/tr15/) ("NFC")
 has been applied to both.
 
 > [!NOTE]

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -446,8 +446,6 @@ that matches all values for a given _selector_.
 
 The value of each _key_ MUST be treated as if it were in
 [Unicode Normalization Form C](https://unicode.org/reports/tr15/) ("NFC").
-When _keys_ are passed during _pattern selection_, the _key_ values MUST
-be normalized into NFC.
 Two _keys_ are considered equal if they are canonically equivalent strings,
 that is, if they consist of the same sequence of Unicode code points after
 Unicode Normalization Form C has been applied to both.


### PR DESCRIPTION
This change defines equality as discussed in the 2024-09-09 teleconference in the following ways:

- It defines _name_ equality as being under NFC
- It defines _literal_ equality as explicitly **not** under NFC
- It moves _name_ before _identifier_ in that section of text to avoid a forward definition.

Note that this deviates from discussion in 2024-09-09's call in that we didn't discuss literals at length. It also doesn't discuss non-name/non-literal values, which I'll point out are limited to ASCII sequences such as keywords.