### PR TITLE
Drop exp value for :number tests with bad option values

### DIFF
--- a/test/tests/functions/number.json
+++ b/test/tests/functions/number.json
@@ -132,18 +132,8 @@
     },
     {
       "src": ".local $foo = {$bar :number minimumFractionDigits=foo} {{bar {$foo}}}",
-      "params": [
-        {
-          "name": "bar",
-          "value": 4.2
-        }
-      ],
-      "exp": "bar {$bar}",
-      "expErrors": [
-        {
-          "type": "bad-option"
-        }
-      ]
+      "params": [{ "name": "bar", "value": 4.2 }],
+      "expErrors": [{ "type": "bad-option" }]
     },
     {
       "src": ".local $foo = {$bar :number} {{bar {$foo}}}",
@@ -182,18 +172,8 @@
     },
     {
       "src": ".input {$foo :number minimumFractionDigits=foo} {{bar {$foo}}}",
-      "params": [
-        {
-          "name": "foo",
-          "value": 4.2
-        }
-      ],
-      "exp": "bar {$foo}",
-      "expErrors": [
-        {
-          "type": "bad-option"
-        }
-      ]
+      "params": [{ "name": "foo", "value": 4.2 }],
+      "expErrors": [{ "type": "bad-option" }]
     },
     {
       "src": ".input {$foo :number} {{bar {$foo}}}",


### PR DESCRIPTION
When an option value does not match the required option values, function behaviour is left as implementation-defined. Therefore, we should not specify an expected formatted result for them.