### PR TITLE
Clarification to default bidi strategy

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -941,7 +941,7 @@ The _Default Bidi Strategy_ is defined as follows:
       1. Append `fmt` to `out`.
    1. Else:
       1. Let `fmt` be the formatted string representation of the _resolved value_ of `part`.
-      1. Let `dir` be the directionality of `fmt`,
+      1. Let `dir` be `DIR(part)`,
          one of « `'LTR'`, `'RTL'`, `'unknown'` », with the same meanings as for `msgdir`.
          > [!NOTE]
          > _Resolved values_ need to track two different pieces of metadata about directionality:
@@ -972,5 +972,21 @@ The _Default Bidi Strategy_ is defined as follows:
          1. Append `fmt` to `out`.
          1. Append U+2069 POP DIRECTIONAL ISOLATE to `out`.
 1. Emit `out` as the formatted output of the message.
+
+The auxiliary function `DIR`, which maps an _expression_ to one of
+« `'LTR'`, `'RTL'`, `'unknown'` », is expected to be defined using the
+_resolved value_ of the _expression_. An implementation can use
+a representation of _resolved values_ that tracks two different
+pieces of metadata about directionality: the `isolate` flag used in step 2(iii),
+and the directionality itself. Each _function handler_ can have its own means
+for determining the directionality annotation on the _resolved value_ it returns.
+Alternately, an implementation could simply compute `DIR(exp)` based on the
+locale.
+
+> [!NOTE]
+> `DIR(exp)` SHOULD NOT be determined by introspecting
+> the character sequence in the formatted string representation
+> of the resolved value of `exp`.
+
 
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -153,7 +153,7 @@ and different implementations MAY choose to perform different levels of resoluti
 >   getValue(): unknown
 >   resolvedOptions(): { [key: string]: MessageValue }
 >   selectKeys(keys: string[]): string[]
