### PR TITLE
spec: fix bad links to cldr-smoke

### DIFF
--- a/exploration/default-registry-and-mf1-compatibility.md
+++ b/exploration/default-registry-and-mf1-compatibility.md
@@ -244,9 +244,9 @@ The followind date/time options are *not* part of the default registry.
 Implementations SHOULD avoid creating options that conflict with these, but
 are encouraged to track development of these options during Tech Preview:
 - `calendar` (default is locale-specific)
-  - valid [Unicode Calendar Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCalendarIdentifier)
+  - valid [Unicode Calendar Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeCalendarIdentifier)
 - `numberingSystem` (default is locale-specific)
-   - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+   - valid [Unicode Number System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
 - `timeZone` (default is system default time zone or UTC)
   - valid identifier per [BCP175](https://www.rfc-editor.org/rfc/rfc6557)
 

--- a/exploration/number-selection.md
+++ b/exploration/number-selection.md
@@ -240,7 +240,7 @@ function `:number`:
    - `engineering`
    - `compact`
 - `numberingSystem`
-   - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+   - valid [Unicode Number System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
      (default is locale-specific)
 - `signDisplay`
    -  `auto` (default)
@@ -280,7 +280,7 @@ function `:integer`:
    -  `ordinal`
    -  `exact`
 - `numberingSystem`
-   - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+   - valid [Unicode Number System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
      (default is locale-specific)
 - `signDisplay`
    -  `auto` (default)
@@ -322,7 +322,7 @@ The following options are _not_ part of the default registry.
 Implementations SHOULD avoid creating options that conflict with these, but
 are encouraged to track development of these options during Tech Preview:
 - `currency`
-   - valid [Unicode Currency Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCurrencyIdentifier)
+   - valid [Unicode Currency Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeCurrencyIdentifier)
      (no default)
 - `currencyDisplay`
    - `symbol` (default)

--- a/spec/functions/README.md
+++ b/spec/functions/README.md
@@ -74,7 +74,7 @@ Such values can be useful to users in cases where local usage and support exists
 > - A Java implementation might _accept_ a `java.time.chrono.Chronology` object
 >   as a value for the _date/time override option_ `calendar`
 > - ICU4J's implementation might _accept_ a `com.ibm.icu.text.NumberingSystem` object
->   instead of using a [Unicode Numbering System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+>   instead of using a [Unicode Numbering System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
 >   for the option `numberingSystem` in _functions_ such as `:number` or `:integer`.
 
 Future versions of this specification MAY define additional _options_ and _option_ values,

--- a/spec/functions/datetime.md
+++ b/spec/functions/datetime.md
@@ -288,9 +288,9 @@ The following _options_ and their values are RECOMMENDED to be available on
 the functions `:datetime`, `:date`, and `:time`.
 
 - `calendar`
-  - valid [Unicode Calendar Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCalendarIdentifier)
+  - valid [Unicode Calendar Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeCalendarIdentifier)
 - `numberingSystem`
-  - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+  - valid [Unicode Number System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
 
 The following _option_ and its values are **Proposed** for
 inclusion in the next release of this specification but have not yet been

--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -35,7 +35,7 @@ The following options and their values are required to be available on the funct
   - `engineering`
   - `compact`
 - `numberingSystem`
-  - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+  - valid [Unicode Number System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
     (default is locale-specific)
 - `signDisplay`
   - `auto` (default)
@@ -152,7 +152,7 @@ function `:integer`:
   - `ordinal`
   - `exact`
 - `numberingSystem`
-  - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+  - valid [Unicode Number System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
     (default is locale-specific)
 - `signDisplay`
   - `auto` (default)
@@ -301,7 +301,7 @@ The option `currency` MUST NOT be used to override the currency of an implementa
 Using this option in such a case results in a _Bad Option_ error.
 
 The value of the _operand_'s `currency` MUST be either a string containing a
-well-formed [Unicode Currency Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCurrencyIdentifier)
+well-formed [Unicode Currency Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeCurrencyIdentifier)
 or an implementation-defined currency type.
 Although currency codes are expected to be uppercase,
 implementations SHOULD treat them in a case-insensitive manner.
@@ -391,7 +391,7 @@ Some implementations might not be able to produce all of these formats for every
 The following options and their values are required to be available on the function `:currency`:
 
 - `currency`
-  - well-formed [Unicode Currency Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeCurrencyIdentifier)
+  - well-formed [Unicode Currency Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeCurrencyIdentifier)
     (no default)
 - `compactDisplay` (this option only has meaning when combined with the option `notation=compact`)
   - `short` (default)
@@ -400,7 +400,7 @@ The following options and their values are required to be available on the funct
   - `standard` (default)
   - `compact`
 - `numberingSystem`
-  - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+  - valid [Unicode Number System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
     (default is locale-specific)
 - `currencySign`
   - `accounting`
@@ -536,7 +536,7 @@ The following options and their values are required to be available on the funct
   - `standard` (default)
   - `compact`
 - `numberingSystem`
-  - valid [Unicode Number System Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#UnicodeNumberSystemIdentifier)
+  - valid [Unicode Number System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
     (default is locale-specific)
 - `signDisplay`
   - `auto` (default)

--- a/spec/u-namespace.md
+++ b/spec/u-namespace.md
@@ -50,7 +50,7 @@ Values matching the following ABNF are always accepted:
 u-locale-option = unicode_bcp47_locale_id *(o "," o unicode_bcp47_locale_id)
 ```
 using `unicode_bcp47_locale_id` as defined for
-[Unicode Locale Identifier](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#unicode_bcp47_locale_id).
+[Unicode Locale Identifier](https://unicode.org/reports/tr35/tr35.html#unicode_bcp47_locale_id).
 
 Implementations MAY support additional language tags,
 such as private-use or grandfathered tags,


### PR DESCRIPTION
- cldr-smoke version of tr35 should not be referred to or linked to, ever.

See also:
- https://github.com/unicode-org/cldr/pull/4353
- https://unicode-org.atlassian.net/browse/CLDR-18295 (broken MFv2 spec links)