### PR TITLE
Add test for :integer and :number composition

### DIFF
--- a/test/tests/functions/integer.json
+++ b/test/tests/functions/integer.json
@@ -27,6 +27,10 @@
         }
       ],
       "exp": "one"
+    },
+    {
+      "src": ".local $x = {1.25 :integer} .local $y = {$x :number} {{{$y}}}",
+      "exp": "1"
     }
   ]
 }


### PR DESCRIPTION
In the WG meeting today, @eemeli gave a reminder that the operand of an `:integer` resolved value is an integer. This test checks for that.