### PR TITLE
Fix term link errors

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -20,7 +20,7 @@ The formatting of a _message_ is defined by the following operations:
   Depending on the implementation, this result could be a single concatenated string,
   an array of objects, an attributed string, or some other locally appropriate data type.
 
-- **_<dfn>Expression Resolution</dfn>_** determines the value of an _expression_ or _markup_,
+- **_<dfn>Expression and Markup Resolution</dfn>_** determines the value of an _expression_ or _markup_,
   with reference to the current _formatting context_.
   This can include multiple steps,
   such as looking up the value of a variable and calling formatting functions.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -20,7 +20,7 @@ The formatting of a _message_ is defined by the following operations:
   Depending on the implementation, this result could be a single concatenated string,
   an array of objects, an attributed string, or some other locally appropriate data type.
 
-- **_<dfn>Expression and Markup Resolution</dfn>_** determines the value of an _expression_ or _markup_,
+- **_<dfn>Expression Resolution</dfn>_** determines the value of an _expression_ or _markup_,
   with reference to the current _formatting context_.
   This can include multiple steps,
   such as looking up the value of a variable and calling formatting functions.
@@ -231,7 +231,7 @@ Its _resolved value_ is defined by _literal resolution_.
 
 #### Literal Resolution
 
-The _resolved value_ of a _text_ or a _literal_ contains
+**_<dfn>Literal resolution</dfn>_** : The _resolved value_ of a _text_ or a _literal_ contains
 the character sequence of the _text_ or _literal_
 after any character escape has been converted to the escaped character.
 
@@ -261,7 +261,7 @@ whether its value was originally a _quoted literal_ or an _unquoted literal_.
 
 #### Variable Resolution
 
-To resolve the value of a _variable_,
+**_<dfn>Variable resolution</dfn>_** : To resolve the value of a _variable_,
 its _name_ is used to identify either a local variable or an input variable.
 If a _declaration_ exists for the _variable_, its _resolved value_ is used.
 Otherwise, the _variable_ is an implicit reference to an input value,
@@ -279,7 +279,7 @@ consisting of the U+0024 DOLLAR SIGN `$` followed by the _name_ of the _variable
 
 #### Function Resolution
 
-To resolve an _expression_ with a _function_,
+**_<dfn>Function resolution</dfn>_** : To resolve an _expression_ with a _function_,
 the following steps are taken:
 
 1. If the _expression_ includes an _operand_, resolve its value.

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -188,6 +188,9 @@ and different implementations MAY choose to perform different levels of resoluti
 _Expressions_ are used in _declarations_ and _patterns_.
 _Markup_ is only used in _patterns_.
 
+#### Expression Resolution
+
+**_<dfn>Expression resolution</dfn>_** determines the value of an _expression_.
 Depending on the presence or absence of a _variable_ or _literal_ operand and a _function_,
 the _resolved value_ of the _expression_ is determined as follows:
 
@@ -229,7 +232,7 @@ Its _resolved value_ is defined by _literal resolution_.
 > {{You have {42 :number}}}
 > ```
 
-#### Literal Resolution
+##### Literal Resolution
 
 **_<dfn>Literal resolution</dfn>_** : The _resolved value_ of a _text_ or a _literal_ contains
 the character sequence of the _text_ or _literal_
@@ -259,7 +262,7 @@ whether its value was originally a _quoted literal_ or an _unquoted literal_.
 > }
 > ```
 
-#### Variable Resolution
+##### Variable Resolution
 
 **_<dfn>Variable resolution</dfn>_** : To resolve the value of a _variable_,
 its _name_ is used to identify either a local variable or an input variable.
@@ -277,7 +280,7 @@ a _fallback value_ is used as the _resolved value_ of the _variable_.
 The _fallback value_ representation of a _variable_ has a string representation
 consisting of the U+0024 DOLLAR SIGN `$` followed by the _name_ of the _variable_.
 
-#### Function Resolution
+##### Function Resolution
 
 **_<dfn>Function resolution</dfn>_** : To resolve an _expression_ with a _function_,
 the following steps are taken:
@@ -338,7 +341,7 @@ the following steps are taken:
   
    In all failure cases, return a _fallback value_ as the _resolved value_ of the _expression_.
 
-##### Function Handler
+###### Function Handler
 
 A **_<dfn>function handler</dfn>_** is an implementation-defined process
 such as a function or method
@@ -370,7 +373,7 @@ and execution time SHOULD be limited.
 
 Implementation-defined _functions_ SHOULD use an implementation-defined _namespace_.
 
-##### Option Resolution
+###### Option Resolution
 
 **_<dfn>Option resolution</dfn>_** is the process of computing the _options_
 for a given _expression_. 
@@ -409,6 +412,7 @@ This mapping can be empty.
 
 #### Markup Resolution
 
+**_<dfn>Markup resolution</dfn>_** determines the value of _markup_.
 Unlike _functions_, the resolution of _markup_ is not customizable.
 
 The _resolved value_ of _markup_ includes the following fields:

--- a/spec/functions/datetime.md
+++ b/spec/functions/datetime.md
@@ -56,6 +56,8 @@ with _options_ on the _expression_ taking priority over any option values of the
 
 ###### Style Options
 
+**_<dfn>Style options</dfn>_** pertain to the overall styling or appearance of the formatted output.
+
 The function `:datetime` has these _style options_.
 
 - `dateStyle`
@@ -71,7 +73,7 @@ The function `:datetime` has these _style options_.
 
 ###### Field Options
 
-_Field options_ describe which fields to include in the formatted output
+**_<dfn>Field options</dfn>_** describe which fields to include in the formatted output
 and what format to use for that field.
 
 > [!NOTE]

--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -630,7 +630,7 @@ digit-size-option = "0" / (("1"-"9") [DIGIT])
 
 If the value of a digit size option does not evaluate as a non-negative integer,
 or if the value exceeds any implementation-defined upper limit
-or any option-specific lower limit, a _Bad Option Error_ is emitted.
+or any option-specific lower limit, a _Bad Option_ error is emitted.
 
 #### Number Selection
 

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -793,7 +793,7 @@ The _names_ are [immutable identifiers](https://www.unicode.org/reports/tr31/#Im
 An **_<dfn>identifier</dfn>_** is a character sequence that
 identifies a _function_, _markup_, or _option_.
 Each _identifier_ consists of a _name_ optionally preceeded by
-a _namespace_. 
+a **_<dfn>namespace</dfn>_**. 
 When present, the _namespace_ is separated from the _name_ by a
 U+003A COLON `:`.
 Built-in _functions_ and their _options_ do not have a _namespace_ identifier.


### PR DESCRIPTION
Fix errors in term highlighting. The missing terms are:

- annotation (not fixed, no longer used formally in the spec)
- bad-option-error (fixed here)
- error  (not fixed)
- expression-resolution (fixed here)
- field-option (fixed here)
- formatter (not fixed)
- function-resolution (fixed here)
- literal-resolution (fixed here)
- namespace (fixed here)
- option-value (not fixed)
- style-option (fixed here)
- variable-resolution (fixed here)
- whitespace (not fixed)