### PR TITLE
Simplify syntax character definitions, dropping content-char

### DIFF
--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -65,18 +65,22 @@ name-char  = name-start / DIGIT / "-" / "."
            / %xB7 / %x300-36F / %x203F-2040
 
 ; Restrictions on characters in various contexts
-simple-start-char = content-char / "@" / "|"
-text-char         = content-char / ws / "." / "@" / "|"
-quoted-char       = content-char / ws / "." / "@" / "{" / "}"
-content-char      = %x01-08        ; omit NULL (%x00), HTAB (%x09) and LF (%x0A)
+simple-start-char = %x01-08        ; omit NULL (%x00), HTAB (%x09) and LF (%x0A)
                   / %x0B-0C        ; omit CR (%x0D)
                   / %x0E-1F        ; omit SP (%x20)
                   / %x21-2D        ; omit . (%x2E)
-                  / %x2F-3F        ; omit @ (%x40)
-                  / %x41-5B        ; omit \ (%x5C)
-                  / %x5D-7A        ; omit { | } (%x7B-7D)
+                  / %x2F-5B        ; omit \ (%x5C)
+                  / %x5D-7A        ; omit { (%x7B)
+                  / %x7C           ; omit } (%x7D)
                   / %x7E-2FFF      ; omit IDEOGRAPHIC SPACE (%x3000)
-                  / %x3001-10FFFF  ; allowing surrogates is intentional
+                  / %x3001-10FFFF
+text-char         = %x01-5B        ; omit NULL (%x00) and \ (%x5C)
+                  / %x5D-7A        ; omit { (%x7B)
+                  / %x7C           ; omit } (%x7D)
+                  / %x7E-10FFFF
+quoted-char       = %x01-5B        ; omit NULL (%x00) and \ (%x5C)
+                  / %x5D-7B        ; omit | (%x7C)
+                  / %x7D-10FFFF
 
 ; Character escapes
 escaped-char = backslash ( backslash / "{" / "|" / "}" )

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -294,24 +294,27 @@ In the ABNF, _text_ is represented by non-empty sequences of
 `simple-start-char`, `text-char`, `escaped-char`, and `s`.
 The production `simple-start-char` represents the first non-whitespace in a _simple message_
 and matches `text-char` except for not allowing U+002E FULL STOP `.`.
-The ABNF uses `content-char` as a shared base for _text_ and _quoted literal_ characters.
 
 Whitespace in _text_, including tabs, spaces, and newlines is significant and MUST
 be preserved during formatting.
 
 ```abnf
-simple-start-char = content-char / "@" / "|"
-text-char         = content-char / ws / "." / "@" / "|"
-quoted-char       = content-char / ws / "." / "@" / "{" / "}"
-content-char      = %x01-08        ; omit NULL (%x00), HTAB (%x09) and LF (%x0A)
+simple-start-char = %x01-08        ; omit NULL (%x00), HTAB (%x09) and LF (%x0A)
                   / %x0B-0C        ; omit CR (%x0D)
                   / %x0E-1F        ; omit SP (%x20)
                   / %x21-2D        ; omit . (%x2E)
-                  / %x2F-3F        ; omit @ (%x40)
-                  / %x41-5B        ; omit \ (%x5C)
-                  / %x5D-7A        ; omit { | } (%x7B-7D)
+                  / %x2F-5B        ; omit \ (%x5C)
+                  / %x5D-7A        ; omit { (%x7B)
+                  / %x7C           ; omit } (%x7D)
                   / %x7E-2FFF      ; omit IDEOGRAPHIC SPACE (%x3000)
-                  / %x3001-10FFFF  ; allowing surrogates is intentional
+                  / %x3001-10FFFF
+text-char         = %x01-5B        ; omit NULL (%x00) and \ (%x5C)
+                  / %x5D-7A        ; omit { (%x7B)
+                  / %x7C           ; omit } (%x7D)
+                  / %x7E-10FFFF
+quoted-char       = %x01-5B        ; omit NULL (%x00) and \ (%x5C)
+                  / %x5D-7B        ; omit | (%x7C)
+                  / %x7D-10FFFF
 ```
 
 > [!NOTE]


### PR DESCRIPTION
With the simplifications we've made to the syntax, in particular allowing unpaired surrogates and dropping the unsupported constructs, the character definitions are no longer benefiting from building on a common `content-char` definition, and it's simpler to not refer to it.

This change is purely editorial, as the final meaning of the ABNF stays just the same as before.