### PR TITLE
Drop :currency currencyDisplay=formalSymbol option value

### DIFF
--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -463,7 +463,6 @@ The following options and their values are required to be available on the funct
   - `symbol` (default)
   - `name`
   - `code`
-  - `formalSymbol`
   - `never` (this is called `hidden` in ICU)
 - `useGrouping`
   - `auto` (default)


### PR DESCRIPTION
This option value was introduced in #915, and was specifically discussed at least under https://github.com/unicode-org/message-format-wg/pull/915#discussion_r1831635432 and during some of our weekly calls. After its introduction, I submitted a [TC39 proposal](https://github.com/tc39/proposal-intl-currency-display-choices) for the option value, which is now at Stage 2.

However, further discussions of the proposal in TC39 TG2, (tc39/ecma402#643 and at the [last meeting](https://github.com/tc39/ecma402/blob/main/meetings/notes-2025-01-16.md#currency-display)) have identified the current data to be quite limited, as `<symbol alt="formal">`is _only_ used for TWD in zh-Hant in all of CLDR.

The more useful form of this that's proposed in the TC39 proposal would e.g. allow for the symbol string `US$` to be available in the en-US locale, which it currently is not, but that option may well end up with a different name than "formalSymbol". @sffc has filed a [CLDR issue](https://unicode-org.atlassian.net/browse/CLDR-18147) about adding data for this.

As [discussed](https://github.com/unicode-org/message-format-wg/blob/main/meetings/2025/notes-2025-01-21.md#currency-symbol) on today's call, it therefore seems like a good idea to not include the option in MF2 at least for now, as that value is not currently useful, and may well be superseded by some more useful option value later.