### PR TITLE
Implement `:unit` as Proposed RECOMMENDED in the registry

### DIFF
--- a/spec/registry.md
+++ b/spec/registry.md
@@ -384,7 +384,6 @@ its _resolved value_ contains the implementation-defined integer value
 of the _operand_ of the annotated _expression_,
 together with the resolved options' values.
 
-====
 
 ### `:unit` function
 
@@ -424,7 +423,7 @@ A [Number Operand](#number-operands) without a `unit` _option_ results in a _Bad
 > For example, such an implementation might define a "unit operand"
 > to include a key-value structure with specific keys to be the
 > local unit operand, which might look like the following:
-> ```json
+> ```
 > {
 >    "value": 123.45,
 >    "unit": "kilometer",
@@ -451,6 +450,10 @@ The following options and their values are required to be available on the funct
 - `perUnit`
   - valid [Unit Identifier](https://www.unicode.org/reports/tr35/tr35-general.html#unit-identifiers)
     (no default)
+- `unitDisplay`
+  - `short` (default)
+  - `narrow`
+  - `long`
 - `compactDisplay` (this option only has meaning when combined with the option `notation=compact`)
    - `short` (default)
    - `long`
@@ -460,6 +463,12 @@ The following options and their values are required to be available on the funct
 - `numberingSystem`
    - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
      (default is locale-specific)
+- `signDisplay`
+   -  `auto` (default)
+   -  `always`
+   -  `exceptZero`
+   -  `negative`
+   -  `never`
 - `useGrouping`
   - `auto` (default)
   - `always`
@@ -524,7 +533,6 @@ together with the resolved options' values.
 > (for example, trying to convert meters to gallons produced a _Bad Option_)
 > nor will all implementations support conversion.
 
-====
 
 ### Number Operands
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -561,13 +561,10 @@ The _function_ `:currency` performs selection as described in [Number Selection]
 
 ### The `:unit` function
 
-The _function_ `:unit` is a selector and formatter for unitized values,
-that is, numeric values associated with a unit of measurement.
+The _function_ `:unit` is **Proposed** for inclusion in the next release of this specification but has not yet been finalized.
+The _function_ `:unit` is proposed to be a **RECOMMENDED** selector and formatter for unitized values,
+that is, for numeric values associated with a unit of measurement.
 This is a specialized form of numeric selection and formatting.
-
-> [!IMPORTANT]
-> Implementation of this function is **_OPTIONAL_**.
-> Any implementation of this function is strongly encouraged to follow this specification.
 
 #### Operands
 
@@ -622,10 +619,10 @@ The following options and their values are required to be available on the funct
    -  `exact`
 - `unit`
    - valid [Unit Identifier](https://www.unicode.org/reports/tr35/tr35-general.html#unit-identifiers)
-     (no default)
-- `usage` \[OPTIONAL\]
-    - Well-formed and valid usage identifiers are defined in [Unicode Preferences](https://www.unicode.org/reports/tr35/tr35-info.html#unit-preferences).
-    - (no default)
+     (no default, see [Unit Conversion](#unit-conversion) below)
+- `usage` \[RECOMMENDED\]
+    - valid [Unicode Unit Preference](https://www.unicode.org/reports/tr35/tr35-info.html#unit-preferences)
+      (no default)
 - `unitDisplay`
   - `short` (default)
   - `narrow`
@@ -691,12 +688,26 @@ with _options_ on the _expression_ taking priority over any _option_ values of t
 > would have the resolved options:
 > `{ unit: 'furlong', minimumFractionDigits: '2', minimumIntegerDigits: '1' }`.
 
-Some implementations support conversion to the locale's preferred units via the `usage` _option_.
+#### Resolved Value
+
+The _resolved value_ of an _expression_ with a `:unit` _function_
+consist of an implementation-defined unit value
+of the _operand_ of the annotated _expression_,
+together with the resolved _options_ and their resolved values.
+
+#### Selection
+
+The _function_ `:unit` performs selection as described in [Number Selection](#number-selection) below.
+
+#### Unit Conversion
+
+Implementations MAY support conversion to the locale's preferred units via the `usage` _option_.
 Implementing this _option_ is optional.
-Attempting to convert units produces an _Unsupported Operation_ error if such conversion is unsupported.
-It produces a _Bad Option_ error if the specified units are incompatible.
+Not all `usage` values are compatible with a given unit.
+Implementations SHOULD emit an _Unsupported Operation_ error if the requestion conversion is not supported.
+
 > For example, trying to convert a `length` unit such as meters
-> to a `volume` unit (such as "gallons") produces a _Bad Option_.
+> to a `volume` unit (such as "gallons") could produce an _Unsupported Operation_ error.
 
 Implementations MUST NOT substitute the unit without performing the associated conversion.
 
@@ -713,20 +724,7 @@ Implementations MUST NOT substitute the unit without performing the associated c
 > ```
 > This can produce "You have 405 feet to go."
 
-Not all `usage` values are compatible with a given unit.
-Implementations will produce a _Bad Option_ error for units 
-or combinations of units and usages that are not supported.
 
-#### Resolved Value
-
-The _resolved value_ of an _expression_ with a `:unit` _function_
-consist of an implementation-defined unit value
-of the _operand_ of the annotated _expression_,
-together with the resolved _options_ and their resolved values.
-
-#### Selection
-
-The _function_ `:unit` performs selection as described in [Number Selection](#number-selection) below.
 
 ### Number Operands
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -483,7 +483,8 @@ The following options and their values are required to be available on the funct
   - ([digit size option](#digit-size-options))
 - `maximumSignificantDigits`
   - ([digit size option](#digit-size-options))
-
+- `usage`
+    - Well-formed and valid usage identifiers are defined in [Unicode Preferences](https://www.unicode.org/reports/tr35/tr35-info.html#unit-preferences).
 If the _operand_ of the _expression_ is an implementation-defined type,
 such as the _resolved value_ of an _expression_ with a `:unit` _annotation_,
 it can include option values.

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -574,9 +574,9 @@ This is a specialized form of numeric selection and formatting.
 The _operand_ of the `:unit` function can be one of any number of
 implementation-defined types,
 each of which contains a numerical `value` plus a `unit`
-or it can be a [Number Operand](#number-operands), as long as the option
+or it can be a [Number Operand](#number-operands), as long as the _option_
 `unit` is provided.
-The option `unit` MAY be used to override the units of an implementation-defined type,
+The _option_ `unit` MAY be used to override the units of an implementation-defined type,
 provided the units are compatible and the implementation supports conversion.
 
 The value of the _operand_'s `unit` SHOULD be either a string containing a
@@ -679,9 +679,9 @@ The following options and their values are required to be available on the funct
 
 If the _operand_ of the _expression_ is an implementation-defined type,
 such as the _resolved value_ of an _expression_ with a `:unit` _annotation_,
-it can include option values.
-These are included in the resolved option values of the _expression_,
-with _options_ on the _expression_ taking priority over any option values of the _operand_.
+it can include _option_ values.
+These are included in the resolved _option_ values of the _expression_,
+with _options_ on the _expression_ taking priority over any _option_ values of the _operand_.
 
 > For example, the _placeholder_ in this _message_:
 > ```
@@ -693,9 +693,10 @@ with _options_ on the _expression_ taking priority over any option values of the
 
 Some implementations support conversion to the locale's preferred units via the `usage` _option_.
 Implementing this _option_ is optional.
-Attempting to convert units produces a _Bad Option_ error if such conversion is unsupported
-or if the specified units are incompatible.
-For example, trying to convert meters to a `volume` unit (such as "gallons") produces a _Bad Option_.
+Attempting to convert units produces an _Unsupported Operation_ error if such conversion is unsupported.
+It produces a _Bad Option_ error if the specified units are incompatible.
+> For example, trying to convert a `length` unit such as meters
+> to a `volume` unit (such as "gallons") produces a _Bad Option_.
 
 Implementations MUST NOT substitute the unit without performing the associated conversion.
 
@@ -712,7 +713,7 @@ Implementations MUST NOT substitute the unit without performing the associated c
 > ```
 > This can produce "You have 405 feet to go."
 
-Not all usages are compatible with the unit.
+Not all `usage` values are compatible with a given unit.
 Implementations will produce a _Bad Option_ error for units 
 or combinations of units and usages that are not supported.
 
@@ -721,7 +722,7 @@ or combinations of units and usages that are not supported.
 The _resolved value_ of an _expression_ with a `:unit` _function_
 consist of an implementation-defined unit value
 of the _operand_ of the annotated _expression_,
-together with the resolved options' values.
+together with the resolved _options_ and their resolved values.
 
 #### Selection
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -399,10 +399,10 @@ This is a specialized form of numeric selection and formatting.
 
 The _operand_ of the `:unit` function can be one of any number of
 implementation-defined types,
-each of which contains a numerical `value` plus a `unit` and optionally a `perUnit`.
-or it can be a [Number Operand](#number-operands), as long as at least the option
+each of which contains a numerical `value` plus a `unit`
+or it can be a [Number Operand](#number-operands), as long as the option
 `unit` is provided.
-The options `unit` and `perUnit` MAY be used to override the units of an implementation-defined type,
+The option `unit` MAY be used to override the units of an implementation-defined type,
 provided the units are compatible and the implementation supports conversion.
 
 The value of the _operand_'s `unit` SHOULD be either a string containing a
@@ -412,22 +412,21 @@ or an implementation-defined unit type.
 A [Number Operand](#number-operands) without a `unit` _option_ results in a _Bad Operand_ error.
 
 > [!NOTE]
-> For example, in ICU4J, the type `com.ibm.icu.util.Measure` can be used
-> to set the `value` and `unit` (and optionally the `perUnit`).
+> For example, in ICU4J, the type `com.ibm.icu.util.Measure` might be used
+> as an _operand_ for `:unit` because it contains the `value` and `unit`.
 
 > [!NOTE]
 > For runtime environments that do not provide a ready-made data structure,
 > class, or type for unit values, the implementation ought to provide
 > a data structure, convenience function, or documentation on how to encode
-> the value, unit, and optionally per-unit for formatting.
+> the value and unit for formatting.
 > For example, such an implementation might define a "unit operand"
 > to include a key-value structure with specific keys to be the
 > local unit operand, which might look like the following:
 > ```
 > {
 >    "value": 123.45,
->    "unit": "kilometer",
->    "perUnit": "hour"
+>    "unit": "kilometer-per-hour"
 > }
 > ```
 
@@ -447,8 +446,8 @@ The following options and their values are required to be available on the funct
 - `unit`
    - valid [Unit Identifier](https://www.unicode.org/reports/tr35/tr35-general.html#unit-identifiers)
      (no default)
-- `perUnit`
-  - valid [Unit Identifier](https://www.unicode.org/reports/tr35/tr35-general.html#unit-identifiers)
+- `usage`
+  - valid usage identifier (TBD)
     (no default)
 - `unitDisplay`
   - `short` (default)
@@ -500,7 +499,7 @@ with _options_ on the _expression_ taking priority over any option values of the
 > `{ unit: 'furlong', minimumFractionDigits: '2', minimumIntegerDigits: '1' }`.
 
 Some implementations support conversion between compatible units.
-Attempting to convert units (by specifying the `unit` option)
+Attempting to convert units (by specifying the `usage` option)
 produces a _Bad Option_ error if conversion is unsupported
 or if the specified units are incompatible.
 For example, trying to convert meters to gallons produces a _Bad Option_.
@@ -520,9 +519,9 @@ Implementations MUST NOT substitute the unit without performing the associated c
 > ```
 > This can produce "You have 405 feet to go."
 
-Not all per-units are compatible with the primary unit.
+Not all usages are compatible with the unit.
 Implementations will produce a _Bad Option_ error for units 
-or combinations of units and per-units that are not supported.
+or combinations of units and usages that are not supported.
 
 #### Selection
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -417,7 +417,7 @@ A [Number Operand](#number-operands) without a `unit` _option_ results in a _Bad
 
 > [!NOTE]
 > For runtime environments that do not provide a ready-made data structure,
-> class, or type for currency values, the implementation ought to provide
+> class, or type for unit values, the implementation ought to provide
 > a data structure, convenience function, or documentation on how to encode
 > the value, unit, and optionally per-unit for formatting.
 > For example, such an implementation might define a "unit operand"
@@ -439,7 +439,7 @@ In general, the default values for such options depend on the locale,
 the unit,
 the value of other options, or all of these.
 
-The following options and their values are required to be available on the function `:currency`:
+The following options and their values are required to be available on the function `:unit`:
 - `select`
    -  `plural` (default)
    -  `ordinal`

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -573,8 +573,6 @@ implementation-defined types,
 each of which contains a numerical `value` plus a `unit`
 or it can be a [Number Operand](#number-operands), as long as the _option_
 `unit` is provided.
-The _option_ `unit` MAY be used to override the units of an implementation-defined type,
-provided the units are compatible and the implementation supports conversion.
 
 The value of the _operand_'s `unit` SHOULD be either a string containing a
 valid [Unit Identifier](https://www.unicode.org/reports/tr35/tr35-general.html#unit-identifiers)
@@ -719,9 +717,10 @@ Implementations MUST NOT substitute the unit without performing the associated c
 >    "unit": "meter"
 > }
 > ```
-> The following _message_ might convert the formatted result to U.S. customary units:
+> The following _message_ might convert the formatted result to U.S. customary units
+> in the `en-US` locale:
 > ```
-> You have {$v :unit unit=foot maximumFractionDigits=0} to go.
+> You have {$v :unit usage=road maximumFractionDigits=0} to go.
 > ```
 > This can produce "You have 405 feet to go."
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -542,17 +542,16 @@ Not all usages are compatible with the unit.
 Implementations will produce a _Bad Option_ error for units 
 or combinations of units and usages that are not supported.
 
+#### Resolved Value
+
+The _resolved value_ of an _expression_ with a `:unit` _function_
+consist of an implementation-defined unit value
+of the _operand_ of the annotated _expression_,
+together with the resolved options' values.
+
 #### Selection
 
 The _function_ `:unit` performs selection as described in [Number Selection](#number-selection) below.
-
-#### Composition
-
-When an _operand_ or an _option_ value uses a _variable_ annotated,
-directly or indirectly, by a `:unit` _annotation_,
-its _resolved value_ contains an implementation-defined unit value
-of the _operand_ of the annotated _expression_,
-together with the resolved options' values.
 
 ### Number Operands
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -384,6 +384,148 @@ its _resolved value_ contains the implementation-defined integer value
 of the _operand_ of the annotated _expression_,
 together with the resolved options' values.
 
+====
+
+### `:unit` function
+
+The function `:unit` is a selector and formatter for unitized values,
+that is, numeric values associated with a unit of measurement.
+This is a specialized form of numeric selection and formatting.
+
+> [!IMPORTANT]
+> Implementation of this function is **_OPTIONAL_**.
+> Any implementation of this function is strongly encouraged to follow this specification.
+
+#### Operands
+
+The _operand_ of the `:unit` function can be one of any number of
+implementation-defined types,
+each of which contains a numerical `value` plus a `unit` and optionally a `perUnit`.
+or it can be a [Number Operand](#number-operands), as long as at least the option
+`unit` is provided.
+The options `unit` and `perUnit` MAY be used to override the units of an implementation-defined type,
+provided the units are compatible and the implementation supports conversion.
+
+The value of the _operand_'s `unit` SHOULD be either a string containing a
+valid [Unit Identifier](https://www.unicode.org/reports/tr35/tr35-general.html#unit-identifiers)
+or an implementation-defined unit type.
+
+A [Number Operand](#number-operands) without a `unit` _option_ results in a _Bad Operand_ error.
+
+> [!NOTE]
+> For example, in ICU4J, the type `com.ibm.icu.util.Measure` can be used
+> to set the `value` and `unit` (and optionally the `perUnit`).
+
+> [!NOTE]
+> For runtime environments that do not provide a ready-made data structure,
+> class, or type for currency values, the implementation ought to provide
+> a data structure, convenience function, or documentation on how to encode
+> the value, unit, and optionally per-unit for formatting.
+> For example, such an implementation might define a "unit operand"
+> to include a key-value structure with specific keys to be the
+> local unit operand, which might look like the following:
+> ```json
+> {
+>    "value": 123.45,
+>    "unit": "kilometer",
+>    "perUnit": "hour"
+> }
+> ```
+
+#### Options
+
+Some options do not have default values defined in this specification.
+The defaults for these options are implementation-dependent.
+In general, the default values for such options depend on the locale, 
+the unit,
+the value of other options, or all of these.
+
+The following options and their values are required to be available on the function `:currency`:
+- `select`
+   -  `plural` (default)
+   -  `ordinal`
+   -  `exact`
+- `unit`
+   - valid [Unit Identifier](https://www.unicode.org/reports/tr35/tr35-general.html#unit-identifiers)
+     (no default)
+- `perUnit`
+  - valid [Unit Identifier](https://www.unicode.org/reports/tr35/tr35-general.html#unit-identifiers)
+    (no default)
+- `compactDisplay` (this option only has meaning when combined with the option `notation=compact`)
+   - `short` (default)
+   - `long`
+- `notation`
+   - `standard` (default)
+   - `compact`
+- `numberingSystem`
+   - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+     (default is locale-specific)
+- `useGrouping`
+  - `auto` (default)
+  - `always`
+  - `never`
+  - `min2`
+- `minimumIntegerDigits`
+  - ([digit size option](#digit-size-options), default: `1`)
+- `minimumFractionDigits`
+  - ([digit size option](#digit-size-options))
+- `maximumFractionDigits`
+  - ([digit size option](#digit-size-options))
+- `minimumSignificantDigits`
+  - ([digit size option](#digit-size-options))
+- `maximumSignificantDigits`
+  - ([digit size option](#digit-size-options))
+
+If the _operand_ of the _expression_ is an implementation-defined type,
+such as the _resolved value_ of an _expression_ with a `:unit` _annotation_,
+it can include option values.
+These are included in the resolved option values of the _expression_,
+with _options_ on the _expression_ taking priority over any option values of the _operand_.
+
+> For example, the _placeholder_ in this _message_:
+> ```
+> .input {$n :unit unit=furlong minimumFractionDigits=2}
+> {{{$n :unit minimumIntegerDigits=1}}}
+> ```
+> would have the resolved options:
+> `{ unit: 'furlong', minimumFractionDigits: '2', minimumIntegerDigits: '1' }`.
+
+Not all per-units are compatible with the primary unit.
+Implementations will produce a _Bad Option_ error for units 
+or combinations of units and per-units that are not supported.
+
+#### Selection
+
+The _function_ `:unit` performs selection as described in [Number Selection](#number-selection) below.
+
+#### Composition
+
+When an _operand_ or an _option_ value uses a _variable_ annotated,
+directly or indirectly, by a `:unit` _annotation_,
+its _resolved value_ contains an implementation-defined unit value
+of the _operand_ of the annotated _expression_,
+together with the resolved options' values.
+
+> [!NOTE]
+> Some implementations support conversation between compatible units.
+> For example, consider the value:
+> ```
+> {
+>    "value": 123.5,
+>    "unit": "meter"
+> }
+> ```
+> The following _message_ might convert the formatted result to U.S. customary units:
+> ```
+> You have {$v :unit unit=foot} to go.
+> ```
+> Care has to be excersized with this type of operation.
+> Not all units support conversion
+> (for example, trying to convert meters to gallons produced a _Bad Option_)
+> nor will all implementations support conversion.
+
+====
+
 ### Number Operands
 
 The _operand_ of a number function is either an implementation-defined type or

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -499,6 +499,27 @@ with _options_ on the _expression_ taking priority over any option values of the
 > would have the resolved options:
 > `{ unit: 'furlong', minimumFractionDigits: '2', minimumIntegerDigits: '1' }`.
 
+Some implementations support conversion between compatible units.
+Attempting to convert units (by specifying the `unit` option)
+produces a _Bad Option_ error if conversion is unsupported
+or if the specified units are incompatible.
+For example, trying to convert meters to gallons produces a _Bad Option_.
+
+Implementations MUST NOT substitute the unit without performing the associated conversion.
+
+> For example, consider the value:
+> ```
+> {
+>    "value": 123.5,
+>    "unit": "meter"
+> }
+> ```
+> The following _message_ might convert the formatted result to U.S. customary units:
+> ```
+> You have {$v :unit unit=foot maximumFractionDigits=0} to go.
+> ```
+> This can produce "You have 405 feet to go."
+
 Not all per-units are compatible with the primary unit.
 Implementations will produce a _Bad Option_ error for units 
 or combinations of units and per-units that are not supported.
@@ -514,25 +535,6 @@ directly or indirectly, by a `:unit` _annotation_,
 its _resolved value_ contains an implementation-defined unit value
 of the _operand_ of the annotated _expression_,
 together with the resolved options' values.
-
-> [!NOTE]
-> Some implementations support conversion between compatible units.
-> For example, consider the value:
-> ```
-> {
->    "value": 123.5,
->    "unit": "meter"
-> }
-> ```
-> The following _message_ might convert the formatted result to U.S. customary units:
-> ```
-> You have {$v :unit unit=foot} to go.
-> ```
-> Care has to be exercised with this type of operation.
-> Not all units support conversion
-> (for example, trying to convert meters to gallons produced a _Bad Option_)
-> nor will all implementations support conversion.
-
 
 ### Number Operands
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -516,7 +516,7 @@ of the _operand_ of the annotated _expression_,
 together with the resolved options' values.
 
 > [!NOTE]
-> Some implementations support conversation between compatible units.
+> Some implementations support conversion between compatible units.
 > For example, consider the value:
 > ```
 > {
@@ -528,7 +528,7 @@ together with the resolved options' values.
 > ```
 > You have {$v :unit unit=foot} to go.
 > ```
-> Care has to be excersized with this type of operation.
+> Care has to be exercised with this type of operation.
 > Not all units support conversion
 > (for example, trying to convert meters to gallons produced a _Bad Option_)
 > nor will all implementations support conversion.

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -617,10 +617,10 @@ The following options and their values are required to be available on the funct
    -  `exact`
 - `unit`
    - valid [Unit Identifier](https://www.unicode.org/reports/tr35/tr35-general.html#unit-identifiers)
-     (no default, see [Unit Conversion](#unit-conversion) below)
+     (no default)
 - `usage` \[RECOMMENDED\]
     - valid [Unicode Unit Preference](https://www.unicode.org/reports/tr35/tr35-info.html#unit-preferences)
-      (no default)
+      (no default, see [Unit Conversion](#unit-conversion) below)
 - `unitDisplay`
   - `short` (default)
   - `narrow`

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -438,17 +438,20 @@ In general, the default values for such options depend on the locale,
 the unit,
 the value of other options, or all of these.
 
+> [!NOTE]
+> The option `select` does not accept the value `ordinal` because selecting
+> unit values using ordinal rules makes no sense.
+
 The following options and their values are required to be available on the function `:unit`:
 - `select`
    -  `plural` (default)
-   -  `ordinal`
    -  `exact`
 - `unit`
    - valid [Unit Identifier](https://www.unicode.org/reports/tr35/tr35-general.html#unit-identifiers)
      (no default)
 - `usage`
-  - valid usage identifier (TBD)
-    (no default)
+    - Well-formed and valid usage identifiers are defined in [Unicode Preferences](https://www.unicode.org/reports/tr35/tr35-info.html#unit-preferences).
+    - (no default)
 - `unitDisplay`
   - `short` (default)
   - `narrow`
@@ -483,8 +486,7 @@ The following options and their values are required to be available on the funct
   - ([digit size option](#digit-size-options))
 - `maximumSignificantDigits`
   - ([digit size option](#digit-size-options))
-- `usage`
-    - Well-formed and valid usage identifiers are defined in [Unicode Preferences](https://www.unicode.org/reports/tr35/tr35-info.html#unit-preferences).
+
 If the _operand_ of the _expression_ is an implementation-defined type,
 such as the _resolved value_ of an _expression_ with a `:unit` _annotation_,
 it can include option values.
@@ -499,11 +501,10 @@ with _options_ on the _expression_ taking priority over any option values of the
 > would have the resolved options:
 > `{ unit: 'furlong', minimumFractionDigits: '2', minimumIntegerDigits: '1' }`.
 
-Some implementations support conversion between compatible units.
-Attempting to convert units (by specifying the `usage` option)
-produces a _Bad Option_ error if conversion is unsupported
+Some implementations support conversion to the locale's preferred units via the `usage` option.
+Attempting to convert units produces a _Bad Option_ error if such conversion is unsupported
 or if the specified units are incompatible.
-For example, trying to convert meters to gallons produces a _Bad Option_.
+For example, trying to convert meters to a `volume` unit (such as "gallons") produces a _Bad Option_.
 
 Implementations MUST NOT substitute the unit without performing the associated conversion.
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -704,10 +704,11 @@ The _function_ `:unit` performs selection as described in [Number Selection](#nu
 Implementations MAY support conversion to the locale's preferred units via the `usage` _option_.
 Implementing this _option_ is optional.
 Not all `usage` values are compatible with a given unit.
-Implementations SHOULD emit an _Unsupported Operation_ error if the requestion conversion is not supported.
+Implementations SHOULD emit an _Unsupported Operation_ error if the requested conversion is not supported.
 
-> For example, trying to convert a `length` unit such as meters
-> to a `volume` unit (such as "gallons") could produce an _Unsupported Operation_ error.
+> For example, trying to convert a `length` unit (such as "meters")
+> to a `volume` usage (which might be a unit akin to "liters" or "gallons", depending on the locale)
+> could produce an _Unsupported Operation_ error.
 
 Implementations MUST NOT substitute the unit without performing the associated conversion.
 

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -486,6 +486,22 @@ The following options and their values are required to be available on the funct
   - ([digit size option](#digit-size-options))
 - `maximumSignificantDigits`
   - ([digit size option](#digit-size-options))
+- `roundingPriority`
+  - `auto` (default)
+  - `morePrecision`
+  - `lessPrecision`
+- `roundingIncrement`
+  - 1 (default), 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, and 5000
+- `roundingMode`
+  - `ceil`
+  - `floor`
+  - `expand`
+  - `trunc`
+  - `halfCeil`
+  - `halfFloor`
+  - `halfExpand` (default)
+  - `halfTrunc`
+  - `halfEven`
 
 If the _operand_ of the _expression_ is an implementation-defined type,
 such as the _resolved value_ of an _expression_ with a `:unit` _annotation_,

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -387,7 +387,7 @@ together with the resolved options' values.
 
 ### `:unit` function
 
-The function `:unit` is a selector and formatter for unitized values,
+The _function_ `:unit` is a selector and formatter for unitized values,
 that is, numeric values associated with a unit of measurement.
 This is a specialized form of numeric selection and formatting.
 
@@ -432,11 +432,11 @@ A [Number Operand](#number-operands) without a `unit` _option_ results in a _Bad
 
 #### Options
 
-Some options do not have default values defined in this specification.
-The defaults for these options are implementation-dependent.
-In general, the default values for such options depend on the locale, 
+Some _options_ do not have default values defined in this specification.
+The defaults for these _options_ are implementation-dependent.
+In general, the default values for such _options_ depend on the locale, 
 the unit,
-the value of other options, or all of these.
+the value of other _options_, or all of these.
 
 > [!NOTE]
 > The option `select` does not accept the value `ordinal` because selecting
@@ -449,7 +449,7 @@ The following options and their values are required to be available on the funct
 - `unit`
    - valid [Unit Identifier](https://www.unicode.org/reports/tr35/tr35-general.html#unit-identifiers)
      (no default)
-- `usage`
+- `usage` \[OPTIONAL\]
     - Well-formed and valid usage identifiers are defined in [Unicode Preferences](https://www.unicode.org/reports/tr35/tr35-info.html#unit-preferences).
     - (no default)
 - `unitDisplay`
@@ -501,7 +501,8 @@ with _options_ on the _expression_ taking priority over any option values of the
 > would have the resolved options:
 > `{ unit: 'furlong', minimumFractionDigits: '2', minimumIntegerDigits: '1' }`.
 
-Some implementations support conversion to the locale's preferred units via the `usage` option.
+Some implementations support conversion to the locale's preferred units via the `usage` _option_.
+Implementing this _option_ is optional.
 Attempting to convert units produces a _Bad Option_ error if such conversion is unsupported
 or if the specified units are incompatible.
 For example, trying to convert meters to a `volume` unit (such as "gallons") produces a _Bad Option_.

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -559,7 +559,7 @@ together with the resolved options' values.
 
 The _function_ `:currency` performs selection as described in [Number Selection](#number-selection) below.
 
-### `:unit` function
+### The `:unit` function
 
 The _function_ `:unit` is a selector and formatter for unitized values,
 that is, numeric values associated with a unit of measurement.


### PR DESCRIPTION
This introduces `:unit` as an optional function, per discussion elsewhere.