### PR TITLE
Fix tests for bidirectional isolation

### DIFF
--- a/test/schemas/v0/tests.schema.json
+++ b/test/schemas/v0/tests.schema.json
@@ -118,6 +118,9 @@
         "src": {
           "$ref": "#/$defs/src"
         },
+        "bidiIsolation": {
+          "$ref": "#/$defs/bidiIsolation"
+        },
         "params": {
           "$ref": "#/$defs/params"
         },
@@ -146,6 +149,9 @@
         "src": {
           "$ref": "#/$defs/src"
         },
+        "bidiIsolation": {
+          "$ref": "#/$defs/bidiIsolation"
+        },
         "params": {
           "$ref": "#/$defs/params"
         },
@@ -171,6 +177,10 @@
     "src": {
       "description": "The MF2 syntax source.",
       "type": "string"
+    },
+    "bidiIsolation": {
+      "description": "The bidi isolation strategy.",
+      "enum": ["default", "none"]
     },
     "params": {
       "description": "Parameters to pass in to the formatter for resolving external variables.",
@@ -240,6 +250,23 @@
               },
               "value": {
                 "type": "string"
+              }
+            }
+          },
+          {
+            "description": "Bidi isolation part.",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "const": "bidiIsolation"
+              },
+              "value": {
+                "enum": ["\u2066", "\u2067", "\u2068", "\u2069"]
               }
             }
           },

