### PR TITLE
Define reserved and custom identifiers

### DIFF
--- a/spec/intro.md
+++ b/spec/intro.md
@@ -113,12 +113,10 @@ defined for _default functions_.
 Updates to this specification will only reserve, define, or require
 _identifiers_ which are _reserved identifiers_.
 
-All other _identifiers_ in these categories are reserved for the use of implementations or users.
-
-> [!IMPORTANT]
-> Implementation-defined or user-defined _functions_ and _function_ _options_
-> SHOULD use a _namespace_ as part of their _identifiers_
-> to help avoid collisions with other implementations.
+> [!NOTE]
+> _Custom identifiers_ are available for the use of implementations or users.
+> In addition, the use of a _namespace_ as part of _custom identifiers_
+> is recommended to help avoid collisions with other implementations.
 
 Future versions of this specification will not introduce changes
 to the data model that would result in a data model representation

--- a/spec/intro.md
+++ b/spec/intro.md
@@ -111,12 +111,7 @@ defined for _default functions_.
 > (such as due to the release of new CLDR versions).
 
 Updates to this specification will only reserve, define, or require
-_function_ _identifiers_ and _function_ _option_ _identifiers_
-which satisfy either of the following two requirements:
-- Includes no _namespace_,
-  and has a _name_ consisting of characters in the ranges a-z, A-Z, and 0-9,
-  and the characters U+002E FULL STOP `.`, U+002D HYPHEN-MINUS `-`, and U+005F LOW LINE `_`.
-- Uses a _namespace_ consisting of a single character in the ranges a-z and A-Z.
+_identifiers_ which are _reserved identifiers_.
 
 All other _identifiers_ in these categories are reserved for the use of implementations or users.
 

--- a/spec/intro.md
+++ b/spec/intro.md
@@ -113,11 +113,6 @@ defined for _default functions_.
 Updates to this specification will only reserve, define, or require
 _identifiers_ which are _reserved identifiers_.
 
-> [!NOTE]
-> _Custom identifiers_ are available for the use of implementations or users.
-> In addition, the use of a _namespace_ as part of _custom identifiers_
-> is recommended to help avoid collisions with other implementations.
-
 Future versions of this specification will not introduce changes
 to the data model that would result in a data model representation
 based on this version being invalid.

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -886,16 +886,19 @@ name-char  = name-start / DIGIT / "-" / "."
 A **_<dfn>reserved identifier</dfn>_** is one that satisfies the following conditions:
 - Includes no _namespace_ or uses a _namespace_ consisting of a single letter
   in the ranges a-z and A-Z.
-- Has a _name_ consisting only of characters in the ranges a-z, A-Z, and 0-9,
-  and the characters U+002E FULL STOP `.`, U+002D HYPHEN-MINUS `-`, and U+005F LOW LINE `_`.
+- Has a _name_ that matches the following ABNF:
+```abnf
+reserved-identifier = ALPHA *[ALPHA / DIGIT / "." / "-" / "_"]
+```
 
 A **_<dfn>custom identifier</dfn>_** is any _identifier_ that is not a _reserved identifier_.
 
-Always use a _namespace_ to identify a _function_ that is not a _default function_
-or when defining a custom _option_ for a _default function_.
-Choose a _custom identifier_ for any _functions_, _markup_, or _attributes_ not defined by this specification.
-
-_Operand_ (variable) _names_ and _option_ _names_ for custom _functions_ are encouraged to use _reserved identifiers_.
+> [!NOTE]
+> Always use a _namespace_ to identify a _function_ that is not a _default function_
+> or when defining a custom _option_ for a _default function_.
+> Choose a _custom identifier_ for any _functions_, _markup_, or _attributes_ not defined by this specification.
+>
+> _Operand_ (variable) _names_ and _option_ _names_ for custom _functions_ are encouraged to use _reserved identifiers_.
 
 The syntax allows a wide range of characters in _names_ and _identifiers_.
 Implementers and authors of _functions_ and _messages_,

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -898,7 +898,7 @@ A **_<dfn>custom identifier</dfn>_** is any _identifier_ that is not a _reserved
 > or when defining a custom _option_ for a _default function_.
 > Choose a _custom identifier_ for any _functions_, _markup_, or _attributes_ not defined by this specification.
 >
-> _Operand_ (variable) _names_ and _option_ _names_ for custom _functions_ are encouraged to use _reserved identifiers_.
+> _Variable_ _names_ and _option_ _names_ for custom _functions_ are encouraged to use _reserved identifiers_.
 
 The syntax allows a wide range of characters in _names_ and _identifiers_.
 Implementers and authors of _functions_ and _messages_,

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -894,11 +894,12 @@ reserved-identifier = ALPHA *[ALPHA / DIGIT / "." / "-" / "_"]
 A **_<dfn>custom identifier</dfn>_** is any _identifier_ that is not a _reserved identifier_.
 
 > [!NOTE]
