### PR TITLE
Rename `:currency` option `currencySign` as `sign`

### DIFF
--- a/spec/registry.md
+++ b/spec/registry.md
@@ -564,7 +564,7 @@ The following options and their values are required to be available on the funct
 - `numberingSystem`
    - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
      (default is locale-specific)
-- `currencySign`
+- `sign`
   - `accounting`
   - `standard` (default)
 - `currencyDisplay`
@@ -617,10 +617,10 @@ with _options_ on the _expression_ taking priority over any option values of the
 > For example, the _placeholder_ in this _message_:
 > ```
 > .input {$n :currency currency=USD trailingZeroDisplay=stripIfInteger}
-> {{{$n :currency currencySign=accounting}}}
+> {{{$n :currency sign=accounting}}}
 > ```
 > would be formatted with the resolved options
-> `{ currencySign: 'accounting', trailingZeroDisplay: 'stripIfInteger', currency: 'USD' }`.
+> `{ sign: 'accounting', trailingZeroDisplay: 'stripIfInteger', currency: 'USD' }`.
 
 #### Resolved Value
 


### PR DESCRIPTION
The option name is inherited from ECMA-402, but as we've already opted to go with `:currency` instead of `:number style=currency`, we don't need the prefix for `currencySign`, but can use just `sign` for it.

The same does not quite apply to `currencyDisplay`, as we also have `compactDisplay`, and that option is specifically about the display of the "currency" part of the formatted value.