->   directionality() : Dir // where Dir is an enum type, one of « `'LTR'`, `'RTL'`, `'unknown'` »
+>   directionality(): 'LTR' | 'RTL' | 'unknown'
 >   isolate(): boolean
 > }
 > ```

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -131,6 +131,13 @@ identifies not only the name of the external input value,
 but also the _variable_ to which the _resolved value_ of the _variable-expression_ is bound.
 
 In a _pattern_, the _resolved value_ of an _expression_ or _markup_ is used in its _formatting_.
+To support the _Default Bidi Strategy_,
+the _resolved value_ of each _expression_ _placeholder_
+SHOULD include information about the directionality
+of its formatted string representation,
+as well as a flag to indicate whether
+its formatted representation requires isolation
+from the surrounding text.
 
 The form that _resolved values_ take is implementation-dependent,
 and different implementations MAY choose to perform different levels of resolution.
@@ -965,18 +972,12 @@ The _Default Bidi Strategy_ is defined as follows:
 1. Emit `out` as the formatted output of the message.
 
 > [!NOTE]
-> A _resolved value_ is derived from an _expression_
-> together with a _formatting context_.)
-> An implementation can use
-> a representation of _resolved values_ that tracks
-> everything needed to determine the directionality
+> As mentioned in the "Resolved Values" section,
+> the representation of a _resolved value_
+> can track everything needed
+> to determine the directionality
 > of the formatted string representation
 > of a _resolved value_.
-> This can be accomplished by incorporating
-> the `isolate` flag used in step 2(iii),
-> as well as the separate directionality annotation
-> (one of « `'LTR'`, `'RTL'`, `'unknown'` »),
-> into the representation of _resolved values_.
 > Each _function handler_ can have its own means
 > for determining the directionality annotation
 > on the _resolved value_ it returns.
@@ -984,7 +985,7 @@ The _Default Bidi Strategy_ is defined as follows:
 > determine directionality
 > based on the locale.
 
-> [!NOTE]
+> [!IMPORTANT]
 > Directionality SHOULD NOT be determined by introspecting
 > the character sequence in the formatted string representation
 > of `resval`.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -940,19 +940,10 @@ The _Default Bidi Strategy_ is defined as follows:
          Note that this is normally the empty string.
       1. Append `fmt` to `out`.
    1. Else:
-      1. Let `fmt` be the formatted string representation of the _resolved value_ of `part`.
-      1. Let `dir` be `DIR(part)`,
+      1. Let `resval` be the _resolved value_ of `part`.
+      1. Let `fmt` be the formatted string representation of `resval`.
+      1. Let `dir` be `DIR(resval)`,
          one of « `'LTR'`, `'RTL'`, `'unknown'` », with the same meanings as for `msgdir`.
-         > [!NOTE]
-         > _Resolved values_ need to track two different pieces of metadata about directionality:
-         > the "isolate" flag (see the next step for how that is used), which determines
-         > whether the formatted result needs to be isolated; and the directionality itself.
-         > Each _function handler_ can have its own means for determining the directionality
-         > of the _resolved value_ it returns.
-         > Alternately, an implementation could elide this tracking and instead determine
-         > the directionality from the locale.
-         > The directionality SHOULD NOT be determined by introspecting
-         > the character sequence in `fmt`.
       1. Let the boolean value `isolate` be
          True if the `u:dir` _option_ of the _resolved value_ of `part` has a value other than `'inherit'`,
           or False otherwise.
@@ -973,20 +964,23 @@ The _Default Bidi Strategy_ is defined as follows:
          1. Append U+2069 POP DIRECTIONAL ISOLATE to `out`.
 1. Emit `out` as the formatted output of the message.
 
-The auxiliary function `DIR`, which maps an _expression_ to one of
-« `'LTR'`, `'RTL'`, `'unknown'` », is expected to be defined using the
-_resolved value_ of the _expression_. An implementation can use
+The auxiliary function `DIR` maps a _resolved value_to one of
+« `'LTR'`, `'RTL'`, `'unknown'` ». (A _resolved value_ in turn
+is derived from an _expression_ together with a _formatting context_.)
+An implementation can use
 a representation of _resolved values_ that tracks two different
-pieces of metadata about directionality: the `isolate` flag used in step 2(iii),
-and the directionality itself. Each _function handler_ can have its own means
+pieces of metadata about directionality:
+the `isolate` flag used in step 2(iii),
+and the directionality itself.
+Each _function handler_ can have its own means
 for determining the directionality annotation on the _resolved value_ it returns.
-Alternately, an implementation could simply compute `DIR(exp)` based on the
-locale.
+Alternately, an implementation could simply compute `DIR(part)`
+based on the locale.
 
 > [!NOTE]
-> `DIR(exp)` SHOULD NOT be determined by introspecting
+> `DIR(part)` SHOULD NOT be determined by introspecting
 > the character sequence in the formatted string representation
-> of the resolved value of `exp`.
+> of the resolved value of `part`.
 
 
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -153,6 +153,8 @@ and different implementations MAY choose to perform different levels of resoluti
 >   getValue(): unknown
 >   resolvedOptions(): { [key: string]: MessageValue }
 >   selectKeys(keys: string[]): string[]
+>   directionality() : Dir // where Dir is an enum type, one of « `'LTR'`, `'RTL'`, `'unknown'` »
+>   isolate(): boolean
 > }
 > ```
 >

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -943,6 +943,16 @@ The _Default Bidi Strategy_ is defined as follows:
       1. Let `fmt` be the formatted string representation of the _resolved value_ of `part`.
       1. Let `dir` be the directionality of `fmt`,
          one of « `'LTR'`, `'RTL'`, `'unknown'` », with the same meanings as for `msgdir`.
+         > [!NOTE]
+         > _Resolved values_ need to track two different pieces of metadata about directionality:
+         > the "isolate" flag (see the next step for how that is used), which determines
+         > whether the formatted result needs to be isolated; and the directionality itself.
+         > Each _function handler_ can have its own means for determining the directionality
+         > of the _resolved value_ it returns.
+         > Alternately, an implementation could elide this tracking and instead determine
+         > the directionality from the locale.
+         > The directionality SHOULD NOT be determined by introspecting
+         > the character sequence in `fmt`.
       1. Let the boolean value `isolate` be
          True if the `u:dir` _option_ of the _resolved value_ of `part` has a value other than `'inherit'`,
           or False otherwise.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -132,7 +132,7 @@ but also the _variable_ to which the _resolved value_ of the _variable-expressio
 
 In a _pattern_, the _resolved value_ of an _expression_ or _markup_ is used in its _formatting_.
 To support the _Default Bidi Strategy_,
