### PR TITLE
Fix normative language in notes

### DIFF
--- a/spec/intro.md
+++ b/spec/intro.md
@@ -119,7 +119,8 @@ which satisfy either of the following two requirements:
 All other _identifiers_ in these categories are reserved for the use of implementations or users.
 
 > [!IMPORTANT]
-> Users defining custom _identifiers_ SHOULD use a _namespace_
+> Implementation-defined or user-defined _functions_ and _function_ _options_
+> SHOULD use a _namespace_ as part of their _identifiers_
 > to avoid collisions with other implementations.
 
 Future versions of this specification will not introduce changes

--- a/spec/intro.md
+++ b/spec/intro.md
@@ -118,10 +118,9 @@ which satisfy either of the following two requirements:
 
 All other _identifiers_ in these categories are reserved for the use of implementations or users.
 
-> [!NOTE]
-> Users defining custom _identifiers_ SHOULD include at least one character outside these ranges
-> to ensure that they will be compatible with future versions of this specification.
-> They SHOULD also use the _namespace_ feature to avoid collisions with other implementations.
+> [!IMPORTANT]
+> Users defining custom _identifiers_ SHOULD use a _namespace_
+> to avoid collisions with other implementations.
 
 Future versions of this specification will not introduce changes
 to the data model that would result in a data model representation

--- a/spec/intro.md
+++ b/spec/intro.md
@@ -121,7 +121,7 @@ All other _identifiers_ in these categories are reserved for the use of implemen
 > [!IMPORTANT]
 > Implementation-defined or user-defined _functions_ and _function_ _options_
 > SHOULD use a _namespace_ as part of their _identifiers_
-> to avoid collisions with other implementations.
+> to help avoid collisions with other implementations.
 
 Future versions of this specification will not introduce changes
 to the data model that would result in a data model representation

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -117,7 +117,6 @@ A **_<dfn>local variable</dfn>_** is a _variable_ created as the result of a _lo
 > that use the UTF-16 encoding 
 > and do not check for unpaired surrogates.
 > (Strings in Java or JavaScript are examples of this.)
-> These code points SHOULD NOT be used in a _message_.
 > Unpaired surrogate code points are likely an indication of mistakes
 > or errors in the creation, serialization, or processing of the _message_.
 > Many processes will convert them to 


### PR DESCRIPTION
I found two notes with normative language; this fixes one to be IMPORTANT instead (and removes the character range comment, as we've since added namespaces that should be used), and drops the unnecessary phrase from the other.