### PR TITLE
Replace Composition with Resolved Value sections for default functions

### DIFF
--- a/spec/registry.md
+++ b/spec/registry.md
@@ -48,6 +48,13 @@ The function `:string` has no options.
 > Proposals for string transformation options or implementation
 > experience with user requirements is desired during the Tech Preview.
 
+#### Resolved Value
+
+The _resolved value_ of an _expression_ with a `:string` _function_
+contains the string value of the _operand_ of the annotated _expression_,
+together with its resolved locale and directionality.
+None of the _options_ set on the _expression_ are part of the _resolved value_.
+
 #### Selection
 
 When implementing [`MatchSelectorKeys(resolvedSelector, keys)`](/spec/formatting.md#resolve-preferences)
@@ -85,14 +92,6 @@ The `:string` function returns the string value of the _resolved value_ of the _
 > The function `:string` does not perform Unicode Normalization of its formatted output.
 > Users SHOULD encode _messages_ and their parts in Unicode Normalization Form C (NFC)
 > unless there is a very good reason not to.
-
-#### Composition
-
-When an _operand_ or an _option_ value uses a _variable_ annotated,
-directly or indirectly, by a `:string` _function_,
-its _resolved value_ contains the string value of the _operand_ of the annotated _expression_,
-together with its resolved locale and directionality.
-None of the _options_ set on the _expression_ are part of the _resolved value_.
 
 ## Numeric Value Selection and Formatting
 
@@ -235,17 +234,16 @@ MUST be multiplied by 100 for the purposes of formatting.
 > should format in a manner similar to:
 > > The total was 50%.
 
+#### Resolved Value
+
+The _resolved value_ of an _expression_ with a `:number` _function_
+contains an implementation-defined numerical value
+of the _operand_ of the annotated _expression_,
+together with the resolved options' values.
+
 #### Selection
 
 The _function_ `:number` performs selection as described in [Number Selection](#number-selection) below.
-
-#### Composition
-
-When an _operand_ or an _option_ value uses a _variable_ annotated,
-directly or indirectly, by a `:number` _annotation_,
-its _resolved value_ contains an implementation-defined numerical value
-of the _operand_ of the annotated _expression_,
-together with the resolved options' values.
 
 ### The `:integer` function
 
@@ -372,17 +370,16 @@ MUST be multiplied by 100 for the purposes of formatting.
 > should format in a manner similar to:
 > > The total was 50%.
 
+#### Resolved Value
+
+The _resolved value_ of an _expression_ with an `:integer` _function_
+contains the implementation-defined integer value
+of the _operand_ of the annotated _expression_,
+together with the resolved options' values.
+
 #### Selection
 
 The _function_ `:integer` performs selection as described in [Number Selection](#number-selection) below.
-
-#### Composition
-
-When an _operand_ or an _option_ value uses a _variable_ annotated,
-directly or indirectly, by a `:integer` _annotation_,
-its _resolved value_ contains the implementation-defined integer value
-of the _operand_ of the annotated _expression_,
-together with the resolved options' values.
 
 ### Number Operands
 
@@ -707,11 +704,10 @@ are encouraged to track development of these options during Tech Preview:
 - `timeZone` (default is system default time zone or UTC)
   - valid identifier per [BCP175](https://www.rfc-editor.org/rfc/rfc6557)
 
-#### Composition
+#### Resolved Value
 
-When an _operand_ or an _option_ value uses a _variable_ annotated,
-directly or indirectly, by a `:datetime` _annotation_,
-its _resolved value_ contains an implementation-defined date/time value
+The _resolved value_ of an _expression_ with a `:datetime` _function_
+contains an implementation-defined date/time value
 of the _operand_ of the annotated _expression_,
 together with the resolved options values.
 
@@ -743,13 +739,14 @@ it can include other option values.
 Any _operand_ option values matching the `:datetime` _style options_ or _field options_ are ignored,
 as is any `style` option.
 
-#### Composition
+#### Resolved Value
 
-When an _operand_ or an _option_ value uses a _variable_ annotated,
-directly or indirectly, by a `:date` _annotation_,
-its _resolved value_ is implementation-defined.
+The _resolved value_ of an _expression_ with a `:date` _function_
+is implementation-defined.
+
 An implementation MAY emit a _Bad Operand_ or _Bad Option_ error (as appropriate)
-when this happens.
+when a _variable_ annotated directly or indirectly by a `:date` _annotation_
+is used as an _operand_ or an _option_ value.
 
 ### The `:time` function
 
@@ -779,13 +776,14 @@ it can include other option values.
 Any _operand_ option values matching the `:datetime` _style options_ or _field options_ are ignored,
 as is any `style` option.
 
-#### Composition
+#### Resolved Value
 
-When an _operand_ or an _option_ value uses a _variable_ annotated,
-directly or indirectly, by a `:time` _annotation_,
-its _resolved value_ is implementation-defined.
+The _resolved value_ of an _expression_ with a `:time` _function_
+is implementation-defined.
+
 An implementation MAY emit a _Bad Operand_ or _Bad Option_ error (as appropriate)
-when this happens.
+when a _variable_ annotated directly or indirectly by a `:time` _annotation_
+is used as an _operand_ or an _option_ value.
 
 ### Date and Time Operands
 


### PR DESCRIPTION
As we've now defined _resolved value_ as a term, and e.g. formatting refers to "resolving" placeholders, we should replace/expand the "Composition" sections of default function descriptions with "Resolved Value" sections.

This should help provide a clearer basis for the text around `:number offset` proposed in #926, which is currently proposing two alternative _resolved value_ definitions for `:number`.