### PR TITLE
Fix `:integer` option `useGrouping` values

### DIFF
--- a/spec/registry.md
+++ b/spec/registry.md
@@ -281,6 +281,7 @@ function `:integer`:
 - `useGrouping`
   - `auto` (default)
   - `always`
+  - `never`
   - `min2`
 - `minimumIntegerDigits`
   - ([digit size option](#digit-size-options), default: `1`)


### PR DESCRIPTION
I noticed that `:integer` does not include the "never" value for the option `useGrouping`. This is a bug.