### PR TITLE
Add test tags, initially for u: options

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -50,6 +50,20 @@ is not included in the schema,
 as it is intended to be an umbrella category
 for implementation-specific errors.
 
+## Test Tags
+
+Some of the tests are for functionality that is not stable,
+i.e. is marked RECOMMENDED, OPTIONAL, or DRAFT.
+Tests for such features have a `tags` array attached to them
+to mark the features that they rely on.
+This may include one or more of the following:
+
+| Tag        | Feature                                               |
+| ---------- | ----------------------------------------------------- |
+| `u:dir`    | The [u:dir](../spec/u-namespace.md#udir) option       |
+| `u:id`     | The [u:id](../spec/u-namespace.md#uid) option         |
+| `u:locale` | The [u:locale](../spec/u-namespace.md#ulocale) option |
+
 ## Test Functions
 
 As the behaviour of some of the default registry _functions_
@@ -68,6 +82,7 @@ The function `:test:function` requires a [Number Operand](/spec/registry.md#numb
 #### Options
 
 The following _options_ are available on `:test:function`:
+
 - `decimalPlaces`, a _digit size option_ for which only `0` and `1` are valid values.
   - `0`
   - `1`

--- a/test/schemas/v0/tests.schema.json
+++ b/test/schemas/v0/tests.schema.json
@@ -124,6 +124,9 @@
         "params": {
           "$ref": "#/$defs/params"
         },
+        "tags": {
+          "$ref": "#/$defs/tags"
+        },
         "exp": {
           "$ref": "#/$defs/exp"
         },
@@ -154,6 +157,9 @@
         },
         "params": {
           "$ref": "#/$defs/params"
+        },
+        "tags": {
+          "$ref": "#/$defs/tags"
         },
         "exp": {
           "$ref": "#/$defs/exp"
@@ -187,6 +193,17 @@
       "type": "array",
       "items": {
         "$ref": "#/$defs/var"
+      }
+    },
+    "tags": {
+      "description": "List of features that the test relies on.",
+      "type": "array",
+      "items": {
+        "enum": [
+          "u:dir",
+          "u:id",
+          "u:locale"
+        ]
       }
     },
     "var": {

--- a/test/tests/u-options.json
+++ b/test/tests/u-options.json
@@ -8,47 +8,44 @@
   },
   "tests": [
     {
+      "tags": ["u:id"],
       "src": "{#tag u:id=x}content{/ns:tag u:id=x}",
       "exp": "content",
       "expParts": [
-        {
-          "type": "markup",
-          "kind": "open",
-          "id": "x",
-          "name": "tag"
-        },
+        { "type": "markup", "kind": "open", "id": "x", "name": "tag" },
         { "type": "text", "value": "content" },
-        {
-          "type": "markup",
-          "kind": "close",
-          "id": "x",
-          "name": "ns:tag"
-        }
+        { "type": "markup", "kind": "close", "id": "x", "name": "ns:tag" }
       ]
     },
     {
-      "src": "{#tag u:dir=rtl u:locale=ar}content{/ns:tag}",
+      "tags": ["u:dir"],
+      "src": "{#tag u:dir=rtl}content{/ns:tag}",
       "exp": "content",
-      "expErrors": [{ "type": "bad-option" }, { "type": "bad-option" }],
+      "expErrors": [{ "type": "bad-option" }],
       "expParts": [
-        {
-          "type": "markup",
-          "kind": "open",
-          "name": "tag"
-        },
+        { "type": "markup", "kind": "open", "name": "tag" },
         { "type": "text", "value": "content" },
-        {
-          "type": "markup",
-          "kind": "close",
-          "name": "ns:tag"
-        }
+        { "type": "markup", "kind": "close", "name": "ns:tag" }
       ]
     },
     {
+      "tags": ["u:locale"],
       "src": "hello {4.2 :number u:locale=fr}",
       "exp": "hello 4,2"
     },
     {
+      "tags": ["u:dir", "u:locale"],
+      "src": "{#tag u:dir=rtl u:locale=ar}content{/ns:tag}",
+      "exp": "content",
+      "expErrors": [{ "type": "bad-option" }],
+      "expParts": [
+        { "type": "markup", "kind": "open", "name": "tag" },
+        { "type": "text", "value": "content" },
+        { "type": "markup", "kind": "close", "name": "ns:tag" }
+      ]
+    },
+    {
+      "tags": ["u:dir", "u:id"],
       "src": "hello {world :string u:dir=ltr u:id=foo}",
       "exp": "hello \u2066world\u2069",
       "expParts": [
@@ -66,6 +63,7 @@
       ]
     },
     {
+      "tags": ["u:dir"],
       "src": "hello {world :string u:dir=rtl}",
       "exp": "hello \u2067world\u2069",
       "expParts": [
@@ -82,6 +80,7 @@
       ]
     },
     {
+      "tags": ["u:dir"],
       "src": "hello {world :string u:dir=auto}",
       "exp": "hello \u2068world\u2069",
       "expParts": [
@@ -97,6 +96,7 @@
       ]
     },
     {
+      "tags": ["u:dir", "u:id"],
       "src": ".local $world = {world :string u:dir=ltr u:id=foo} {{hello {$world}}}",
       "exp": "hello \u2066world\u2069",
       "expParts": [
@@ -113,16 +113,19 @@
       ]
     },
     {
+      "tags": ["u:dir"],
       "locale": "ar",
       "src": "أهلاً {بالعالم :string u:dir=rtl}",
       "exp": "أهلاً \u2067بالعالم\u2069"
     },
     {
+      "tags": ["u:dir"],
       "locale": "ar",
       "src": "أهلاً {بالعالم :string u:dir=auto}",
       "exp": "أهلاً \u2068بالعالم\u2069"
     },
     {
+      "tags": ["u:dir"],
       "locale": "ar",
       "src": "أهلاً {world :string u:dir=ltr}",
       "exp": "أهلاً \u2066world\u2069"


### PR DESCRIPTION
After #1012, the `u:locale` option has Draft status, while `u:id` and `u:dir` are RECOMMENDED. However, the tests for all three are in the same file, and indistinguishable from eahc other.

~We should for now drop the rather minimal tests for `u:locale`, and add more comprehensive tests when the status changes.~

See latest comments, as the PR now keeps the tests, but adds an array of tags to them.