### PR TITLE
Add calendar and numberingSystem options to date/time

### DIFF
--- a/spec/registry.md
+++ b/spec/registry.md
@@ -1112,7 +1112,6 @@ the functions `:datetime` and `:time`:
 
 The following _options_ and their values are RECOMMENDED to be available on
 the functions `:datetime`, `:date`, and `:time`.
-The maturity level for each is **Proposed**.
 
 - `calendar`
   - valid [Unicode Calendar Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCalendarIdentifier)

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -1095,3 +1095,17 @@ For more information, see [Working with Timezones](https://w3c.github.io/timezon
 > The form of these serializations is known and is a de facto standard.
 > Support for these extensions is expected to be required in the post-tech preview.
 > See: https://datatracker.ietf.org/doc/draft-ietf-sedate-datetime-extended/
+
+**_<dfn>Date/time override options</dfn>_** are _options_ that allow an _expression_ to
+override values set by the current locale,
+or provided by the _formatting context_ (such as the default time zone),
+or embedded in an implementation-defined date/time _operand_ value.
+
+The following **RECOMMENDED** options and their values SHOULD be available on
+the functions `:datetime`, `:date`, and `:time`.
+The maturity level for each is **Proposed**.
+
+- `calendar`
+  - valid [Unicode Calendar Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCalendarIdentifier)
+- `numberingSystem`
+  - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)


### PR DESCRIPTION
This is as per the discussion in the WG, separating them out from https://github.com/unicode-org/message-format-wg/pull/911

Two changes from that:
1. Used RECOMMENDED instead of Optional, as per https://github.com/unicode-org/message-format-wg/pull/946
2. I noticed also there that RECOMMENDED needs a maturity status, so added a placeholder for that, with **Proposed**. Since that is only in exploration/maintaining-registry.md, I presume it would be removed for release.