### PR TITLE
Remove tech preview note from `:string`

### DIFF
--- a/spec/registry.md
+++ b/spec/registry.md
@@ -81,6 +81,13 @@ All other values produce a _Bad Operand_ error.
 
 The function `:string` has no _options_.
 
+> [!NOTE]
+> While `:string` has no built- in _options_,
+> _options_ in the `u:` _namespace_ can be used. 
+> For example: 
+>```
+> {$s :string u:dir=ltr u:locale=fr-CA}
+>```
 #### Resolved Value
 
 The _resolved value_ of an _expression_ with a `:string` _function_

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -79,11 +79,7 @@ All other values produce a _Bad Operand_ error.
 
 #### Options
 
-The function `:string` has no options.
-
-> [!NOTE]
-> Proposals for string transformation options or implementation
-> experience with user requirements is desired during the Tech Preview.
+The function `:string` has no _options_.
 
 #### Resolved Value
 


### PR DESCRIPTION
Remove a note that is no longer relevant