### PR TITLE
Require select option to be set by a literal value

### DIFF
--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -658,7 +658,7 @@ or any option-specific lower limit, a _Bad Option Error_ is emitted.
 ### Number Selection
 
 The value of the `select` _option_ MUST be set by a _literal_,
-as otherwise the message might not be translatable.
+as otherwise the _message_ might not be translatable.
 If this value is set by a _variable_ or
 the option value of an implementation-defined type used as an _operand_,
 a _Bad Option Error_ is emitted and

--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -22,8 +22,8 @@ the value of other options, or both.
 
 The following options and their values are REQUIRED to be available on the function `:number`:
 
-- `select`
-  - `plural` (default; see [Default Value of `select` Option](#default-value-of-select-option) below)
+- `select` (see [Number Selection](#number-selection) below)
+  - `plural` (default)
   - `ordinal`
   - `exact`
 - `compactDisplay` (this option only has meaning when combined with the option `notation=compact`)
@@ -128,8 +128,8 @@ the value of other options, or both.
 
 The following options and their values are REQUIRED to be available on the function `:integer`:
 
-- `select`
-  - `plural` (default; see [Default Value of `select` Option](#default-value-of-select-option) below)
+- `select` (see [Number Selection](#number-selection) below)
+  - `plural` (default)
   - `ordinal`
   - `exact`
 - `numberingSystem`
@@ -656,6 +656,14 @@ or if the value exceeds any implementation-defined upper limit
 or any option-specific lower limit, a _Bad Option Error_ is emitted.
 
 ### Number Selection
+
+The value of the `select` _option_ MUST be set by a _literal_,
+as otherwise the message might not be translatable.
+If this value is set by a _variable_ or
+the option value of an implementation-defined type used as an _operand_,
+a _Bad Option Error_ is emitted and
+the _resolved value_ of the expression MUST NOT support selection.
+The formatting of the _resolved value_ is not affected by the `select` _option_.
 
 Number selection has three modes:
 

--- a/test/tests/functions/integer.json
+++ b/test/tests/functions/integer.json
@@ -36,6 +36,36 @@
     {
       "src": ".local $x = {1.25 :integer} .local $y = {$x :number} {{{$y}}}",
       "exp": "1"
+    },
+    {
+      "src": "literal select {1 :integer select=exact}",
+      "exp": "literal select {1}"
+    },
+    {
+      "src": ".local $bad = {exact} {{variable select {1 :integer select=$bad}}}",
+      "exp": "variable select {1}",
+      "expErrors": [{ "type": "bad-option" }]
+    },
+    {
+      "src": "variable select {1 :integer select=$bad}",
+      "params": [{ "name": "bad", "value": "exact" }],
+      "exp": "variable select {1}",
+      "expErrors": [{ "type": "bad-option" }]
+    },
+    {
+      "src": ".local $sel = {1 :integer select=exact} .match $sel 1 {{literal select {$sel}}} * {{OTHER}}",
+      "exp": "literal select {1}"
+    },
+    {
+      "src": ".local $sel = {1 :integer select=exact} .local $bad = {$sel :integer} .match $bad 1 {{ONE}} * {{operand select {$bad}}}",
+      "exp": "operand select {1}",
+      "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
+    },
+    {
+      "src": ".local $sel = {1 :integer select=$bad} .match $sel 1 {{ONE}} * {{variable select {$sel}}}",
+      "params": [{ "name": "bad", "value": "exact" }],
+      "exp": "variable select {1}",
+      "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
     }
   ]
 }

--- a/test/tests/functions/number.json
+++ b/test/tests/functions/number.json
@@ -186,6 +186,36 @@
       ]
     },
     {
+      "src": "literal select {1 :number select=exact}",
+      "exp": "literal select {1}"
+    },
+    {
+      "src": ".local $bad = {exact} {{variable select {1 :number select=$bad}}}",
+      "exp": "variable select {1}",
+      "expErrors": [{ "type": "bad-option" }]
+    },
+    {
+      "src": "variable select {1 :number select=$bad}",
+      "params": [{ "name": "bad", "value": "exact" }],
+      "exp": "variable select {1}",
+      "expErrors": [{ "type": "bad-option" }]
+    },
+    {
+      "src": ".local $sel = {1 :number select=exact} .match $sel 1 {{literal select {$sel}}} * {{OTHER}}",
+      "exp": "literal select {1}"
+    },
+    {
+      "src": ".local $sel = {1 :number select=exact} .local $bad = {$sel :number} .match $bad 1 {{ONE}} * {{operand select {$bad}}}",
+      "exp": "operand select {1}",
+      "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
+    },
+    {
+      "src": ".local $sel = {1 :number select=$bad} .match $sel 1 {{ONE}} * {{variable select {$sel}}}",
+      "params": [{ "name": "bad", "value": "exact" }],
+      "exp": "variable select {1}",
+      "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
+    },
+    {
       "src": "{42 :number @foo @bar=13}",
       "exp": "42",
       "expParts": [


### PR DESCRIPTION
For context, see #1006 

As pointed out by @aphillips in a comment on the ICU4X-TC feedback doc:
> [It's] nearly impossible to localize a message in which [the `select`] option is passed by reference, since tools and translators can't tell how to translate the messages or how to explode (expand/contract) the list of keywords in a given locale.

We can't really make using a variable for `select` a syntax or data model error unless we add a really special case for it in the Syntax part, but this is _nearly_ that.

Note that as shown in the test cases, formatting the following message would result in `bad-option` and `bad-selector` errors:

```
.local $sel = {1 :number select=exact}
.local $bad = {$sel :number}
.match $bad
1 {{ONE}}
* {{operand select {$bad}}}
```