### PR TITLE
Clarify meaning of `fails` option for test functions

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -126,7 +126,8 @@ the behaviour of calling it as the `rv` value of MatchSelectorKeys(`rv`, `keys`)
 depends on its `Input`, `DecimalPlaces` and `FailsSelect` values.
 
 - If `FailsSelect` is `true`,
-  calling the method will fail and not return any value.
+  calling the method will emit a _Message Function Error_
+  and not return any value.
 - If the `Input` is 1 and `DecimalPlaces` is 1,
   the method will return some slice of the list « `'1.0'`, `'1'` »,
   depending on whether those values are included in `keys`.
@@ -154,7 +155,8 @@ each of the above parts will be emitted separately
 rather than being concatenated into a single string.
 
 If `FailsFormat` is `true`,
-attempting to format the _placeholder_ to any formatting target will fail.
+attempting to format the _placeholder_ to any formatting target will
+emit a _Message Function Error_.
 
 ### `:test:select`
 

--- a/test/tests/fallback.json
+++ b/test/tests/fallback.json
@@ -9,6 +9,16 @@
   },
   "tests": [
     {
+      "description": "function with unquoted literal operand",
+      "src": "{42 :test:function fails=format}",
+      "exp": "{|42|}"
+    },
+    {
+      "description": "function with quoted literal operand",
+      "src": "{|C:\\\\| :test:function fails=format}",
+      "exp": "{|C:\\\\|}"
+    },
+    {
       "description": "unannotated implicit input variable",
       "src": "{$var}",
       "exp": "{$var}"

--- a/test/tests/fallback.json
+++ b/test/tests/fallback.json
@@ -9,16 +9,6 @@
   },
   "tests": [
     {
-      "description": "function with unquoted literal operand",
-      "src": "{42 :test:function fails=format}",
-      "exp": "{|42|}"
-    },
-    {
-      "description": "function with quoted literal operand",
-      "src": "{|C:\\\\| :test:function fails=format}",
-      "exp": "{|C:\\\\|}"
-    },
-    {
       "description": "unannotated implicit input variable",
       "src": "{$var}",
       "exp": "{$var}"


### PR DESCRIPTION
[The spec for `:test:function` says](https://github.com/unicode-org/message-format-wg/blob/main/test/README.md#test-functions):

"If `FailsFormat` is true, attempting to format the _placeholder_ to any formatting target will fail."

This doesn't say anything about what the output should be for `:test:function fails=format` with any operand. However, the first two tests in fallback.json impose requirements on the output. This is stronger than what the spec requires. Hence I suggest removing these tests.