### PR TITLE
Clean up `quoted-pattern` definition

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -12,12 +12,12 @@ complex-body      = quoted-pattern / matcher
 input-declaration = input o variable-expression
 local-declaration = local s variable o "=" o expression
 
-quoted-pattern    = o "{{" pattern "}}"
+quoted-pattern    = "{{" pattern "}}"
 
 matcher           = match-statement s variant *(o variant)
 match-statement   = match 1*(s selector)
 selector          = variable
-variant           = key *(s key) quoted-pattern
+variant           = key *(s key) o quoted-pattern
 key               = literal / "*"
 
 ; Expressions

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -274,7 +274,7 @@ A _quoted pattern_ starts with a sequence of two U+007B LEFT CURLY BRACKET `{{`
 and ends with a sequence of two U+007D RIGHT CURLY BRACKET `}}`.
 
 ```abnf
-quoted-pattern = o "{{" pattern "}}"
+quoted-pattern = "{{" pattern "}}"
 ```
 
 A _quoted pattern_ MAY be empty.
@@ -449,7 +449,7 @@ Each _key_ is separated from each other by whitespace.
 Whitespace is permitted but not required between the last _key_ and the _quoted pattern_.
 
 ```abnf
-variant = key *(s key) quoted-pattern
+variant = key *(s key) o quoted-pattern
 key     = literal / "*"
 ```
 


### PR DESCRIPTION
`complex-body` was already always prefixed by optional space, so in that case there was effectively two subsequent optional spaces: that is unnecessary. It is much cleaner to remove the optional leading space from the `quoted-pattern` definition, and instead move it to explicitly before `quoted-pattern` in  `variant`.

This change is purely editorial and has no normative impact.
