### PR TITLE
Fix select tests to not presume fallback for formatting

### DIFF
--- a/test/tests/functions/integer.json
+++ b/test/tests/functions/integer.json
@@ -43,13 +43,13 @@
     },
     {
       "src": ".local $bad = {exact} {{variable select {1 :integer select=$bad}}}",
-      "exp": "variable select {|1|}",
+      "exp": "variable select 1",
       "expErrors": [{ "type": "bad-option" }]
     },
     {
       "src": "variable select {1 :integer select=$bad}",
       "params": [{ "name": "bad", "value": "exact" }],
-      "exp": "variable select {|1|}",
+      "exp": "variable select 1",
       "expErrors": [{ "type": "bad-option" }]
     },
     {
@@ -58,13 +58,13 @@
     },
     {
       "src": ".local $sel = {1 :integer select=exact} .local $bad = {$sel :integer} .match $bad 1 {{ONE}} * {{operand select {$bad}}}",
-      "exp": "operand select {$sel}",
+      "exp": "operand select 1",
       "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
     },
     {
       "src": ".local $sel = {1 :integer select=$bad} .match $sel 1 {{ONE}} * {{variable select {$sel}}}",
       "params": [{ "name": "bad", "value": "exact" }],
-      "exp": "variable select {$sel}",
+      "exp": "variable select 1",
       "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
     }
   ]

--- a/test/tests/functions/number.json
+++ b/test/tests/functions/number.json
@@ -290,13 +290,13 @@
     },
     {
       "src": ".local $bad = {exact} {{variable select {1 :number select=$bad}}}",
-      "exp": "variable select {|1|}",
+      "exp": "variable select 1",
       "expErrors": [{ "type": "bad-option" }]
     },
     {
       "src": "variable select {1 :number select=$bad}",
       "params": [{ "name": "bad", "value": "exact" }],
-      "exp": "variable select {|1|}",
+      "exp": "variable select 1",
       "expErrors": [{ "type": "bad-option" }]
     },
     {
@@ -305,13 +305,13 @@
     },
     {
       "src": ".local $sel = {1 :number select=exact} .local $bad = {$sel :number} .match $bad 1 {{ONE}} * {{operand select {$bad}}}",
-      "exp": "operand select {$sel}",
+      "exp": "operand select 1",
       "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
     },
     {
       "src": ".local $sel = {1 :number select=$bad} .match $sel 1 {{ONE}} * {{variable select {$sel}}}",
       "params": [{ "name": "bad", "value": "exact" }],
-      "exp": "variable select {$sel}",
+      "exp": "variable select 1",
       "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
     },
     {

--- a/test/tests/functions/number.json
+++ b/test/tests/functions/number.json
@@ -285,30 +285,36 @@
       ]
     },
     {
+      "description": "formatting with select=literal has no effect",
       "src": "literal select {1 :number select=exact}",
       "exp": "literal select 1"
     },
     {
+      "description": "select=$var with local literal value causes error but no fallback",
       "src": ".local $bad = {exact} {{variable select {1 :number select=$bad}}}",
       "exp": "variable select 1",
       "expErrors": [{ "type": "bad-option" }]
     },
     {
+      "description": "select=$var with external string value is not allowed",
       "src": "variable select {1 :number select=$bad}",
       "params": [{ "name": "bad", "value": "exact" }],
       "exp": "variable select 1",
       "expErrors": [{ "type": "bad-option" }]
     },
     {
+      "description": "select=literal works",
       "src": ".local $sel = {1 :number select=exact} .match $sel 1 {{literal select {$sel}}} * {{OTHER}}",
       "exp": "literal select 1"
     },
     {
+      "description": "having select=literal as a selector operand is not allowed",
       "src": ".local $sel = {1 :number select=exact} .local $bad = {$sel :number} .match $bad 1 {{ONE}} * {{operand select {$bad}}}",
       "exp": "operand select 1",
       "expErrors": [{ "type": "bad-option" }, { "type": "bad-selector" }]
     },
     {
+      "description": "with select=$var, * is always selected but its formatting is unaffected",
       "src": ".local $sel = {1 :number select=$bad} .match $sel 1 {{ONE}} * {{variable select {$sel}}}",
       "params": [{ "name": "bad", "value": "exact" }],
       "exp": "variable select 1",


### PR DESCRIPTION
The changes in #1046 weren't quite enough, as they don't account for this part of the spec: https://github.com/unicode-org/message-format-wg/blob/662076e128887cad9caa5502b4d4601c5c9bb231/spec/functions/number.md?plain=1#L645

That means that the formatting of a placeholder with `select=$bad` does not experience fallback, even if an error is emitted.