### PR TITLE
Drop references to a "function registry"

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -97,8 +97,8 @@ At a minimum, it includes:
   defining variable values that are available during _variable resolution_.
   This is often determined by a user-provided argument of a formatting function call.
 
-- The _function registry_,
-  providing the _function handlers_ of the functions referred to by _message_ _functions_.
+- A mapping of string identifiers to the _function handlers_
+  that are available during _function resolution_.
 
 - Optionally, a fallback string to use for the _message_ if it is not _valid_.
 
@@ -290,8 +290,8 @@ the following steps are taken:
    emit an _Unknown Function_ error
    and return a _fallback value_ as the _resolved value_ of the _expression_.
 
-   Implementations are not required to implement _namespaces_ or installable
-   _function registries_.
+   Implementations are not required to implement _namespaces_ or
+   support _functions_ other than the _default functions_.
 
 3. Perform _option resolution_.
 

--- a/spec/functions/README.md
+++ b/spec/functions/README.md
@@ -1,4 +1,4 @@
-# MessageFormat 2.0 Default Function Registry
+# MessageFormat 2.0 Default Functions
 
 ## Table of Contents
 
@@ -18,8 +18,9 @@
 
 ## Introduction
 
-This section defines the **REQUIRED** _functions_ which are REQUIRED for conformance with this specification,
-along with **RECOMMENDED** _functions_ that SHOULD be implemented to support
+This section defines the **_<dfn>default functions</dfn>_**
+which are REQUIRED for conformance with this specification,
+along with _default functions_ that SHOULD be implemented to support
 additional functionality.
 
 To **_<dfn>accept</dfn>_** a function means that an implementation MUST NOT
@@ -34,26 +35,25 @@ Implementations MAY emit an _Unsupported Operation_ error for _options_
 or _option_ values that they cannot support.
 
 _Functions_ can define _options_. 
-An _option_ can be **REQUIRED** or **RECOMMENDED**.
+An _option_ can be REQUIRED or RECOMMENDED.
 
-Implementations MUST _accept_ each **REQUIRED** _function_ and
-MUST _accept_ all _options_ defined as **REQUIRED** for those _functions_.
+Implementations MUST _accept_ each REQUIRED _default function_ and
+MUST _accept_ all _options_ defined as REQUIRED for those _functions_.
 
-Implementations SHOULD _accept_ each **RECOMMENDED** _function_. 
+Implementations SHOULD _accept_ each RECOMMENDED _default function_. 
 For each such _function_, the implementation MUST accept all _options_
-listed as **REQUIRED** for that _function_.
+listed as REQUIRED for that _function_.
 
-Implementations SHOULD _accept_ _options_ that are marked as **RECOMMENDED**.
+Implementations SHOULD _accept_ _options_ that are marked as RECOMMENDED.
 
 Implementations MAY _accept_ _functions_ not defined in this specification.
 In addition, implementations SHOULD provide mechanisms for users to
-register and use user-defined _functions_ and their associated _functional handlers_.
+register and use user-defined _functions_ and their associated _function handlers_.
 Functions not defined by any version of this specification SHOULD use 
 an implementation-defined or user-defined _namespace_.
 
 Implementations MAY implement additional _options_ not defined
-by any version of this specification
-for **REQUIRED** and **RECOMMENDED** functions.
+by any version of this specification for _default functions_.
 Such _options_ MUST use an implementation-specific _namespace_.
 
 Implementations MAY _accept_, for _options_ defined in this specification,
@@ -61,7 +61,7 @@ _option_ values which are not defined in this specification.
 However, such values might become defined with a different meaning in the future,
 including with a different, incompatible name
 or using an incompatible value space.
-Supporting implementation-specific _option_ values for **REQUIRED** or **RECOMMENDED** functions is NOT RECOMMENDED.
+Supporting implementation-specific _option_ values for _default functions_ is NOT RECOMMENDED.
 
 Implementations MAY _accept_, for _operands_ or _options_ defined in this specification,
 values with implementation-defined types.

--- a/spec/functions/datetime.md
+++ b/spec/functions/datetime.md
@@ -1,7 +1,7 @@
 ## Date and Time Value Formatting
 
 This subsection describes the functions and options for date/time formatting.
-Selection based on date and time values is not required in this release.
+Selection based on date and time values is NOT REQUIRED in this release.
 
 > [!NOTE]
 > Selection based on date/time types is not required by MF2.

--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -20,7 +20,7 @@ the value of other options, or both.
 > [options](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options)
 > in JavaScript's `Intl.NumberFormat`.
 
