### PR TITLE
Add namespaces to example non-default functions

### DIFF
--- a/spec/errors.md
+++ b/spec/errors.md
@@ -86,15 +86,15 @@ does not equal the number of _selectors_.
 > Example invalid messages resulting in a _Variant Key Mismatch_ error:
 >
 > ```
-> .input {$one :func}
+> .input {$one :ns:func}
 > .match $one
 > 1 2 {{Too many}}
 > * {{Otherwise}}
 > ```
 >
 > ```
-> .input {$one :func}
-> .input {$two :func}
+> .input {$one :ns:func}
+> .input {$two :ns:func}
 > .match $one $two
 > 1 2 {{Two keys}}
 > * {{Missing a key}}
@@ -109,15 +109,15 @@ does not include a _variant_ with only catch-all keys.
 > Example invalid messages resulting in a _Missing Fallback Variant_ error:
 >
 > ```
-> .input {$one :func}
+> .input {$one :ns:func}
 > .match $one
 > 1 {{Value is one}}
 > 2 {{Value is two}}
 > ```
 >
 > ```
-> .input {$one :func}
-> .input {$two :func}
+> .input {$one :ns:func}
+> .input {$two :ns:func}
 > .match $one $two
 > 1 * {{First is one}}
 > * 1 {{Second is one}}
@@ -176,9 +176,9 @@ so explicitly declaring it after such use is also an error.
 > .input {$var2 :number}
 > {{Redeclaration of the implicit input variable $var2}}
 >
-> .local $var = {$ext :someFunction}
+> .local $var = {$ext :ns:func}
 > .local $var = {$error}
-> .local $var2 = {$var2 :error}
+> .local $var2 = {$var2 :ns:error}
 > {{{$var} cannot be redefined. {$var2} cannot refer to itself}}
 > ```
 
@@ -194,7 +194,7 @@ appears on the left-hand side of more than one _option_ in the same _expression_
 > ```
 >
 > ```
-> .local $foo = {horse :func one=1 two=2 one=1}
+> .local $foo = {horse :ns:func one=1 two=2 one=1}
 > {{This is {$foo}}}
 > ```
 
@@ -240,7 +240,7 @@ An **_<dfn>Unresolved Variable</dfn>_** error occurs when a variable reference c
 > ```
 >
 > ```
-> .input {$var :func}
+> .input {$var :ns:func}
 > .match $var
 > 1 {{The value is one.}}
 > * {{The value is not one.}}
@@ -253,14 +253,14 @@ a reference to a function which cannot be resolved.
 
 > For example, attempting to format either of the following messages
 > would result in an _Unknown Function_ error if done within a context that
-> does not provide for the function `:func` to be successfully resolved:
+> does not provide for the function `:ns:func` to be successfully resolved:
 >
 > ```
-> The value is {horse :func}.
+> The value is {horse :ns:func}.
 > ```
 >
 > ```
-> .local $horse = {|horse| :func}
+> .local $horse = {|horse| :ns:func}
 > .match $horse
 > 1 {{The value is one.}}
 > * {{The value is not one.}}
@@ -297,26 +297,26 @@ Implementations MAY also provide implementation-defined _Message Function Error_
 >    an object `{ name: 'Kat', id: 1234 }`,
 > 2. Provides for the variable reference `$field` to resolve to
 >    a string `'address'`, and
-> 3. Uses a `:get` message function which requires its argument to be an object and
+> 3. Uses a `:ns:get` message function which requires its argument to be an object and
 >    an option `field` to be provided with a string value.
 >
 > The exact type of _Message Function Error_ is determined by the _function handler_.
 >
 > ```
-> Hello, {horse :get field=name}!
+> Hello, {horse :ns:get field=name}!
 > ```
 >
 > ```
-> Hello, {$user :get}!
+> Hello, {$user :ns:get}!
 > ```
 >
 > ```
-> .local $id = {$user :get field=id}
-> {{Hello, {$id :get field=name}!}}
+> .local $id = {$user :ns:get field=id}
+> {{Hello, {$id :ns:get field=name}!}}
 > ```
 >
 > ```
-> Your {$field} is {$id :get field=$field}
+> Your {$field} is {$id :ns:get field=$field}
 > ```
 
 ### Bad Operand

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -213,7 +213,7 @@ Its _resolved value_ is defined by _literal resolution_.
 > ```
 > .local $aNumber = {1234 :number}
 > .local $aDate = {|2023-08-30| :datetime}
-> .local $aFoo = {|some foo| :foo}
+> .local $aFoo = {|some foo| :ns:foo}
 > {{You have {42 :number}}}
 > ```
 
@@ -367,7 +367,7 @@ The order of _options_ MUST NOT be significant.
 
 > For example, the following _message_ treats both both placeholders identically:
 > ```