--- a/test/tests/bidi.json
+++ b/test/tests/bidi.json
@@ -2,6 +2,7 @@
   "scenario": "Bidi support",
   "description": "Tests for correct parsing of messages with bidirectional marks and isolates",
   "defaultTestProperties": {
+    "bidiIsolation": "default",
     "locale": "en-US"
   },
   "tests": [
@@ -13,17 +14,17 @@
     {
         "description": "complex-message   = o *(declaration o) complex-body o",
         "src": "\u200E .local $x = {1} {{ {$x}}}",
-        "exp": " 1"
+        "exp": " \u20681\u2069"
     },
     {
         "description": "complex-message   = o *(declaration o) complex-body o",
         "src": ".local $x = {1} \u200F {{ {$x}}}",
-        "exp": " 1"
+        "exp": " \u20681\u2069"
     },
     {
         "description": "complex-message   = o *(declaration o) complex-body o",
         "src": ".local $x = {1} {{ {$x}}} \u2066",
-        "exp": " 1"
+        "exp": " \u20681\u2069"
     },
     {
         "description": "input-declaration = input o variable-expression",
@@ -79,12 +80,12 @@
     {
         "description": "literal-expression  = \"{\" o literal [s function] *(s attribute) o \"}\"",
         "src": "{\u200E hello \u200F}",
-        "exp": "hello"
+        "exp": "\u2068hello\u2069"
     },
     {
         "description": "variable-expression = \"{\" o variable [s function] *(s attribute) o \"}\"",
         "src": ".local $x = {1} {{ {\u200E $x \u200F} }}",
-        "exp": " 1 "
+        "exp": " \u20681\u2069 "
     },
     {
         "description": "function-expression = \"{\" o function *(s attribute) o \"}\"",
@@ -114,7 +115,7 @@
     {
         "description":  " name... excludes U+FFFD and U+061C -- this pases as name -> [bidi] name-start *name-char",
         "src": ".local $\u061Cfoo = {1} {{ {$\u061Cfoo} }}",
-        "exp": " 1 "
+        "exp": " \u20681\u2069 "
     },
     {
         "description":  " name matches https://www.w3.org/TR/REC-xml-names/#NT-NCName but excludes U+FFFD and U+061C",
@@ -124,17 +125,17 @@
     {
         "description":  "name       = [bidi] name-start *name-char [bidi]",
         "src": ".local $\u200Efoo\u200F = {3} {{{$\u200Efoo\u200F}}}",
-        "exp": "3"
+        "exp": "\u20683\u2069"
     },
     {
         "description":  "name       = [bidi] name-start *name-char [bidi]",
         "src": ".local $foo = {4} {{{$\u200Efoo\u200F}}}",
-        "exp": "4"
+        "exp": "\u20684\u2069"
     },
     {
         "description":  "name       = [bidi] name-start *name-char [bidi]",
         "src": ".local $\u200Efoo\u200F = {5} {{{$foo}}}",
-        "exp": "5"
+        "exp": "\u20685\u2069"
     },
     {
         "description":  "name       = [bidi] name-start *name-char [bidi]",

--- a/test/tests/functions/date.json
+++ b/test/tests/functions/date.json
@@ -3,6 +3,7 @@
   "scenario": "Date function",
   "description": "The built-in formatter for dates.",
   "defaultTestProperties": {
+    "bidiIsolation": "none",
     "locale": "en-US",
     "expErrors": false
   },

--- a/test/tests/functions/datetime.json
+++ b/test/tests/functions/datetime.json
@@ -3,6 +3,7 @@
   "scenario": "Datetime function",
   "description": "The built-in formatter for datetimes.",
   "defaultTestProperties": {
+    "bidiIsolation": "none",
     "locale": "en-US",
     "expErrors": false
   },

--- a/test/tests/functions/integer.json
+++ b/test/tests/functions/integer.json
@@ -3,6 +3,7 @@
   "scenario": "Integer function",
   "description": "The built-in formatter for integers.",
   "defaultTestProperties": {
+    "bidiIsolation": "none",
     "locale": "en-US"
   },
   "tests": [

--- a/test/tests/functions/number.json
+++ b/test/tests/functions/number.json
@@ -3,6 +3,7 @@
   "scenario": "Number function",
   "description": "The built-in formatter for numbers.",
   "defaultTestProperties": {
+    "bidiIsolation": "none",
     "locale": "en-US"
   },
   "tests": [

--- a/test/tests/functions/string.json
+++ b/test/tests/functions/string.json
@@ -3,6 +3,7 @@
   "scenario": "String function",
   "description": "The built-in formatter for strings.",
   "defaultTestProperties": {
+    "bidiIsolation": "none",
     "locale": "en-US"
   },
   "tests": [

--- a/test/tests/functions/time.json
+++ b/test/tests/functions/time.json
@@ -3,6 +3,7 @@
   "scenario": "Time function",
   "description": "The built-in formatter for times.",
   "defaultTestProperties": {
+    "bidiIsolation": "none",
     "locale": "en-US",
     "expErrors": false
   },

--- a/test/tests/syntax.json
+++ b/test/tests/syntax.json
@@ -3,6 +3,7 @@
   "scenario": "Syntax",
   "description": "Test cases that do not depend on any registry definitions.",
   "defaultTestProperties": {
+    "bidiIsolation": "none",
     "locale": "en-US"
   },
   "tests": [

--- a/test/tests/u-options.json
+++ b/test/tests/u-options.json
@@ -3,6 +3,7 @@
   "scenario": "u: Options",
   "description": "Common options affecting the function context",
   "defaultTestProperties": {
+    "bidiIsolation": "default",
     "locale": "en-US"
   },
   "tests": [
@@ -24,7 +25,7 @@
           "type": "markup",
           "kind": "close",
           "id": "x",
-          "name": "tag"
+          "name": "ns:tag"
         }
       ]
     },
@@ -45,7 +46,7 @@
         {
           "type": "markup",
           "kind": "close",
-          "name": "tag"
+          "name": "ns:tag"
         }
       ]
     },
@@ -74,32 +75,31 @@
       "src": "hello {world :string u:dir=rtl}",
       "exp": "hello \u2067world\u2069",
       "expParts": [
-        {
-          "type": "literal",
-          "value": "hello "
-        },
+        { "type": "literal", "value": "hello " },
+        { "type": "bidiIsolation", "value": "\u2067" },
         {
           "type": "string",
           "source": "|world|",
           "dir": "rtl",
+          "locale": "en-US",
           "value": "world"
-        }
+        },
+        { "type": "bidiIsolation", "value": "\u2069" }
       ]
     },
     {
       "src": "hello {world :string u:dir=auto}",
       "exp": "hello \u2068world\u2069",
       "expParts": [
-        {
-          "type": "literal",
-          "value": "hello "
-        },
+        { "type": "literal", "value": "hello " },
+        { "type": "bidiIsolation", "value": "\u2068" },
         {
           "type": "string",
           "source": "|world|",
-          "dir": "auto",
+          "locale": "en-US",
           "value": "world"
-        }
+        },
+        { "type": "bidiIsolation", "value": "\u2069" }
       ]
     },
     {
@@ -120,7 +120,7 @@
     {
       "locale": "ar",
       "src": "أهلاً {بالعالم :string}",
-      "exp": "أهلاً \u2067بالعالم\u2069"
+      "exp": "أهلاً \u2068بالعالم\u2069"
     }
   ]
 }


### PR DESCRIPTION
The current tests do not account for the [bidirectional isolation](https://github.com/unicode-org/message-format-wg/blob/main/spec/formatting.md#handling-bidirectional-text) of the formatted results. This adds an option `bidiIsolation` to the tests, with values `'default'` and `'none'` corresponding to the _Default BiDi Strategy_ and to a strategy of not applying any isolation.

Most of the existing tests follow the `'none'` strategy, and have been left unchanged except for noting this state of affairs. The `bidi.json` tests have been updated to use the `'default'` strategy, as that seemed appropriate.

A new `type: 'bidiIsolation'` part is added, and included in the `u-options.json` `expParts` results as appropriate; some bugs in those tests have also been addressed.