### PR TITLE
Always apply isolation when `u:dir` is set

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -938,9 +938,13 @@ The _Default Bidi Strategy_ is defined as follows:
    1. Let `fmt` be the formatted string representation of the _resolved value_ of `exp`.
    1. Let `dir` be the directionality of `fmt`,
       one of « `'LTR'`, `'RTL'`, `'unknown'` », with the same meanings as for `msgdir`.
+   1. Let the boolean value `isolate` be
+      True if the `u:dir` _option_ is set on the _resolved value_ of `exp`,
+      or False if it is not set or the implementation does not support the option.
    1. If `dir` is `'LTR'`:
-      1. If `msgdir` is `'LTR'`
-         in the formatted output, let `fmt` be itself
+      1. If `msgdir` is `'LTR'` in the formatted output
+         and `isolate` is False,
+         let `fmt` be itself
       1. Else, in the formatted output,
          prefix `fmt` with U+2066 LEFT-TO-RIGHT ISOLATE
          and postfix it with U+2069 POP DIRECTIONAL ISOLATE.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -939,8 +939,8 @@ The _Default Bidi Strategy_ is defined as follows:
    1. Let `dir` be the directionality of `fmt`,
       one of « `'LTR'`, `'RTL'`, `'unknown'` », with the same meanings as for `msgdir`.
    1. Let the boolean value `isolate` be
-      True if the `u:dir` _option_ is set on the _resolved value_ of `exp`,
-      or False if it is not set or the implementation does not support the option.
+      True if the `u:dir` _option_ of the _resolved value_ of `exp` has a value other than `'inherit'`,
+      or False otherwise.
    1. If `dir` is `'LTR'`:
       1. If `msgdir` is `'LTR'` in the formatted output
          and `isolate` is False,

--- a/spec/u-namespace.md
+++ b/spec/u-namespace.md
@@ -84,8 +84,9 @@ or a _variable_ whose _resolved value_ is one of these _literals_:
 - `ltr`: left-to-right directionality
 - `rtl`: right-to-left directionality
 - `auto`: directionality determined from _expression_ contents
-- `inherit` (default): directionality inherited from the _message_,
-  without isolation of the _expression_ value
+- `inherit` (default): directionality inherited from the _message_
+   or from the _resolved value_ of the _operand_ without
+   requiring isolation of the _expression_ value.
 
 For other values, a _Bad Option_ error is emitted
 and the value of the `u:dir` option is ignored.

--- a/spec/u-namespace.md
+++ b/spec/u-namespace.md
@@ -68,7 +68,8 @@ not valid, or some other reason.
 ### `u:dir`
 
 Replaces the base directionality defined in
-the _function context_ for this _expression_.
+the _function context_ for this _expression_
+and applies bidirectional isolation to it.
 
 If this option is set on _markup_, a _Bad Option_ error is emitted
 and the value of the `u:dir` option is ignored.
@@ -76,6 +77,7 @@ and the value of the `u:dir` option is ignored.
 During processing, the `u:dir` option
 MUST be removed from the resolved mapping of _options_
 before calling the _function handler_.
+Its value is retained in the _resolved value_ of the _expression_.
 
 The value of the `u:dir` _option_ MUST be one of the following _literal_ values
 or a _variable_ whose _resolved value_ is one of these _literals_:

--- a/spec/u-namespace.md
+++ b/spec/u-namespace.md
@@ -84,6 +84,8 @@ or a _variable_ whose _resolved value_ is one of these _literals_:
 - `ltr`: left-to-right directionality
 - `rtl`: right-to-left directionality
 - `auto`: directionality determined from _expression_ contents
+- `inherit` (default): directionality inherited from the _message_,
+  without isolation of the _expression_ value
 
 For other values, a _Bad Option_ error is emitted
 and the value of the `u:dir` option is ignored.

--- a/test/tests/u-options.json
+++ b/test/tests/u-options.json
@@ -56,19 +56,22 @@
     },
     {
       "src": "hello {world :string u:dir=ltr u:id=foo}",
-      "exp": "hello world",
+      "exp": "hello \u2066world\u2069",
       "expParts": [
         {
           "type": "literal",
           "value": "hello "
         },
+        { "type": "bidiIsolation", "value": "\u2066" },
         {
           "type": "string",
           "source": "|world|",
           "dir": "ltr",
           "id": "foo",
           "value": "world"
-        }
+        },
+        { "type": "bidiIsolation", "value": "\u2069" }
+
       ]
     },
     {
@@ -97,6 +100,25 @@
           "type": "string",
           "source": "|world|",
           "locale": "en-US",
+          "value": "world"
+        },
+        { "type": "bidiIsolation", "value": "\u2069" }
+      ]
+    },
+    {
+      "src": ".local $world = {world :string u:dir=ltr u:id=foo} {{hello {$world}}}",
+      "exp": "hello \u2066world\u2069",
+      "expParts": [
+        {
+          "type": "literal",
+          "value": "hello "
+        },
+        { "type": "bidiIsolation", "value": "\u2066" },
+        {
+          "type": "string",
+          "source": "|world|",
+          "dir": "ltr",
+          "id": "foo",
           "value": "world"
         },
         { "type": "bidiIsolation", "value": "\u2069" }


### PR DESCRIPTION
See #916 for some of the preceding discussion.

In addition to changing the directionality of a placeholder, we should treat an explicitly set `u:dir` option as a request to isolate the placeholder, even if the direction matches the message's direction.

This requires a small change to our default bidi strategy.

The inheritance of the option is not specified when it's set on a value that's used as a function operand, so e.g. a message like
```
.local $world = {world :string u:dir=ltr}
{{hello {$world :string}}}
```
might or might not have the placeholder isolated (depending on the implementation), while it would always be isolated in messages like
```
hello {world :string u:dir=ltr}
```
and
```
.local $world = {world :string u:dir=ltr}
{{hello {$world}}}
```