-the _resolved value_ of each _expression_ _placeholder_
+the _resolved value_ of each _expression_
 SHOULD include information about the directionality
 of its formatted string representation,
 as well as a flag to indicate whether

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -942,7 +942,7 @@ The _Default Bidi Strategy_ is defined as follows:
    1. Else:
       1. Let `resval` be the _resolved value_ of `part`.
       1. Let `fmt` be the formatted string representation of `resval`.
-      1. Let `dir` be `DIR(resval)`,
+      1. Let `dir` be the directionality of `resval`,
          one of « `'LTR'`, `'RTL'`, `'unknown'` », with the same meanings as for `msgdir`.
       1. Let the boolean value `isolate` be
          True if the `u:dir` _option_ of `resval` has a value other than `'inherit'`,
@@ -964,23 +964,30 @@ The _Default Bidi Strategy_ is defined as follows:
          1. Append U+2069 POP DIRECTIONAL ISOLATE to `out`.
 1. Emit `out` as the formatted output of the message.
 
-The auxiliary function `DIR` maps a _resolved value_to one of
-« `'LTR'`, `'RTL'`, `'unknown'` ». (A _resolved value_ in turn
-is derived from an _expression_ together with a _formatting context_.)
-An implementation can use
-a representation of _resolved values_ that tracks two different
-pieces of metadata about directionality:
-the `isolate` flag used in step 2(iii),
-and the directionality itself.
-Each _function handler_ can have its own means
-for determining the directionality annotation on the _resolved value_ it returns.
-Alternately, an implementation could simply compute `DIR(part)`
-based on the locale.
+> [!NOTE]
+> A _resolved value_ is derived from an _expression_
+> together with a _formatting context_.)
+> An implementation can use
+> a representation of _resolved values_ that tracks
+> everything needed to determine the directionality
+> of the formatted string representation
+> of a _resolved value_.
+> This can be accomplished by incorporating
+> the `isolate` flag used in step 2(iii),
+> as well as the separate directionality annotation
+> (one of « `'LTR'`, `'RTL'`, `'unknown'` »),
+> into the representation of _resolved values_.
+> Each _function handler_ can have its own means
+> for determining the directionality annotation
+> on the _resolved value_ it returns.
+> Alternately, an implementation could simply
+> determine directionality
+> based on the locale.
 
 > [!NOTE]
-> `DIR(part)` SHOULD NOT be determined by introspecting
+> Directionality SHOULD NOT be determined by introspecting
 > the character sequence in the formatted string representation
-> of the resolved value of `part`.
+> of `resval`.
 
 
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -945,7 +945,7 @@ The _Default Bidi Strategy_ is defined as follows:
       1. Let `dir` be `DIR(resval)`,
          one of « `'LTR'`, `'RTL'`, `'unknown'` », with the same meanings as for `msgdir`.
       1. Let the boolean value `isolate` be
-         True if the `u:dir` _option_ of the _resolved value_ of `part` has a value other than `'inherit'`,
+         True if the `u:dir` _option_ of `resval` has a value other than `'inherit'`,
           or False otherwise.
       1. If `dir` is `'LTR'`:
          1. If `msgdir` is `'LTR'` and `isolate` is False:


### PR DESCRIPTION
I'm submitting this PR to test my understanding of the spec. As I understand it (having read https://github.com/unicode-org/message-format-wg/issues/918 ), the directionality of `fmt` _could_ be determined by introspection on `fmt`, but the implementation is not required to do that introspection. Rather, the resolved value of the expression has both an "input directionality" (determined by the `u:dir` attribute) and an "output directionality" (determined by the function handler for the annotation, or with a default value for placeholders without annotation.) The "output directionality" is what is meant by "the directionality of `fmt`" in the original text. 

I was confused because point 5 of  https://github.com/unicode-org/message-format-wg/issues/918 implies that no introspection is necessary, if I'm understanding correctly; but "the directionality of `fmt`" seems to imply that the directionality has to be determined from the formatted output, rather than from the metadata of that formatted output that is created by a function (that is, the "resolved value").

If I'm still confused, hopefully there's another edit that would make it clearer.