### PR TITLE
Remove misleading terms/clauses for `:currency` options and operands

### DIFF
--- a/spec/registry.md
+++ b/spec/registry.md
@@ -393,9 +393,8 @@ or it can be a [Number Operand](#number-operands), as long as the option
 The option `currency` MUST NOT be used to override the currency of an implementation-defined type.
 Using this option in such a case results in a _Bad Option_ error.
 
-The value of the _operand_'s `currency` MUST be either a string containing a
-well-formed [Unicode Currency Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCurrencyIdentifier)
-or an implementation-defined currency type.
+The value of the _operand_'s `currency` is a
+well-formed [Unicode Currency Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCurrencyIdentifier).
 Although currency codes are expected to be uppercase,
 implementations SHOULD treat them in a case-insensitive manner.
 A well-formed Unicode Currency Identifier matches the production `currency_code` in this ABNF:
@@ -608,7 +607,6 @@ of a digit size option option consistent with that implementation's practical li
 
 In most cases, the value of a digit size option will be a string that
 encodes the value as a non-negative integer.
-Implementations MAY also accept implementation-defined types as the value.
 When provided as a string, the representation of a digit size option matches the following ABNF:
 >```abnf
 > digit-size-option = "0" / (("1"-"9") [DIGIT])


### PR DESCRIPTION
We already state near the top of the document that:

>Implementations MAY _accept_ additional _option_ values for _options_ defined here.
However, such values might become defined with a different meaning in the future,
including with a different, incompatible name
or using an incompatible value space.
Supporting implementation-specific _option_ values for **standard** or **optional** functions is NOT RECOMMENDED.

So there is no need to have a separate statement for particular options saying that X must be either Y or an implementation defined value. Moreover, by calling it out on *one* option on a function, it makes the readers mistrust whether is actually the case for _other_ options on the function.

Eg, "berries can be added to any desserts" at the top of the menu, then later 
"desserts are pancakes (optionally with berries), or waffles". 

It makes people question whether you can have waffles with berries even though you say at the top you can.