-> Always use a _namespace_ to identify a _function_ that is not a _default function_
-> or when defining a custom _option_ for a _default function_.
 > Choose a _custom identifier_ for any _functions_, _markup_, or _attributes_ not defined by this specification.
+> Use a _namespace_ in a _custom identifier_ to identify a _function_ that is not a _default function_
+> or when defining a custom _option_ for a _default function_.
 >
-> _Variable_ _names_ and _option_ _names_ for custom _functions_ are encouraged to use _reserved identifiers_.
+> _Variable_ _names_ are encouraged to use _reserved identifiers_.
+> _Option_ _names_ for custom _functions_ are encouraged to use _reserved identifiers_.
 
 The syntax allows a wide range of characters in _names_ and _identifiers_.
 Implementers and authors of _functions_ and _messages_,

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -883,11 +883,20 @@ name-char  = name-start / DIGIT / "-" / "."
 > * Surrogate code points (`GC=Cs`)
 > * Non-Characters (`NChar`)
 
+A **_<dfn>reserved identifier</dfn>_** is one that satisfies the following conditions:
+- Includes no _namespace_ or uses a _namespace_ consisting of a single letter
+  in the ranges a-z and A-Z.
+- Has a _name_ consisting only of characters in the ranges a-z, A-Z, and 0-9,
+  and the characters U+002E FULL STOP `.`, U+002D HYPHEN-MINUS `-`, and U+005F LOW LINE `_`.
+
+A **_<dfn>custom identifier</dfn>_** is any _identifier_ that is not a _reserved identifier_.
+
 This syntax allows a wide range of characters in _names_ and _identifiers_.
 Implementers and authors of _functions_ and _messages_,
-including _functions_, _options_, and _operands_ (variable names),
+including _functions_, _options_, and _operands_ (variable names) 
+SHOULD choose _custom identifiers_ when selecting _names_ and
 SHOULD avoid creating _names_ that could produce confusion or harm usability
-by choosing names consistent with the following guidelines.
+by choosing _names_ consistent with the following guidelines.
 MessageFormat tools, such as linters, SHOULD warn when _names_ chosen by users
 violate these constraints.
 >

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -891,10 +891,13 @@ A **_<dfn>reserved identifier</dfn>_** is one that satisfies the following condi
 
 A **_<dfn>custom identifier</dfn>_** is any _identifier_ that is not a _reserved identifier_.
 
-This syntax allows a wide range of characters in _names_ and _identifiers_.
+Always use a _namespace_ to identify a _function_ that is not a _default function_
+or when defining a custom _option_ for a _default function_.
+Choose a _custom identifier_ for any _functions_, _markup_, _options_, or _attributes_ not defined by this specification.
+
+The syntax allows a wide range of characters in _names_ and _identifiers_.
 Implementers and authors of _functions_ and _messages_,
 including _functions_, _options_, and _operands_ (variable names) 
-SHOULD choose _custom identifiers_ when selecting _names_ and
 SHOULD avoid creating _names_ that could produce confusion or harm usability
 by choosing _names_ consistent with the following guidelines.
 MessageFormat tools, such as linters, SHOULD warn when _names_ chosen by users

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -902,7 +902,7 @@ A **_<dfn>custom identifier</dfn>_** is any _identifier_ that is not a _reserved
 
 The syntax allows a wide range of characters in _names_ and _identifiers_.
 Implementers and authors of _functions_ and _messages_,
-including _functions_, _options_, and _operands_ (variable names) 
+including _functions_, _options_, and _variables_,
 SHOULD avoid creating _names_ that could produce confusion or harm usability
 by choosing _names_ consistent with the following guidelines.
 MessageFormat tools, such as linters, SHOULD warn when _names_ chosen by users

--- a/spec/syntax.md
+++ b/spec/syntax.md
@@ -893,7 +893,9 @@ A **_<dfn>custom identifier</dfn>_** is any _identifier_ that is not a _reserved
 
 Always use a _namespace_ to identify a _function_ that is not a _default function_
 or when defining a custom _option_ for a _default function_.
-Choose a _custom identifier_ for any _functions_, _markup_, _options_, or _attributes_ not defined by this specification.
+Choose a _custom identifier_ for any _functions_, _markup_, or _attributes_ not defined by this specification.
+
+_Operand_ (variable) _names_ and _option_ _names_ for custom _functions_ are encouraged to use _reserved identifiers_.
 
 The syntax allows a wide range of characters in _names_ and _identifiers_.
 Implementers and authors of _functions_ and _messages_,


### PR DESCRIPTION
Moves these definitions from the stability policy into the section on identifiers in syntax.