### PR TITLE
Add a note about representing the string `*` in a key

### DIFF
--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -465,6 +465,7 @@ that matches all values for a given _selector_.
 > To represent a _key_ consisting of the character `*` U+002A ASTERISK,
 > use a _quoted literal_:
 > ```
+> .input {$value :string}
 > .match $value
 > |*| {{Matches the string *}}
 > *   {{Matches any other string}}

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -462,8 +462,8 @@ The **_<dfn>catch-all key</dfn>_** is a special key, represented by `*`,
 that matches all values for a given _selector_.
 
 > [!NOTE]
-> To represent a key_ consisting of the character `*` U+002A ASTERISK,
-> use a quoted literal:
+> To represent a _key_ consisting of the character `*` U+002A ASTERISK,
+> use a _quoted literal_:
 > ```
 > .match $value
 > |*| {{Matches the string *}}

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -461,6 +461,15 @@ A _key_ can be either a _literal_ value or the "catch-all" key `*`.
 The **_<dfn>catch-all key</dfn>_** is a special key, represented by `*`,
 that matches all values for a given _selector_.
 
+> [!NOTE]
+> To represent a key_ consisting of the character `*` U+002A ASTERISK,
+> use a quoted literal:
+> ```
+> .match $value
+> |*| {{Matches the string *}}
+> *   {{Matches any other string}}
+> ```
+
 The value of each _literal_ _key_ MUST be treated as if it were in
 [Unicode Normalization Form C](https://unicode.org/reports/tr15/) ("NFC").
 Two _literal_ _keys_ are considered equal if they are canonically equivalent strings,


### PR DESCRIPTION
This addresses the problem by spelling out the difference between `|*|` and `*` in keys.