### PR TITLE
Require digit size to support values 0-99

### DIFF
--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -640,7 +640,8 @@ such as the number of fraction, integer, or significant digits.
 A "digit size option" is an _option_ value that the _function_ interprets
 as a small integer value greater than or equal to zero.
 Implementations MAY define an upper limit on the _resolved value_
-of a digit size option option consistent with that implementation's practical limits.
+of a digit size option option consistent with that implementation's practical limits,
+as long as all integer values from 0 to 99 (inclusive) are supported.
 
 In most cases, the value of a digit size option will be a string that
 encodes the value as a non-negative integer.

--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -640,7 +640,7 @@ such as the number of fraction, integer, or significant digits.
 A "digit size option" is an _option_ value that the _function_ interprets
 as a small integer value greater than or equal to zero.
 Implementations MAY define an upper limit on the _resolved value_
-of a digit size option option consistent with that implementation's practical limits,
+of a digit size option consistent with that implementation's practical limits,
 as long as all integer values from 0 to 99 (inclusive) are supported.
 
 In most cases, the value of a digit size option will be a string that


### PR DESCRIPTION
Digit size option values MAY have an implementation-defined upper limit, but let's make sure that does not exclude anything allowed by the `digit-size-option` rule for literal values.