-> {$x :function option1=foo option2=bar} {$x :function option2=bar option1=foo}
+> {$x :ns:func option1=foo option2=bar} {$x :ns:func option2=bar option1=foo}
 > ```
 
 For each _option_:
@@ -439,9 +439,9 @@ The string representation of the _fallback value_ of an _expression_ depends on 
   and then by U+007C VERTICAL LINE `|`.
 
   > Examples:
-  > In a context where `:func` fails to resolve,
-  > `{42 :func}` resolves to a _fallback value_ with a string representation `|42|` and
-  > `{|C:\\| :func}` resolves to a _fallback value_ with a string representation `|C:\\|`.
+  > In a context where `:ns:func` fails to resolve,
+  > `{42 :ns:func}` resolves to a _fallback value_ with a string representation `|42|` and
+  > `{|C:\\| :ns:func}` resolves to a _fallback value_ with a string representation `|C:\\|`.
 
 - _expression_ with _variable_ _operand_:
   the _fallback value_ representation of that _variable_,
@@ -452,24 +452,22 @@ The string representation of the _fallback value_ of an _expression_ depends on 
   > both resolve to a _fallback value_ with a string representation `$var`
   > (even if `:number` fails to resolve).
   >
-  > In a context where `:func` fails to resolve,
-  > the _placeholder_ in `.local $var = {|val| :func} {{{$var}}}`
+  > In a context where `:ns:func` fails to resolve,
+  > the _placeholder_ in `.local $var = {|val| :ns:func} {{{$var}}}`
   > resolves to a _fallback value_ with a string representation `$var`.
   >
-  > In a context where either `:now` or `:pretty` fails to resolve,
+  > In a context where either `:ns:now` or `:ns:pretty` fails to resolve,
   > the _placeholder_ in
   > ```
-  > .local $time = {:now format=iso8601}
-  > {{{$time :pretty}}}
+  > .local $time = {:ns:now format=iso8601}
+  > {{{$time :ns:pretty}}}
   > ```
   > resolves to a _fallback value_ with a string representation `$time`.
 
 - _function_ _expression_ with no _operand_:
   U+003A COLON `:` followed by the _function_ _identifier_
 
-  > Examples:
-  > In a context where `:func` fails to resolve,
-  > `{:func}` resolves to a _fallback value_ with a string representation `:func`.
+  > Example:
   > In a context where `:ns:func` fails to resolve,
   > `{:ns:func}` resolves to a _fallback value_ with a string representation `:ns:func`.
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -814,14 +814,14 @@ Examples:
 > This has an {42 :integer}
 > ```
 >
-> A function from the `icu` namespace:
+> A function from the `ns` namespace:
 > ```
-> This has a {:icu:function}
+> This has a {:ns:function}
 > ```
 >
 > Options with and without a namespace:
 > ```
-> This has {:icu:function option=value ns:option=add_on}
+> This has {:ns:function option=value ns:option=value}
 > ```
 
 Support for _namespaces_ and their interpretation is implementation-defined

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -406,14 +406,14 @@ There MUST be at least one _selector_ in a _matcher_.
 There MAY be any number of additional _selectors_.
 
 > A _message_ with a single _selector_ that uses a custom _function_
-> `:hasCase` which is a _selector_ that allows the _message_ to choose a _pattern_
+> `:ns:hasCase` which is a _selector_ that allows the _message_ to choose a _pattern_
 > based on grammatical case:
 >
 > ```
-> .local $hasCase = {$userName :hasCase}
+> .local $hasCase = {$userName :ns:hasCase}
 > .match $hasCase
-> vocative {{Hello, {$userName :person case=vocative}!}}
-> accusative {{Please welcome {$userName :person case=accusative}!}}
+> vocative {{Hello, {$userName :ns:person case=vocative}!}}
+> accusative {{Please welcome {$userName :ns:person case=accusative}!}}
 > * {{Hello!}}
 > ```
 
@@ -505,7 +505,7 @@ Additionally, an _input-declaration_ can contain a _variable-expression_.
 > Declarations:
 >
 > ```
-> .input {$x :function option=value}
+> .input {$x :ns:func option=value}
 > .local $y = {|This is an expression|}
 > ```
 >
@@ -514,8 +514,8 @@ Additionally, an _input-declaration_ can contain a _variable-expression_.
 > ```
 > This placeholder contains a literal expression: {|literal|}
 > This placeholder contains a variable expression: {$variable}
-> This placeholder references a function on a variable: {$variable :function with=options}
-> This placeholder contains a function expression with a variable-valued option: {:function option=$variable}
+> This placeholder references a function on a variable: {$variable :ns:func with=options}
+> This placeholder contains a function expression with a variable-valued option: {:ns:func option=$variable}
 > ```
 
 ### Operand
@@ -808,17 +808,20 @@ Examples:
 >```
 > This has a {$variable}
 >```
-> A function:
+>
+> A default function:
 > ```
-> This has a {:function}
+> This has an {42 :integer}
 > ```
-> An add-on function from the `icu` namespace:
+>
+> A function from the `icu` namespace:
 > ```
 > This has a {:icu:function}
 > ```
-> An option and an add-on option:
+>
+> Options with and without a namespace:
 > ```
-> This has {:options option=value icu:option=add_on}
+> This has {:icu:function option=value ns:option=add_on}
 > ```
 
 Support for _namespaces_ and their interpretation is implementation-defined


### PR DESCRIPTION
Given that our spec includes this: https://github.com/unicode-org/message-format-wg/blob/7c1f1a4af4aead387ca6aec48fffc2c6e2191c4d/spec/registry.md?plain=1#L33-L34

We should apply that same guideline to our own examples which use non-default functions.