### PR TITLE
Allow name-char as first character of unquoted-literal

### DIFF
--- a/spec/functions/datetime.md
+++ b/spec/functions/datetime.md
@@ -74,19 +74,7 @@ and what format to use for that field.
 > [!NOTE] > _Field options_ do not have default values because they are only to be used
 > to compose the formatter.
 
-The _field options_ are defined as follows:
-
-> [!IMPORTANT]
-> The value `2-digit` for some _field options_ MUST be quoted
-> in the MessageFormat syntax because it starts with a digit
-> but does not match the `number-literal` production in the ABNF.
->
-> ```
-> .local $correct = {$someDate :datetime year=|2-digit|}
-> .local $syntaxError = {$someDate :datetime year=2-digit}
-> ```
-
-The function `:datetime` has the following options:
+The function `:datetime` has the following _field options_:
 
 - `weekday`
   - `long`

--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -655,8 +655,12 @@ Implementations MUST NOT substitute the unit without performing the associated c
 ### Number Operands
 
 The _operand_ of a number function is either an implementation-defined type or
-a literal whose contents match the `number-literal` production in the [ABNF](/spec/message.abnf).
+a literal whose contents match the following `number-literal` production.
 All other values produce a _Bad Operand_ error.
+
+```abnf
+number-literal = ["-"] (%x30 / (%x31-39 *DIGIT)) ["." 1*DIGIT]
+```
 
 > For example, in Java, any subclass of `java.lang.Number` plus the primitive
 > types (`byte`, `short`, `int`, `long`, `float`, `double`, etc.)
@@ -667,7 +671,7 @@ All other values produce a _Bad Operand_ error.
 > [!NOTE]
 > String values passed as variables in the _formatting context_'s
 > _input mapping_ can be formatted as numeric values as long as their
-> contents match the `number-literal` production in the [ABNF](/spec/message.abnf).
+> contents match the `number-literal` production.
 >
 > For example, if the value of the variable `num` were the string
 > `-1234.567`, it would behave identically to the local

--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -659,7 +659,7 @@ a literal whose contents match the following `number-literal` production.
 All other values produce a _Bad Operand_ error.
 
 ```abnf
-number-literal = ["-"] (%x30 / (%x31-39 *DIGIT)) ["." 1*DIGIT]
+number-literal = ["-"] (%x30 / (%x31-39 *DIGIT)) ["." 1*DIGIT] [%i"e" ["-" / "+"] 1*DIGIT]
 ```
 
 > For example, in Java, any subclass of `java.lang.Number` plus the primitive

--- a/spec/message.abnf
+++ b/spec/message.abnf
@@ -41,9 +41,7 @@ variable       = "$" name
 
 literal          = quoted-literal / unquoted-literal
 quoted-literal   = "|" *(quoted-char / escaped-char) "|"
