### PR TITLE
Create option `timezone` as Proposed REQUIRED option

### DIFF
--- a/spec/registry.md
+++ b/spec/registry.md
@@ -1115,18 +1115,11 @@ This option currently has a Maturity Level of **Proposed**.
 
 - `timeZone`
   - A valid time zone identifier
-    (see [BCP175](https://www.rfc-editor.org/bpc/bpc175))
+    (see [TZDB](https://www.iana.org/time-zones)
+    and [LDML](https://www.unicode.org/reports/tr35/tr35-dates.html#Time_Zone_Names)
+    for information on identifiers)
   - `local`
   - `UTC`
-  
-A time zone identifier is well-formed if it matches `tzId` in the following ABNF:
-```abnf
-tzId   = tzPath / tzEtc
-tzPath = tzPart 1*("/" tzPart)
-tzPart = tzWord *("_" tzWord)
-tzWord = (%x41-5A) *(%x61-7A) ; Uppercase ASCII letter followed by lowercase letters
-tzEtc  = "Etc/GMT" ("+" / "-") 1*2DIGIT
-```
   
 > [!NOTE]
 > The value `local` permits a _message_ to convert a date/time value

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -1114,9 +1114,19 @@ the functions `:datetime` and `:time`:
   - `true`
   - `false`
 
-The following _option_ and its values will be REQUIRED to be available on
+The following _options_ and their values are RECOMMENDED to be available on
 the functions `:datetime`, `:date`, and `:time`.
-This option currently has a Maturity Level of **Proposed**.
+
+- `calendar`
+  - valid [Unicode Calendar Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCalendarIdentifier)
+- `numberingSystem`
+  - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+
+The following _option_ and its values are **Proposed** for
+inclusion in the next release of this specification but have not yet been
+finalized.
+If accepted, implementations could be REQUIRED to make this _option_
+available in the functions `:datetime`, `:date`, and `:time`.
 
 - `timeZone`
   - A valid time zone identifier
@@ -1131,13 +1141,3 @@ This option currently has a Maturity Level of **Proposed**.
 > into a [floating](https://www.w3.org/TR/timezone/#floating) time value
 > (sometimes called a _plain_ or _local_ time value) by removing
 > the association with a specific time zone.
-
-The following _options_ and their values are RECOMMENDED to be available on
-the functions `:datetime`, `:date`, and `:time`.
-
-- `calendar`
-  - valid [Unicode Calendar Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCalendarIdentifier)
-- `numberingSystem`
-  - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
-
-

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -1109,6 +1109,31 @@ the functions `:datetime` and `:time`:
   - `true`
   - `false`
 
+The following _option_ and its values will be REQUIRED to be available on
+the functions `:datetime`, `:date`, and `:time`.
+This option currently has a Maturity Level of **Proposed**.
+
+- `timezone`
+  - A valid time zone identifier
+    (see [BCP175](https://www.rfc-editor.org/bpc/bpc175))
+  - `local`
+  - `UTC`
+  
+A time zone identifier is well-formed if it matches `tzId` in the following ABNF:
+```abnf
+tzId   = tzPath / tzEtc
+tzPath = tzPart 1*("/" tzPart)
+tzPart = tzWord *("_" tzWord)
+tzWord = (%x41-5A) *(%x61-7A) ; Uppercase ASCII letter followed by lowercase letters
+tzEtc  = ("Etc/" ("UTC" / "GMT" (("+" / "-") 1*2DIGIT))
+```
+  
+> [!NOTE]
+> The value `local` permits a _message_ to convert a date/time value
+> into a [floating](https://www.w3.org/TR/timezone/#floating) time value
+> (sometimes called a _plain_ or _local_ time value) by removing
+> the association with a specific time zone.
+
 > [!NOTE]
 > These options do not have default values because they are only to be used
 > as overrides for locale-and-value dependent implementation-defined defaults.

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -1125,7 +1125,7 @@ tzId   = tzPath / tzEtc
 tzPath = tzPart 1*("/" tzPart)
 tzPart = tzWord *("_" tzWord)
 tzWord = (%x41-5A) *(%x61-7A) ; Uppercase ASCII letter followed by lowercase letters
-tzEtc  = ("Etc/" ("UTC" / "GMT" (("+" / "-") 1*2DIGIT))
+tzEtc  = "Etc/GMT" ("+" / "-") 1*2DIGIT
 ```
   
 > [!NOTE]

--- a/spec/registry.md
+++ b/spec/registry.md
@@ -1113,7 +1113,7 @@ The following _option_ and its values will be REQUIRED to be available on
 the functions `:datetime`, `:date`, and `:time`.
 This option currently has a Maturity Level of **Proposed**.
 
-- `timezone`
+- `timeZone`
   - A valid time zone identifier
     (see [BCP175](https://www.rfc-editor.org/bpc/bpc175))
   - `local`


### PR DESCRIPTION
This still has the ABNF for time zone ID, which should disappear as soon as I can replace it with something formal.

It's fair game to discuss whether this should be RECOMMENDED instead.