### PR TITLE
Move note about Draft vs. Stable status to Stability Policy

### DIFF
--- a/spec/functions/README.md
+++ b/spec/functions/README.md
@@ -20,14 +20,6 @@ which are REQUIRED for conformance with this specification,
 along with _default functions_ that SHOULD be implemented to support
 additional functionality.
 
-> [!IMPORTANT]
-> _Functions_ that are not marked **Draft** are **Stable** and subject to
-> the provisions of the [stability policy](../intro.md#stability-policy).
->
-> _Functions_ or _options_ marked as **Draft** are not stable.
-> Their name, _operands_, and _options_/_values_, and other requirements
-> might change or be removed before being declared **Stable** in a future release.
-
 To **_<dfn>accept</dfn>_** a function means that an implementation MUST NOT
 emit an _Unknown Function_ error for that _function_'s _identifier_.
 To _accept_ an _option_ means that a _function handler_ MUST NOT

--- a/spec/intro.md
+++ b/spec/intro.md
@@ -94,6 +94,14 @@ Updates to this specification will not remove any _default functions_.
 Updates to this specification will not remove any _options_ or _option_ values
 defined for _default functions_.
 
+> [!IMPORTANT]
+> _Functions_ that are not marked **Draft** are **Stable** and subject to
+> the provisions of this stability policy.
+>
+> _Functions_ or _options_ marked as **Draft** are not stable.
+> Their name, _operands_, and _options_/_values_, and other requirements
+> might change or be removed before being declared **Stable** in a future release.
+
 > [!NOTE]
 > The foregoing policies are _not_ a guarantee that the results of formatting will never change.
 > Even when this specification or its implementation do not change,


### PR DESCRIPTION
With the specification of `u:locale`'s Draft status in #1012, we're now using those terms outside the Default Functions section. Correspondingly, it would probably be better to define them in the Stability Policy so it's clear what they mean for `u:locale` as well.

This PR only moves the text to a different location, hence marking it as editorial & askign for fast-tracking.