-The following options and their values are required to be available on the function `:number`:
+The following options and their values are REQUIRED to be available on the function `:number`:
 
 - `select`
   - `plural` (default; see [Default Value of `select` Option](#default-value-of-select-option) below)
@@ -167,8 +167,7 @@ the value of other options, or both.
 > [options](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options)
 > in JavaScript's `Intl.NumberFormat`.
 
-The following options and their values are required in the default registry to be available on the
-function `:integer`:
+The following options and their values are REQUIRED to be available on the function `:integer`:
 
 - `select`
   - `plural` (default)
@@ -287,8 +286,7 @@ The options on `:math` are exclusive with each other,
 and exactly one option is always required.
 The options do not have default values.
 
-The following options and their values are
-required in the default registry to be available on the function `:math`:
+The following options and their values are REQUIRED to be available on the function `:math`:
 
 - `add`
   - ([digit size option](#digit-size-options))
@@ -438,7 +436,7 @@ Some implementations might not be able to produce all of these formats for every
 > The option `select` does not accept the value `ordinal` because selecting
 > currency values using ordinal rules makes no sense.
 
-The following options and their values are required to be available on the function `:currency`:
+The following options and their values are REQUIRED to be available on the function `:currency`:
 
 - `select`
   - `plural` (default)
@@ -529,7 +527,7 @@ The _function_ `:currency` performs selection as described in [Number Selection]
 ### The `:unit` function
 
 The _function_ `:unit` is **Proposed** for inclusion in the next release of this specification but has not yet been finalized.
-The _function_ `:unit` is proposed to be a **RECOMMENDED** selector and formatter for unitized values,
+The _function_ `:unit` is proposed to be a RECOMMENDED selector and formatter for unitized values,
 that is, for numeric values associated with a unit of measurement.
 This is a specialized form of numeric selection and formatting.
 
@@ -579,7 +577,8 @@ the value of other _options_, or all of these.
 > The option `select` does not accept the value `ordinal` because selecting
 > unit values using ordinal rules makes no sense.
 
-The following options and their values are required to be available on the function `:unit`:
+The following options and their values are REQUIRED to be available on the function `:unit`,
+unless otherwise indicated:
 
 - `select`
   - `plural` (default)

--- a/spec/intro.md
+++ b/spec/intro.md
@@ -10,7 +10,7 @@
    1. [`message.abnf`](message.abnf)
 1. [Formatting](formatting.md)
 1. [Errors](errors.md)
-1. [Default Function Registry](functions/README.md)
+1. [Default Functions](functions/README.md)
 1. [`u:` Namespace](u-namespace.md)
 1. [Interchange data model](data-model/README.md)
 1. [Appendices](appendices.md)
@@ -95,10 +95,10 @@ that previously did not specify a _fallback value_.
 Updates to this specification will not change the syntactical meaning
 of any syntax defined in this specification.
 
-Updates to this specification will not remove any _functions_ defined in the default function registry.
+Updates to this specification will not remove any _default functions_.
 
 Updates to this specification will not remove any _options_ or _option_ values
-defined in the default function registry.
+defined for _default functions_.
 
 > [!NOTE]
 > The foregoing policies are _not_ a guarantee that the results of formatting will never change.
@@ -137,7 +137,7 @@ based on this version being invalid.
 > - Future versions may add additional structure or meaning to existing syntax.
 > - Future versions may define new _keywords_.
 > - Future versions may make previously invalid _messages_ valid.
-> - Future versions may define additional _functions_ in the default registry
+> - Future versions may define additional _default functions_.
 >   or may reserve the names of _functions_ for the purposes of interoperability.
 > - Future versions may define additional _options_ to existing functions.
 > - Future versions may define additional _option_ values for existing _options_.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -536,7 +536,8 @@ The resolution of a _function_ relies on an implementation-defined _function han
 Some _functions_ can be used both as a _selector_ as well as in a _placeholder_;
 others are only valid in one of these positions.
 _Functions_ also differ in their requirements on the _operand_ and _options_ that they accept.
-See _Function Resolution_ and _default functions_ for more information.
+See [Function Resolution](./spec/formatting.md#function-resolution)
+and [Default Functions](./spec/functions/README.md) for more information.
 
 A _function_ starts with a prefix sigil `:` followed by an _identifier_.
 The _identifier_ MAY be followed by one or more _options_.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -532,14 +532,11 @@ values during formatting.
 A _function_ can appear in an _expression_ by itself or following a single _operand_.
 When following an _operand_, the _operand_ serves as input to the _function_.
 
-Each _function_ is defined by the runtime's _function registry_.
-A _function_'s entry in the _function registry_ will define
-whether the _function_ is a _selector_ or formatter (or both),
-whether an _operand_ is required,
-what form the values of an _operand_ can take,
-what _options_ and _option_ values are acceptable,
-and what outputs might result.
-See [function registry](./functions/README.md) for more information.
+The resolution of a _function_ relies on an implementation-defined _function handler_.
+Some _functions_ can be used both as a _selector_ as well as in a _placeholder_;
+others are only valid in one of these positions.
+_Functions_ also differ in their requirements on the _operand_ and _options_ that they accept.
+See _Function Resolution_ and _default functions_ for more information.
 
 A _function_ starts with a prefix sigil `:` followed by an _identifier_.
 The _identifier_ MAY be followed by one or more _options_.


### PR DESCRIPTION
As discussed previously (most recently in https://github.com/unicode-org/message-format-wg/pull/974#discussion_r1894125386), we should update our terminology to no longer refer to a "function registry", a term that we don't actually define.

This PR applies that change, along with some incidental cleanup. The term _**default function**_ is introduced, and used where appropriate.

The GitHub label `registry` should probably also be renamed as `default-functions`.