### PR TITLE
Do not initialise function context direction from message direction

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -267,7 +267,8 @@ the following steps are taken:
 
    - The current _locale_,
      potentially including a fallback chain of locales.
-   - The base directionality of the _message_ and its _text_ tokens.
+   - The base directionality of the _expression_.
+     By default, this is undefined or empty.
 
    If the resolved mapping of _options_ includes any _`u:` options_
    supported by the implementation, process them as specified.


### PR DESCRIPTION
When implementing bidi isolation, it took me a while to figure out that the _function context_ directionality should not default to the message directionality, but be left empty unless overridden by `u:dir`.

To see how this works, consider this English message:
```
Hello {$name :string} 1234
```

If we were to use the message's LTR directionality when formatting the placeholder, and if the name were RTL, we would end up with a _resolved value_ that claimed that its contents were LTR, when they actually are not. The placeholder would therefore not be isolated, and the message would render incorrectly (i.e. with `1234` to the left of the name).

If instead we don't have any presumptions about the directionality of the `$name`, then we end up either auto-detecting its direction within the `:string` handler, or isolating it with FSI/PDI, and getting the right results.