### PR TITLE
Test schema: allow `src` property to either be a string or array of strings

### DIFF
--- a/test/schemas/v0/tests.schema.json
+++ b/test/schemas/v0/tests.schema.json
@@ -175,8 +175,17 @@
       "type": "string"
     },
     "src": {
-      "description": "The MF2 syntax source.",
-      "type": "string"
+      "oneOf": [
+        {
+          "description": "The MF2 syntax source.",
+          "type": "string"
+        },
+        {
+          "description": "The MF2 syntax source, as an array of strings to be concatenated.",
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      ]
     },
     "bidiIsolation": {
       "description": "The bidi isolation strategy.",


### PR DESCRIPTION
This makes the test schema consistent with the schema in https://github.com/unicode-org/conformance/blob/main/schema/message_fmt2/testgen_schema.json