### PR TITLE
Limit spec-defined option values

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -110,7 +110,7 @@ Updates to this specification will only reserve, define, or require
 function identifiers and function option identifiers
 which satisfy either of the following two requirements:
 - Includes no namespace,
-  and has a name consisting of characters in the ranges a-z, A-Z, and 0-9.
+  and has a name consisting of characters in the ranges a-z, A-Z, and 0-9, and the characters '.', '-', and '_'.
 - Uses a namespace consisting of a single character in the range a-z.
 
 All other identifiers in these categories are reserved for the use of implementations or users.

--- a/spec/README.md
+++ b/spec/README.md
@@ -110,7 +110,8 @@ Updates to this specification will only reserve, define, or require
 function identifiers and function option identifiers
 which satisfy either of the following two requirements:
 - Includes no namespace,
-  and has a name consisting of characters in the ranges a-z, A-Z, and 0-9, and the characters '.', '-', and '_'.
+  and has a name consisting of characters in the ranges a-z, A-Z, and 0-9,
+  and the characters U+002E FULL STOP `.`, U+002D HYPHEN-MINUS `-`, and U+005F LOW LINE `_`.
 - Uses a namespace consisting of a single character in the ranges a-z and A-Z.
 
 All other identifiers in these categories are reserved for the use of implementations or users.

--- a/spec/README.md
+++ b/spec/README.md
@@ -111,18 +111,12 @@ function identifiers and function option identifiers
 which satisfy either of the following two requirements:
 - Includes no namespace,
   and has a name consisting of characters in the ranges a-z, A-Z, and 0-9.
-- Uses the `u:` namespace.
+- Uses a namespace consisting of a single character in the range a-z.
 
 All other identifiers in these categories are reserved for the use of implementations or users.
 
-Updates to this specification will only reserve, define, or require
-function option values
-consisting of characters in the ranges a-z, A-Z, and 0-9,
-and the characters U+002D HYPHEN-MINUS `-` and U+002E FULL STOP `.`.
-All other option values are reserved for the use of implementations or users.
-
 > [!NOTE]
-> Users defining custom identifiers and values SHOULD include at least one character outside these ranges
+> Users defining custom identifiers SHOULD include at least one character outside these ranges
 > to ensure that they will be compatible with future versions of this specification.
 > They SHOULD also use the namespace feature to avoid collisions with other implementations.
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -84,10 +84,10 @@ Updates to this specification will not make any valid _message_ invalid.
 
 Updates to this specification will not remove any syntax provided in this version.
 
-Updates to this specification MUST NOT specify an error for any message
+Updates to this specification will not specify an error for any message
 that previously did not specify an error.
 
-Updates to this specification MUST NOT specify the use of a fallback value for any message
+Updates to this specification will not specify the use of a fallback value for any message
 that previously did not specify a fallback value.
 
 Updates to this specification will not change the syntactical meaning
@@ -107,12 +107,22 @@ defined in the default registry.
 > (such as due to the release of new CLDR versions).
 
 Updates to this specification will only reserve, define, or require
-function names or function option names
-consisting of characters in the ranges a-z, A-Z, and 0-9.
-All other names in these categories are reserved for the use of implementations or users.
+function identifiers and function option identifiers
+which satisfy either of the following two requirements:
+- Includes no namespace,
+  and has a name consisting of characters in the ranges a-z, A-Z, and 0-9.
+- Uses the `u:` namespace.
+
+All other identifiers in these categories are reserved for the use of implementations or users.
+
+Updates to this specification will only reserve, define, or require
+function option values
+consisting of characters in the ranges a-z, A-Z, and 0-9,
+and the characters U+002D HYPHEN-MINUS `-` and U+002E FULL STOP `.`.
+All other option values are reserved for the use of implementations or users.
 
 > [!NOTE]
-> Users defining custom names SHOULD include at least one character outside these ranges
+> Users defining custom identifiers and values SHOULD include at least one character outside these ranges
 > to ensure that they will be compatible with future versions of this specification.
 > They SHOULD also use the namespace feature to avoid collisions with other implementations.
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -111,7 +111,7 @@ function identifiers and function option identifiers
 which satisfy either of the following two requirements:
 - Includes no namespace,
   and has a name consisting of characters in the ranges a-z, A-Z, and 0-9, and the characters '.', '-', and '_'.
-- Uses a namespace consisting of a single character in the range a-z.
+- Uses a namespace consisting of a single character in the ranges a-z and A-Z.
 
 All other identifiers in these categories are reserved for the use of implementations or users.
 


### PR DESCRIPTION
Fixes #928 

Explicitly reserves the `u:` namespace, which was previously only mentioned in the syntax.

Limits spec option values to `a-zA-Z0-9`, `-` and `.`. The `.` is not currently used, but is needed to allow for e.g. `2.5` as a future reserved value.

Replaces two "MUST NOT" restrictions elsewhere with "will not" to match the style of the rest of the text.