### PR TITLE
Define optionality separately for each u: option

### DIFF
--- a/spec/u-namespace.md
+++ b/spec/u-namespace.md
@@ -12,10 +12,13 @@ manages the specification for this namespace, hence the _namespace_ `u:`.
 
 ## Options
 
-This section describes common **_<dfn>`u:` options</dfn>_** which each implementation SHOULD support
+This section describes common **_<dfn>`u:` options</dfn>_** that apply
 for all _functions_ and _markup_.
 
 ### `u:id`
+
+Implementations providing a formatting target other than a concatenated string
+SHOULD support this option.
 
 A string value that is included as an `id` or other suitable value
 in the formatted parts for the _placeholder_,
@@ -30,6 +33,8 @@ For other values, a _Bad Option_ error is emitted
 and the `u:id` option is ignored.
 
 ### `u:locale`
+
+Implementations MAY support this option.
 
 Replaces the _locale_ defined in the _function context_ for this _expression_.
 
@@ -66,6 +71,8 @@ or because the language tag is not well-formed,
 not valid, or some other reason.
 
 ### `u:dir`
+
+Implementations SHOULD support this option.
 
 Replaces the base directionality defined in
 the _function context_ for this _expression_

--- a/spec/u-namespace.md
+++ b/spec/u-namespace.md
@@ -12,8 +12,9 @@ manages the specification for this namespace, hence the _namespace_ `u:`.
 
 ## Options
 
-This section describes common **_<dfn>`u:` options</dfn>_** that apply
-for all _functions_ and _markup_.
+This section describes **_<dfn>`u:` options</dfn>_**.
+When implemented, they apply to all _functions_ and _markup_,
+including user-defined _functions_ in that implementation.
 
 ### `u:id`
 

--- a/spec/u-namespace.md
+++ b/spec/u-namespace.md
@@ -1,4 +1,4 @@
-# MessageFormat 2.0 Unicode Namespace
+# MessageFormat Unicode Namespace
 
 The `u:` _namespace_ is reserved for the definition of _options_
 which affect the _function context_ of the specific _expressions_
@@ -41,6 +41,10 @@ For other values, a _Bad Option_ error is emitted
 and the `u:id` option is ignored.
 
 ### `u:locale`
+
+> [!IMPORTANT]
+> This _option_ has a status of **Draft**.
+> It is proposed for inclusion in a future release and is not Stable.
 
 Implementations MAY support this option.
 

--- a/spec/u-namespace.md
+++ b/spec/u-namespace.md
@@ -25,6 +25,13 @@ A string value that is included as an `id` or other suitable value
 in the formatted parts for the _placeholder_,
 or any other structured formatted results.
 
+> For example, `u:id` could be used to distinguish
+> two otherwise matching placeholders from each other:
+>
+> ```
+> The first number was {$a :number u:id=first} and the second {$b :number u:id=second}.
+> ```
+
 Ignored when formatting a message to a string.
 
 The value of the `u:id` _option_ MUST be a _literal_ or a


### PR DESCRIPTION
This clarifies the requirement status for each `u:` option separately, as `u:id` only has an effect if the output can be something other than a single string, and concerns have been raised about `u:locale`.

I would be very happy to say that `u:id` and `u:dir` MUST be supported, if the rest of the WG agrees.

This should also clarify that an implementation might choose to support a subset of the `u:` options.