### PR TITLE
Remove obsolete note about `calendar`/`numberingSystem`/`timeZone` op…

### DIFF
--- a/spec/registry.md
+++ b/spec/registry.md
@@ -949,20 +949,6 @@ The function `:datetime` has the following options:
   - `shortGeneric`
   - `longGeneric`
 
-> [!NOTE]
-> The following options do not have default values because they are only to be used
-> as overrides for locale-and-value dependent implementation-defined defaults.
-
-The following date/time options are **not** part of the default registry.
-Implementations SHOULD avoid creating options that conflict with these, but
-are encouraged to track development of these options during Tech Preview:
-- `calendar` (default is locale-specific)
-  - valid [Unicode Calendar Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCalendarIdentifier)
-- `numberingSystem` (default is locale-specific)
-   - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
-- `timeZone` (default is system default time zone or UTC)
-  - valid identifier per [BCP175](https://www.rfc-editor.org/rfc/rfc6557)
-
 #### Resolved Value
 
 The _resolved value_ of an _expression_ with a `:datetime` _function_


### PR DESCRIPTION
…tions