### PR TITLE
Require u:locale option to be set by a literal value

### DIFF
--- a/spec/u-namespace.md
+++ b/spec/u-namespace.md
@@ -38,6 +38,11 @@ well-formed [BCP 47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
 language tags,
 or an implementation-defined list of such tags.
 
+The value of this _option_ MUST be set by a _literal_.
+If this value is set by a _variable_ or
+the option value of an implementation-defined type used as an _operand_,
+a _Bad Option Error_ is emitted and the value is ignored.
+
 If this _option_ is set on _markup_, a _Bad Option_ error is emitted
 and the value of the `u:locale` _option_ is ignored.
 

--- a/test/tests/u-options.json
+++ b/test/tests/u-options.json
@@ -55,6 +55,22 @@
       "exp": "hello 4,2"
     },
     {
+      "src": "hello {4.2 :number u:locale=$bad}",
+      "params": [{"name": "bad", "value": "fr"}],
+      "expErrors": [{ "type": "bad-option" }],
+      "exp": "hello 4.2"
+    },
+    {
+      "src": ".local $good = {4.2 :number u:locale=fr} {{hello {$good}}}",
+      "exp": "hello 4,2"
+    },
+    {
+      "src": ".local $bad = {4.2 :number u:locale=fr} {{hello {$bad :number}}}",
+      "params": [{"name": "bad", "value": "fr"}],
+      "expErrors": [{ "type": "bad-option" }],
+      "exp": "hello 4.2"
+    },
+    {
       "src": "hello {world :string u:dir=ltr u:id=foo}",
       "exp": "hello \u2066world\u2069",
       "expParts": [


### PR DESCRIPTION
This is an alternative to #1014, and requires the `u:locale` to have a literal value using similar spec language as proposed for `select` in #1016.

Filing this too as a draft, to more clearly show what this change would look like and to make it easier to adopt if we so choose.