### PR TITLE
In tests, use "text" rather than "literal" as the type for formatted-parts text parts

### DIFF
--- a/test/schemas/v0/tests.schema.json
+++ b/test/schemas/v0/tests.schema.json
@@ -237,7 +237,7 @@
       "items": {
         "oneOf": [
           {
-            "description": "Message literal part.",
+            "description": "Message text part.",
             "type": "object",
             "additionalProperties": false,
             "required": [
@@ -246,7 +246,7 @@
             ],
             "properties": {
               "type": {
-                "const": "literal"
+                "const": "text"
               },
               "value": {
                 "type": "string"

--- a/test/tests/syntax.json
+++ b/test/tests/syntax.json
@@ -644,7 +644,7 @@
           "name": "tag"
         },
         {
-          "type": "literal",
+          "type": "text",
           "value": "content"
         }
       ]
@@ -659,7 +659,7 @@
           "name": "ns:tag"
         },
         {
-          "type": "literal",
+          "type": "text",
           "value": "content"
         },
         {
@@ -679,7 +679,7 @@
           "name": "tag"
         },
         {
-          "type": "literal",
+          "type": "text",
           "value": "content"
         }
       ]

--- a/test/tests/u-options.json
+++ b/test/tests/u-options.json
@@ -17,10 +17,7 @@
           "id": "x",
           "name": "tag"
         },
-        {
-          "type": "literal",
-          "value": "content"
-        },
+        { "type": "text", "value": "content" },
         {
           "type": "markup",
           "kind": "close",
@@ -39,10 +36,7 @@
           "kind": "open",
           "name": "tag"
         },
-        {
-          "type": "literal",
-          "value": "content"
-        },
+        { "type": "text", "value": "content" },
         {
           "type": "markup",
           "kind": "close",
@@ -58,10 +52,7 @@
       "src": "hello {world :string u:dir=ltr u:id=foo}",
       "exp": "hello \u2066world\u2069",
       "expParts": [
-        {
-          "type": "literal",
-          "value": "hello "
-        },
+        { "type": "text", "value": "hello " },
         { "type": "bidiIsolation", "value": "\u2066" },
         {
           "type": "string",
@@ -78,7 +69,7 @@
       "src": "hello {world :string u:dir=rtl}",
       "exp": "hello \u2067world\u2069",
       "expParts": [
-        { "type": "literal", "value": "hello " },
+        { "type": "text", "value": "hello " },
         { "type": "bidiIsolation", "value": "\u2067" },
         {
           "type": "string",
@@ -94,7 +85,7 @@
       "src": "hello {world :string u:dir=auto}",
       "exp": "hello \u2068world\u2069",
       "expParts": [
-        { "type": "literal", "value": "hello " },
+        { "type": "text", "value": "hello " },
         { "type": "bidiIsolation", "value": "\u2068" },
         {
           "type": "string",
@@ -109,10 +100,7 @@
       "src": ".local $world = {world :string u:dir=ltr u:id=foo} {{hello {$world}}}",
       "exp": "hello \u2066world\u2069",
       "expParts": [
-        {
-          "type": "literal",
-          "value": "hello "
-        },
+        { "type": "text", "value": "hello " },
         { "type": "bidiIsolation", "value": "\u2066" },
         {
           "type": "string",


### PR DESCRIPTION
The test suite `expParts` should not expect message text parts to be formatted as `"literal"`, but as `"text"`. The current type is misleading, given that in our spec _literals_ are a different thing.