### PR TITLE
Define locale options for `:datetime`, `:date` & `:time`

### DIFF
--- a/spec/registry.md
+++ b/spec/registry.md
@@ -598,6 +598,9 @@ it can include _style options_, _field options_, or other option values.
 These are included in the resolved option values of the _expression_,
 with _options_ on the _expression_ taking priority over any option values of the _operand_.
 
+In addition to _style options_ and _field options_,
+an implementation MAY also support _date/time locale options_ for `:datetime`.
+
 > [!NOTE]
 > The names of _options_ and their _values_ were derived from the
 > [options](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions#description)
@@ -671,11 +674,6 @@ The function `:datetime` has the following options:
   - `1`
   - `2`
   - `3`
-- `hourCycle` (default is locale-specific)
-  - `h11`
-  - `h12`
-  - `h23`
-  - `h24`
 - `timeZoneName`
   - `long`
   - `short`
@@ -683,20 +681,6 @@ The function `:datetime` has the following options:
   - `longOffset`
   - `shortGeneric`
   - `longGeneric`
-
-> [!NOTE]
-> The following options do not have default values because they are only to be used
-> as overrides for locale-and-value dependent implementation-defined defaults.
-
-The following date/time options are **not** part of the default registry.
-Implementations SHOULD avoid creating options that conflict with these, but
-are encouraged to track development of these options during Tech Preview:
-- `calendar` (default is locale-specific)
-  - valid [Unicode Calendar Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCalendarIdentifier)
-- `numberingSystem` (default is locale-specific)
-   - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
-- `timeZone` (default is system default time zone or UTC)
-  - valid identifier per [BCP175](https://www.rfc-editor.org/rfc/rfc6557)
 
 #### Composition
 
@@ -728,6 +712,7 @@ The function `:date` has these _options_:
   - `long`
   - `medium` (default)
   - `short`
+- _date/time locale options_
 
 If the _operand_ of the _expression_ is an implementation-defined date/time type,
 it can include other option values.
@@ -764,6 +749,7 @@ The function `:time` has these _options_:
   - `long`
   - `medium`
   - `short` (default)
+- _date/time locale options_
 
 If the _operand_ of the _expression_ is an implementation-defined date/time type,
 it can include other option values.
@@ -826,3 +812,24 @@ For more information, see [Working with Timezones](https://w3c.github.io/timezon
 > The form of these serializations is known and is a de facto standard.
 > Support for these extensions is expected to be required in the post-tech preview.
 > See: https://datatracker.ietf.org/doc/draft-ietf-sedate-datetime-extended/
+
+### Date and Time Locale Options
+
+Implementations MAY support overriding some of the options set by the current locale
+or an implementation-defined date/time _operand_ value.
+To do so, the following **_<dfn>date/time locale options</dfn>_**
+can be made available on `:datetime`, `:date`, and `:time`:
+
+- `calendar`
+  - valid [Unicode Calendar Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCalendarIdentifier)
+- `numberingSystem`
+   - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+- `hour12`
+  - `true`
+  - `false`
+- `timeZone`
+  - valid identifier per [BCP175](https://www.rfc-editor.org/rfc/rfc6557)
+
+> [!NOTE]
+> These options do not have default values because they are only to be used
+> as overrides for locale-and-value dependent implementation-defined defaults.

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -1073,17 +1073,21 @@ override values set by the current locale,
 or provided by the _formatting context_ (such as the default time zone),
 or embedded in an implementation-defined date/time _operand_ value.
 
-The following options and their values are required to be available on
-the functions `:datetime`, `:date`, and `:time`:
+The following **standard** option and its values MUST be available on
+the functions `:datetime` and `:time`:
 
 - `hour12`
   - `true`
   - `false`
-- `calendar` \[OPTIONAL\]
+
+The following **optional** options and their values SHOULD be available on
+the functions `:datetime`, `:date`, and `:time`:
+
+- `calendar`
   - valid [Unicode Calendar Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCalendarIdentifier)
-- `numberingSystem` \[OPTIONAL\]
+- `numberingSystem`
   - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
-- `timeZone` \[OPTIONAL\]
+- `timeZone`
   - valid identifier per [BCP175](https://www.rfc-editor.org/rfc/rfc6557)
 
 > [!NOTE]

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -595,7 +595,7 @@ All other _operand_ values produce a _Bad Operand_ error.
 The `:datetime` function can use either the appropriate _style options_ 
 or can use a collection of _field options_ (but not both) to control the formatted 
 output.
-_Date/time locale options_ can be combined with either _style options_ or _field options_.
+_Date/time override options_ can be combined with either _style options_ or _field options_.
 
 If both _style options_ and _field options_ are specified,
 a _Bad Option_ error is emitted
@@ -716,7 +716,7 @@ The function `:date` has these _options_:
   - `long`
   - `medium` (default)
   - `short`
-- _Date/time locale options_
+- _Date/time override options_
 
 If the _operand_ of the _expression_ is an implementation-defined date/time type,
 it can include other option values.
@@ -754,7 +754,7 @@ The function `:time` has these _options_:
   - `long`
   - `medium`
   - `short` (default)
-- _Date/time locale options_
+- _Date/time override options_
 
 If the _operand_ of the _expression_ is an implementation-defined date/time type,
 it can include other option values.
@@ -819,10 +819,12 @@ For more information, see [Working with Timezones](https://w3c.github.io/timezon
 > Support for these extensions is expected to be required in the post-tech preview.
 > See: https://datatracker.ietf.org/doc/draft-ietf-sedate-datetime-extended/
 
-### Date and Time Locale Options
+### Date and Time Override Options
 
-**_<dfn>Date/time locale options</dfn>_** override options set by the current locale
-or an implementation-defined date/time _operand_ value.
+**_<dfn>Date/time override options</dfn>_** are _options_ that allow an _expression_ to
+override values set by the current locale,
+or provided by the _formatting context_ (such as the default time zone),
+or embedded in an implementation-defined date/time _operand_ value.
 
 The following options and their values are required to be available on
 the functions `:datetime`, `:date`, and `:time`:

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -589,17 +589,16 @@ All other _operand_ values produce a _Bad Operand_ error.
 The `:datetime` function can use either the appropriate _style options_ 
 or can use a collection of _field options_ (but not both) to control the formatted 
 output.
+_Date/time locale options_ can be combined with either _style options_ or _field options_.
 
-If both are specified, a _Bad Option_ error MUST be emitted
+If both _style options_ and _field options_ are specified,
+a _Bad Option_ error is emitted
 and a _fallback value_ used as the _resolved value_ of the _expression_.
 
 If the _operand_ of the _expression_ is an implementation-defined date/time type,
 it can include _style options_, _field options_, or other option values.
 These are included in the resolved option values of the _expression_,
 with _options_ on the _expression_ taking priority over any option values of the _operand_.
-
-In addition to _style options_ and _field options_,
-an implementation MAY also support _date/time locale options_ for `:datetime`.
 
 > [!NOTE]
 > The names of _options_ and their _values_ were derived from the
@@ -632,7 +631,7 @@ and what format to use for that field.
 The _field options_ are defined as follows:
 
 > [!IMPORTANT]
-> The value `2-digit` for some _field options_ **must** be quoted
+> The value `2-digit` for some _field options_ MUST be quoted
 > in the MessageFormat syntax because it starts with a digit
 > but does not match the `number-literal` production in the ABNF.
 > ```
@@ -712,7 +711,7 @@ The function `:date` has these _options_:
   - `long`
   - `medium` (default)
   - `short`
-- _date/time locale options_
+- _Date/time locale options_
 
 If the _operand_ of the _expression_ is an implementation-defined date/time type,
 it can include other option values.
@@ -749,7 +748,7 @@ The function `:time` has these _options_:
   - `long`
   - `medium`
   - `short` (default)
-- _date/time locale options_
+- _Date/time locale options_
 
 If the _operand_ of the _expression_ is an implementation-defined date/time type,
 it can include other option values.
@@ -815,19 +814,20 @@ For more information, see [Working with Timezones](https://w3c.github.io/timezon
 
 ### Date and Time Locale Options
 
-Implementations MAY support overriding some of the options set by the current locale
+**_<dfn>Date/time locale options</dfn>_** override options set by the current locale
 or an implementation-defined date/time _operand_ value.
-To do so, the following **_<dfn>date/time locale options</dfn>_**
-can be made available on `:datetime`, `:date`, and `:time`:
 
-- `calendar`
-  - valid [Unicode Calendar Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCalendarIdentifier)
-- `numberingSystem`
-   - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+The following options and their values are required to be available on
+the functions `:datetime`, `:date`, and `:time`:
+
 - `hour12`
   - `true`
   - `false`
-- `timeZone`
+- `calendar` \[OPTIONAL\]
+  - valid [Unicode Calendar Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCalendarIdentifier)
+- `numberingSystem` \[OPTIONAL\]
+  - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+- `timeZone` \[OPTIONAL\]
   - valid identifier per [BCP175](https://www.rfc-editor.org/rfc/rfc6557)
 
 > [!NOTE]


### PR DESCRIPTION
Adds a new "basket" of **_date/time locale options_** that override defaults set in the current locale or an implementation-defined date/time _operand_ value. These are optional, and can be made available on each of `:datetime`, `:date` & `:time`.

The `hourCycle` option is dropped from the `:datetime` _field options_ (where it never belonged), and its functionality is replaced by the `hour12=true|false`_date/time locale option_.

This PR explicitly does not address the concerns raised in #866; that is a separate discussion.