### PR TITLE
Explicitly allow implementations to support additional option values

### DIFF
--- a/spec/registry.md
+++ b/spec/registry.md
@@ -3,9 +3,8 @@
 This section describes the functions for which each implementation MUST provide
 a _function handler_ to be conformant with this specification.
 
-Implementations MAY implement additional _functions_ or additional _options_.
-In particular, implementations are encouraged to provide feedback on proposed
-_options_ and their values.
+Implementations MAY implement additional _functions_,
+additional _options_, and additional _option_ values.
 
 > [!NOTE]
 > The [Stability Policy](/spec#stability-policy) allows for updates to


### PR DESCRIPTION
We should more explicitly allow implementations to support option values for default functions that are not listed in `registry.md`. This is currently only implicit, as we preface the lists of options with
> The following options and their values are required in the default registry to be available on the function ...

which does not say anything about behaviour with unlisted values.

There's also a tech preview request for feedback here that ought to be dropped.