### PR TITLE
Update specification and readme for "Final Candidate"

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -1,21 +1,7 @@
 # MessageFormat 2.0 Specification
 
-## Table of Contents
-
-1. [Introduction](intro.md)
-   1. [Conformance](intro.md#conformance)
-   1. [Terminology and Conventions](intro.md#terminology-and-conventions)
-   1. [Stability Policy](intro.md#stability-policy)
-1. [Syntax](syntax.md)
-   1. [`message.abnf`](message.abnf)
-1. [Formatting](formatting.md)
-1. [Errors](errors.md)
-1. [Default Function Registry](registry.md)
-1. [`u:` Namespace](u-namespace.md)
-1. [Interchange data model](data-model/README.md)
-1. [Appendices](appendices.md)
-   1. [Security Considerations](appendices.md#security-considerations)
-   1. [Acknowledgements](appendices.md#acknowledgements)
+> [!IMPORTANT]
+> This page is not a part of the specification and is not normative.
 
 ## What is MessageFormat 2?
 
@@ -34,14 +20,15 @@ thus enabling gradual adoption by users of older formatting systems.
 The goal is to allow developers and translators to create natural-sounding, grammatically-correct,
 user interfaces that can appear in any language and support the needs of diverse cultures.
 
-## MessageFormat 2 Specification and Syntax
+## Status of the documents in this repo
 
-The current specification starts [here](#table-of-contents) and may have changed since the publication
-of the Tech Preview version.
-The Tech Preview specification is [here](https://www.unicode.org/reports/tr35/tr35-73/tr35-messageFormat.html)
+The editor's copy of the specification is found in this directory of this repo and starts [here](intro.md).
+The editor's copy may have changed since the publication of the most recent LDML version.
 
-The current draft syntax for defining messages can be found in [spec/syntax.md](./syntax.md).
-The syntax is formally described in [ABNF](./message.abnf).
+The Final Candidate specification is in [LDML 46.1](https://www.unicode.org/reports/tr35/tr35-73/tr35-messageFormat.html)
+which is identical to the materials in the LDML 46.1 release in this repo.
+
+## About
 
 Messages can be simple strings:
 

--- a/spec/appendices.md
+++ b/spec/appendices.md
@@ -1,4 +1,4 @@
-# DRAFT Appendices
+# Appendices
 
 ## Security Considerations
 

--- a/spec/data-model/README.md
+++ b/spec/data-model/README.md
@@ -1,4 +1,4 @@
-# DRAFT MessageFormat 2.0 Data Model
+# MessageFormat 2.0 Data Model
 
 This section defines a data model representation of MessageFormat 2 _messages_.
 

--- a/spec/errors.md
+++ b/spec/errors.md
@@ -1,4 +1,4 @@
-# MessageFormat 2.0 Errors
+# Errors
 
 Errors can occur during the processing of a _message_.
 Some errors can be detected statically, 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -1,4 +1,4 @@
-# DRAFT MessageFormat 2.0 Formatting
+# MessageFormat 2.0 Formatting
 
 ## Introduction
 
@@ -534,7 +534,7 @@ according to their _key_ values and selecting the first one.
 > > *    {{Only used by fractions in Polish.}}
 > > ```
 >
-> In the Tech Preview, feedback from users and implementers is desired about
+> During the Final Candidate review period, feedback from users and implementers is desired about
 > whether to relax the requirement that such a "fallback _variant_" appear in
 > every message, versus the potential for a _message_ to fail at runtime
 > because no matching _variant_ is available.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -1,4 +1,4 @@
-# Formatting Messages
+# Formatting
 
 ## Introduction
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -1,4 +1,4 @@
-# MessageFormat 2.0 Formatting
+# Formatting Messages
 
 ## Introduction
 

--- a/spec/intro.md
+++ b/spec/intro.md
@@ -1,5 +1,22 @@
 # MessageFormat 2.0 Specification
 
+## Table of Contents
+
+1. [Introduction](intro.md)
+   1. [Conformance](intro.md#conformance)
+   1. [Terminology and Conventions](intro.md#terminology-and-conventions)
+   1. [Stability Policy](intro.md#stability-policy)
+1. [Syntax](syntax.md)
+   1. [`message.abnf`](message.abnf)
+1. [Formatting](formatting.md)
+1. [Errors](errors.md)
+1. [Default Function Registry](registry.md)
+1. [`u:` Namespace](u-namespace.md)
+1. [Interchange data model](data-model/README.md)
+1. [Appendices](appendices.md)
+   1. [Security Considerations](appendices.md#security-considerations)
+   1. [Acknowledgements](appendices.md#acknowledgements)
+
 ## Introduction
 
 One of the challenges in adapting software to work for

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -1,4 +1,4 @@
-# MessageFormat 2.0 Syntax
+# Syntax
 
 ### Introduction
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -1,8 +1,4 @@
-# DRAFT MessageFormat 2.0 Syntax
-
-## Table of Contents
-
-\[TBD\]
+# MessageFormat 2.0 Syntax
 
 ### Introduction
 


### PR DESCRIPTION
This PR updates the specification for conversion to the LDML 46.1 release (and future maintenance).

The titles of the various documents have been updated to match the TOC (mostly by removing "MessageFormat 2.0" from every page and by removing "DRAFT". (An exception to removing MF2 from the title is the data-model, where it's in a sub-directory and could be considered the formal title of the thing??)

One mention of Tech Preview was replaced with Final Candidate.

The TOC was moved to the intro. The readme was made non-normative and excluded from the specification.