### PR TITLE
Fix data model JSON Schema

### DIFF
--- a/spec/data-model/message.json
+++ b/spec/data-model/message.json
@@ -53,7 +53,7 @@
         "function": { "$ref": "#/$defs/function" },
         "attributes": { "$ref": "#/$defs/attributes" }
       },
-      "oneOf": [
+      "anyOf": [
         { "required": ["type", "arg"] },
         { "required": ["type", "function"] }
       ]
@@ -63,7 +63,7 @@
       "type": "object",
       "properties": {
         "type": { "const": "markup" },
-        "kind": { "oneOf": ["open", "standalone", "close"] },
+        "kind": { "enum": ["open", "standalone", "close"] },
         "name": { "type": "string" },
         "options": { "$ref": "#/$defs/options" },
         "attributes": { "$ref": "#/$defs/attributes" }
@@ -87,7 +87,17 @@
       "properties": {
         "type": { "const": "input" },
         "name": { "type": "string" },
-        "value": { "$ref": "#/$defs/variable-expression" }
+        "value": {
+          "allOf": [
+            { "$ref": "#/$defs/expression" },
+            {
+              "properties": {
+                "arg": { "$ref": "#/$defs/variable" }
+              },
+              "required": ["arg"]
+            }
+          ]
+        }
       },
       "required": ["type", "name", "value"]
     },


### PR DESCRIPTION
While putting together some Python tooling for MF2 (mozilla/moz-l10n#40), I came across a few bugs in the JSON Schema that had been missed, as it looks like no-one's actually used it for realz previously. This PR is meant to only fix those bugs, and not change the intent of the schema in any way.

The tooling in question isn't a Python formatter implementation, but bidirectional converters between a number of formats (including the MF2 source & JSON interchange formats) and the `moz.l10n` internal message data model (which is very closesly based on MF2, but designed for developer ergonomics rather than interchange).