### PR TITLE
Drop the u:locale option

### DIFF
--- a/spec/functions/string.md
+++ b/spec/functions/string.md
@@ -32,7 +32,7 @@ The function `:string` has no _options_.
 > For example:
 >
 > ```
-> {$s :string u:dir=ltr u:locale=fr-CA}
+> {$s :string u:dir=ltr}
 > ```
 
 #### Resolved Value

--- a/spec/u-namespace.md
+++ b/spec/u-namespace.md
@@ -29,42 +29,6 @@ or can be resolved to a string without error.
 For other values, a _Bad Option_ error is emitted
 and the `u:id` option is ignored.
 
-### `u:locale`
-
-Replaces the _locale_ defined in the _function context_ for this _expression_.
-
-A comma-delimited list consisting of
-well-formed [BCP 47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
-language tags,
-or an implementation-defined list of such tags.
-
-If this _option_ is set on _markup_, a _Bad Option_ error is emitted
-and the value of the `u:locale` _option_ is ignored.
-
-During processing, the `u:locale` _option_
-MUST be removed from the resolved mapping of _options_
-before calling the _function handler_.
-
-Values matching the following ABNF are always accepted:
-```abnf
-u-locale-option = unicode_bcp47_locale_id *(o "," o unicode_bcp47_locale_id)
-```
-using `unicode_bcp47_locale_id` as defined for
-[Unicode Locale Identifier](https://unicode.org/reports/tr35/tr35.html#unicode_bcp47_locale_id).
-
-Implementations MAY support additional language tags,
-such as private-use or grandfathered tags,
-or tags using `_` instead of `-` as a separator.
-When the value of `u:locale` is set by a _variable_,
-implementations MAY support non-string values otherwise representing locales.
-
-Implementations MAY emit a _Bad Option_ error
-and MAY ignore the value of the `u:locale` _option_ as a whole
-or any of the entries in the list of language tags.
-This might be because the locale specified is not supported
-or because the language tag is not well-formed,
-not valid, or some other reason.
-
 ### `u:dir`
 
 Replaces the base directionality defined in

--- a/test/tests/u-options.json
+++ b/test/tests/u-options.json
@@ -30,9 +30,9 @@
       ]
     },
     {
-      "src": "{#tag u:dir=rtl u:locale=ar}content{/ns:tag}",
+      "src": "{#tag u:dir=rtl}content{/ns:tag}",
       "exp": "content",
-      "expErrors": [{ "type": "bad-option" }, { "type": "bad-option" }],
+      "expErrors": [{ "type": "bad-option" }],
       "expParts": [
         {
           "type": "markup",
@@ -49,10 +49,6 @@
           "name": "ns:tag"
         }
       ]
-    },
-    {
-      "src": "hello {4.2 :number u:locale=fr}",
-      "exp": "hello 4,2"
     },
     {
       "src": "hello {world :string u:dir=ltr u:id=foo}",


### PR DESCRIPTION
I'm somewhat ambivalent on this myself, but filing this as a draft so that a WG decision becomes a little easier to enact.

I'd be fine leaving this out of the '47 release, as we can add it in if/once user need for it can be demonstrated.

There's a minor overlap with #1012, which should be easy to resolve.