### PR TITLE
Tests: fix 'literal select' tests for :number and :integer

### DIFF
--- a/test/tests/functions/integer.json
+++ b/test/tests/functions/integer.json
@@ -64,7 +64,7 @@
     {
       "src": ".local $sel = {1 :integer select=$bad} .match $sel 1 {{ONE}} * {{variable select {$sel}}}",
       "params": [{ "name": "bad", "value": "exact" }],
-      "exp": "variable select {|1|}",
+      "exp": "variable select {$sel}",
       "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
     }
   ]

--- a/test/tests/functions/integer.json
+++ b/test/tests/functions/integer.json
@@ -54,7 +54,7 @@
     },
     {
       "src": ".local $sel = {1 :integer select=exact} .match $sel 1 {{literal select {$sel}}} * {{OTHER}}",
-      "exp": "literal select {1}"
+      "exp": "literal select 1"
     },
     {
       "src": ".local $sel = {1 :integer select=exact} .local $bad = {$sel :integer} .match $bad 1 {{ONE}} * {{operand select {$bad}}}",

--- a/test/tests/functions/integer.json
+++ b/test/tests/functions/integer.json
@@ -39,7 +39,7 @@
     },
     {
       "src": "literal select {1 :integer select=exact}",
-      "exp": "literal select {1}"
+      "exp": "literal select 1"
     },
     {
       "src": ".local $bad = {exact} {{variable select {1 :integer select=$bad}}}",

--- a/test/tests/functions/integer.json
+++ b/test/tests/functions/integer.json
@@ -43,13 +43,13 @@
     },
     {
       "src": ".local $bad = {exact} {{variable select {1 :integer select=$bad}}}",
-      "exp": "variable select {1}",
+      "exp": "variable select {|1|}",
       "expErrors": [{ "type": "bad-option" }]
     },
     {
       "src": "variable select {1 :integer select=$bad}",
       "params": [{ "name": "bad", "value": "exact" }],
-      "exp": "variable select {1}",
+      "exp": "variable select {|1|}",
       "expErrors": [{ "type": "bad-option" }]
     },
     {
@@ -58,13 +58,13 @@
     },
     {
       "src": ".local $sel = {1 :integer select=exact} .local $bad = {$sel :integer} .match $bad 1 {{ONE}} * {{operand select {$bad}}}",
-      "exp": "operand select {1}",
+      "exp": "operand select {|1|}",
       "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
     },
     {
       "src": ".local $sel = {1 :integer select=$bad} .match $sel 1 {{ONE}} * {{variable select {$sel}}}",
       "params": [{ "name": "bad", "value": "exact" }],
-      "exp": "variable select {1}",
+      "exp": "variable select {|1|}",
       "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
     }
   ]

--- a/test/tests/functions/integer.json
+++ b/test/tests/functions/integer.json
@@ -58,7 +58,7 @@
     },
     {
       "src": ".local $sel = {1 :integer select=exact} .local $bad = {$sel :integer} .match $bad 1 {{ONE}} * {{operand select {$bad}}}",
-      "exp": "operand select {|1|}",
+      "exp": "operand select {$sel}",
       "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
     },
     {

--- a/test/tests/functions/number.json
+++ b/test/tests/functions/number.json
@@ -202,7 +202,7 @@
     },
     {
       "src": ".local $sel = {1 :number select=exact} .match $sel 1 {{literal select {$sel}}} * {{OTHER}}",
-      "exp": "literal select {1}"
+      "exp": "literal select 1"
     },
     {
       "src": ".local $sel = {1 :number select=exact} .local $bad = {$sel :number} .match $bad 1 {{ONE}} * {{operand select {$bad}}}",

--- a/test/tests/functions/number.json
+++ b/test/tests/functions/number.json
@@ -206,13 +206,13 @@
     },
     {
       "src": ".local $sel = {1 :number select=exact} .local $bad = {$sel :number} .match $bad 1 {{ONE}} * {{operand select {$bad}}}",
-      "exp": "operand select {|1|}",
+      "exp": "operand select {$sel}",
       "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
     },
     {
       "src": ".local $sel = {1 :number select=$bad} .match $sel 1 {{ONE}} * {{variable select {$sel}}}",
       "params": [{ "name": "bad", "value": "exact" }],
-      "exp": "variable select {|1|}",
+      "exp": "variable select {$sel}",
       "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
     },
     {

--- a/test/tests/functions/number.json
+++ b/test/tests/functions/number.json
@@ -191,13 +191,13 @@
     },
     {
       "src": ".local $bad = {exact} {{variable select {1 :number select=$bad}}}",
-      "exp": "variable select {1}",
+      "exp": "variable select {|1|}",
       "expErrors": [{ "type": "bad-option" }]
     },
     {
       "src": "variable select {1 :number select=$bad}",
       "params": [{ "name": "bad", "value": "exact" }],
-      "exp": "variable select {1}",
+      "exp": "variable select {|1|}",
       "expErrors": [{ "type": "bad-option" }]
     },
     {
@@ -206,13 +206,13 @@
     },
     {
       "src": ".local $sel = {1 :number select=exact} .local $bad = {$sel :number} .match $bad 1 {{ONE}} * {{operand select {$bad}}}",
-      "exp": "operand select {1}",
+      "exp": "operand select {|1|}",
       "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
     },
     {
       "src": ".local $sel = {1 :number select=$bad} .match $sel 1 {{ONE}} * {{variable select {$sel}}}",
       "params": [{ "name": "bad", "value": "exact" }],
-      "exp": "variable select {1}",
+      "exp": "variable select {|1|}",
       "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
     },
     {

--- a/test/tests/functions/number.json
+++ b/test/tests/functions/number.json
@@ -187,7 +187,7 @@
     },
     {
       "src": "literal select {1 :number select=exact}",
-      "exp": "literal select {1}"
+      "exp": "literal select 1"
     },
     {
       "src": ".local $bad = {exact} {{variable select {1 :number select=$bad}}}",


### PR DESCRIPTION
Unless I'm misunderstanding something, `literal select {1 :integer select=exact}` should format to `literal select 1` (with no fallback output), since `exact` is a literal.