-unquoted-literal = name / number-literal
-; number-literal matches JSON number (https://www.rfc-editor.org/rfc/rfc8259#section-6)
-number-literal   = ["-"] (%x30 / (%x31-39 *DIGIT)) ["." 1*DIGIT] [%i"e" ["-" / "+"] 1*DIGIT]
+unquoted-literal = 1*name-char
 
 ; Keywords; Note that these are case-sensitive
 input = %s".input"

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -735,19 +735,17 @@ escaped as `\\` and `\|`.
 An **_<dfn>unquoted literal</dfn>_** is a _literal_ that does not require the `|`
 quotes around it to be distinct from the rest of the _message_ syntax.
 An _unquoted literal_ MAY be used when the content of the _literal_
-contains no whitespace and otherwise matches the `unquoted` production.
+contains no whitespace and otherwise matches the `unquoted-literal` production.
 Implementations MUST NOT distinguish between _quoted literals_ and _unquoted literals_
 that have the same sequence of code points.
 
-_Unquoted literals_ can contain a _name_ or consist of a _number-literal_.
-A _number-literal_ uses the same syntax as JSON and is intended for the encoding 
-of number values in _operands_ or _options_, or as _keys_ for _variants_.
+_Unquoted literals_ can contain any characters also valid in _name_,
+but with none of its additional restrictions on its first character.
 
 ```abnf
 literal          = quoted-literal / unquoted-literal
 quoted-literal   = "|" *(quoted-char / escaped-char) "|"
-unquoted-literal = name / number-literal
-number-literal   = ["-"] (%x30 / (%x31-39 *DIGIT)) ["." 1*DIGIT] [%i"e" ["-" / "+"] 1*DIGIT]
+unquoted-literal = 1*name-char
 ```
 
 ### Names and Identifiers

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -740,7 +740,7 @@ Implementations MUST NOT distinguish between _quoted literals_ and _unquoted lit
 that have the same sequence of code points.
 
 _Unquoted literals_ can contain any characters also valid in _name_,
-but with none of its additional restrictions on its first character.
+less _name_'s additional restrictions on the first character.
 
 ```abnf
 literal          = quoted-literal / unquoted-literal

--- a/test/tests/functions/datetime.json
+++ b/test/tests/functions/datetime.json
@@ -45,7 +45,7 @@
       "src": "{|2006-01-02T15:04:06| :datetime}"
     },
     {
-      "src": "{|2006-01-02T15:04:06| :datetime year=numeric month=|2-digit|}"
+      "src": "{|2006-01-02T15:04:06| :datetime year=numeric month=2-digit}"
     },
     {
       "src": "{|2006-01-02T15:04:06| :datetime dateStyle=long}"

--- a/test/tests/functions/integer.json
+++ b/test/tests/functions/integer.json
@@ -16,8 +16,8 @@
       "exp": "hello -4"
     },
     {
-      "src": "hello {0.42e+1 :integer}",
-      "exp": "hello 4"
+      "src": "hello {0.42 :integer}",
+      "exp": "hello 0"
     },
     {
       "src": ".input {$foo :integer} .match $foo 1 {{=1}} * {{other}}",

--- a/test/tests/functions/integer.json
+++ b/test/tests/functions/integer.json
@@ -20,6 +20,10 @@
       "exp": "hello 0"
     },
     {
+      "src": "hello {|0.42e+1| :integer}",
+      "exp": "hello 4"
+    },
+    {
       "src": ".input {$foo :integer} .match $foo 1 {{=1}} * {{other}}",
       "params": [{ "name": "foo", "value": 1.2 }],
       "exp": "=1"

--- a/test/tests/functions/number.json
+++ b/test/tests/functions/number.json
@@ -20,6 +20,10 @@
       "exp": "hello 0.42"
     },
     {
+      "src": "hello {|0.42e+1| :number}",
+      "exp": "hello 4.2"
+    },
+    {
       "src": "hello {foo :number}",
       "exp": "hello {|foo|}",
       "expErrors": [

--- a/test/tests/functions/number.json
+++ b/test/tests/functions/number.json
@@ -16,8 +16,8 @@
       "exp": "hello -4.2"
     },
     {
-      "src": "hello {0.42e+1 :number}",
-      "exp": "hello 4.2"
+      "src": "hello {0.42 :number}",
+      "exp": "hello 0.42"
     },
     {
       "src": "hello {foo :number}",

--- a/test/tests/syntax.json
+++ b/test/tests/syntax.json
@@ -421,72 +421,72 @@
       ]
     },
     {
-      "description": "... literal -> quoted-literal -> \"|\" \"|\" ...",
+      "description": "... quoted-literal",
       "src": "{||}",
       "exp": ""
     },
     {
-      "description": "... quoted-literal -> \"|\" quoted-char \"|\"",
+      "description": "... quoted-literal",
       "src": "{|a|}",
       "exp": "a"
     },
     {
-      "description": "... quoted-literal -> \"|\" escaped-char \"|\"",
+      "description": "... quoted-literal",
       "src": "{|\\\\|}",
       "exp": "\\"
     },
     {
-      "description": "... quoted-literal -> \"|\" quoted-char 1*escaped-char \"|\"",
+      "description": "... quoted-literal",
       "src": "{|a\\\\\\{\\|\\}|}",
       "exp": "a\\{|}"
     },
     {
-      "description": "... unquoted-literal -> number-literal -> %x30",
+      "description": "... unquoted-literal",
       "src": "{0}",
       "exp": "0"
     },
     {
-      "description": "... unquoted-literal -> number-literal -> \"-\" %x30",
+      "description": "... unquoted-literal",
       "src": "{-0}",
       "exp": "-0"
     },
     {
-      "description": "... unquoted-literal -> number-literal -> (%x31-39 *DIGIT) -> %x31",
+      "description": "... unquoted-literal",
       "src": "{1}",
       "exp": "1"
     },
     {
-      "description": "... unquoted-literal -> number-literal -> (%x31-39 *DIGIT) -> %x31 DIGIT -> 11",
+      "description": "... unquoted-literal",
       "src": "{11}",
       "exp": "11"
     },
     {
-      "description": "... unquoted-literal -> number-literal -> %x30 \".\" 1*DIGIT -> 0 \".\" 1",
+      "description": "... unquoted-literal",
       "src": "{0.1}",
       "exp": "0.1"
     },
     {
-      "description": "... unquoted-literal -> number-literal -> %x30 \".\" 1*DIGIT -> %x30 \".\" DIGIT DIGIT -> 0 \".\" 1 2",
+      "description": "... unquoted-literal",
       "src": "{0.12}",
       "exp": "0.12"
     },
     {
-      "description": "... unquoted-literal -> number-literal -> %x30 %i\"e\" 1*DIGIT -> %x30 \"e\" DIGIT",
+      "description": "... unquoted-literal",
       "src": "{0e1}",
       "exp": "0e1"
     },
     {
-      "description": "... unquoted-literal -> number-literal -> %x30 %i\"e\" 1*DIGIT -> %x30 \"E\" DIGIT",
+      "description": "... unquoted-literal",
       "src": "{0E1}",
       "exp": "0E1"
     },
     {
-      "description": "... unquoted-literal -> number-literal -> %x30 %i\"e\" \"-\" 1*DIGIT ...",
+      "description": "... unquoted-literal",
       "src": "{0E-1}",
       "exp": "0E-1"
     },
     {
-      "description": "... unquoted-literal -> number-literal -> %x30 %i\"e\" \"+\" 1*DIGIT ...",
+      "description": "... unquoted-literal",
       "src": "{0E-1}",
       "exp": "0E-1"
     },


### PR DESCRIPTION
Fixes #724 

As discussed today, our `name` definition is a slightly restricted variant of the XML `NCName`, which has not been updated to account for developments in the last 15 years or so that have e.g. included combining marks and the ALM in the `name-start` range.

So as the `name` production is already messy, `unquoted-literal` is not really made _much worse_ by allowing `name-char` as its first character. Doing so also allows us to drop the `number-literal` rule from the syntax.

The `number-literal` rule is still needed for number functions, hence its re-definition in the Number Operands section. Note that I've left out the exponenetial part from it, as the `+` character is no longer valid without quoting.

This change also removes the need to quote `2-digit`, a valid literal value for some `:datetime` options. Previously, it was the only default function option value that needed quoting.

Filing initially as a draft, as I want to implement this to make sure it works as expected, and to make sure that all test suite changes have been accounted for.