### PR TITLE
Drop the notation, compactDisplay, & numberingSystem options

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -116,10 +116,10 @@ which makes it available for use in later _expressions_ and _markup_ _options_.
 > For example, in
 > ```
 > .input {$a :number minimumFractionDigits=3}
-> .local $b = {$a :integer notation=compact}
+> .local $b = {$a :integer useGrouping=never}
 > .match $a
 > 0 {{The value is zero.}}
-> * {{In compact form, the value {$a} is rendered as {$b}.}}
+> * {{Without grouping separators, the value {$a} is rendered as {$b}.}}
 > ```
 > the _resolved value_ bound to `$a` is used as the _operand_
 > of the `:integer` _function_ when resolving the value of the _variable_ `$b`,
@@ -991,6 +991,4 @@ The _Default Bidi Strategy_ is defined as follows:
 > Directionality SHOULD NOT be determined by introspecting
 > the character sequence in the formatted string representation
 > of `resval`.
-
-
 

--- a/spec/functions/README.md
+++ b/spec/functions/README.md
@@ -73,9 +73,6 @@ Such values can be useful to users in cases where local usage and support exists
 >   for currency amounts as the _operand_ in the _function_ `:currency`.
 > - A Java implementation might _accept_ a `java.time.chrono.Chronology` object
 >   as a value for the _date/time override option_ `calendar`
-> - ICU4J's implementation might _accept_ a `com.ibm.icu.text.NumberingSystem` object
->   instead of using a [Unicode Numbering System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
->   for the option `numberingSystem` in _functions_ such as `:number` or `:integer`.
 
 Future versions of this specification MAY define additional _options_ and _option_ values,
 subject to the rules in the [Stability Policy](#stability-policy),

--- a/spec/functions/datetime.md
+++ b/spec/functions/datetime.md
@@ -272,13 +272,11 @@ the functions `:datetime` and `:time`:
   - `true`
   - `false`
 
-The following _options_ and their values are RECOMMENDED to be available on
+The following _option_ and its values are RECOMMENDED to be available on
 the functions `:datetime`, `:date`, and `:time`.
 
 - `calendar`
   - valid [Unicode Calendar Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeCalendarIdentifier)
-- `numberingSystem`
-  - valid [Unicode Number System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
 
 The following _option_ and its values are **Proposed** for
 inclusion in the next release of this specification but have not yet been

--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -26,17 +26,6 @@ The following options and their values are REQUIRED to be available on the funct
   - `plural` (default; see [Default Value of `select` Option](#default-value-of-select-option) below)
   - `ordinal`
   - `exact`
-- `compactDisplay` (this option only has meaning when combined with the option `notation=compact`)
-  - `short` (default)
-  - `long`
-- `notation`
-  - `standard` (default)
-  - `scientific`
-  - `engineering`
-  - `compact`
-- `numberingSystem`
-  - valid [Unicode Number System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
-    (default is locale-specific)
 - `signDisplay`
   - `auto` (default)
   - `always`
@@ -87,12 +76,12 @@ with _options_ on the _expression_ taking priority over any option values of the
 > For example, the _placeholder_ in this _message_:
 >
 > ```
-> .input {$n :number notation=scientific minimumFractionDigits=2}
+> .input {$n :number minimumFractionDigits=2 signDisplay=always}
 > {{{$n :number minimumFractionDigits=1}}}
 > ```
 >
 > would be formatted with the resolved options
-> `{ notation: 'scientific', minimumFractionDigits: '1' }`.
+> `{ minimumFractionDigits: '1', signDisplay: 'always' }`.
 
 #### Resolved Value
 
@@ -132,9 +121,6 @@ The following options and their values are REQUIRED to be available on the funct
   - `plural` (default; see [Default Value of `select` Option](#default-value-of-select-option) below)
   - `ordinal`
   - `exact`
-- `numberingSystem`
-  - valid [Unicode Number System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
-    (default is locale-specific)
 - `signDisplay`
   - `auto` (default)
   - `always`
@@ -158,8 +144,6 @@ In general, these are included in the resolved option values of the _expression_
 with _options_ on the _expression_ taking priority over any option values of the _operand_.
 Option values with the following names are however discarded if included in the _operand_:
 
-- `compactDisplay`
-- `notation`
 - `minimumFractionDigits`
 - `maximumFractionDigits`
 - `minimumSignificantDigits`
@@ -355,15 +339,6 @@ The following options and their values are REQUIRED to be available on the funct
 - `currency`
   - well-formed [Unicode Currency Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeCurrencyIdentifier)
     (no default)
-- `compactDisplay` (this option only has meaning when combined with the option `notation=compact`)
-  - `short` (default)
-  - `long`
-- `notation`
-  - `standard` (default)
-  - `compact`
-- `numberingSystem`
-  - valid [Unicode Number System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
-    (default is locale-specific)
 - `currencySign`
   - `accounting`
   - `standard` (default)
@@ -492,15 +467,6 @@ unless otherwise indicated:
   - `short` (default)
   - `narrow`
   - `long`
-- `compactDisplay` (this option only has meaning when combined with the option `notation=compact`)
-  - `short` (default)
-  - `long`
-- `notation`
-  - `standard` (default)
-  - `compact`
-- `numberingSystem`
-  - valid [Unicode Number System Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeNumberSystemIdentifier)
-    (default is locale-specific)
 - `signDisplay`
   - `auto` (default)
   - `always`
@@ -783,7 +749,6 @@ representing its decimal value:
 - `minimumIntegerDigits`
 - `minimumSignificantDigits`
 - `maximumSignificantDigits`
-- `notation`
 
 ```abnf
 integer = "0" / ["-"] ("1"-"9") *DIGIT


### PR DESCRIPTION
This fixes some of the issues identified in the ICU4X TC in the doc linked from https://github.com/unicode-org/message-format-wg/issues/1006#issuecomment-2659730990 by removing the notation, compactDisplay, and numberingSystem options from all functions that currently have them.

This is not a complete solution, nor is it the one preferred by the ICU4X TC, but for at least these options it's the simplest thing we can do, and as @aphillips notes in a comment on the doc:
> Compact display strikes me as a candidate for removal to another function, since not all platforms have this feature in their low-level I18N libraries. We hived off percent. Compact display seems more optional.

The removal of `notation` and `compactDisplay` was previously considered in #664, but dismissed on [2024-02-26](https://github.com/unicode-org/message-format-wg/blob/main/meetings/2024/notes-2024-02-26.md#664).

Regarding `numberingSystem`, we should take it out for now and re-evaluate what shape its option ought to take after the '47 release. Again, quoting @aphillips:
> [Toggling between Latin and native digit shaping] is a VERY common thing to want to do. Forcing Latin doesn't require a variable, but setting native digits does with the current design, since you have to specify the script. We might provide a boolean option to turn "digit shaping" on/off to reduce the incidence of needing `numberingSystem` as an option. I would even support removing this option in favor of such a switch. If you want arbitrary digit shaping, you are doing something super-special and probably not I18N best practices.