### PR TITLE
In test suite, drop source from non-fallback formatted parts

### DIFF
--- a/.github/workflows/validate_tests.yml
+++ b/.github/workflows/validate_tests.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - test/**
   pull_request:
-    branches: '**'
     paths:
       - test/** 
 
@@ -22,7 +21,7 @@ jobs:
         run: npm install --global ajv-cli
       - name: Validate tests using the latest schema version
         run: >
-            ajv validate --spec=draft2020
+            ajv validate --spec=draft2020 --allow-union-types
             -s $(ls -1v schemas/*/*schema.json | tail -1)
             -d 'tests/**/*.json'
         working-directory: ./test

--- a/test/schemas/v0/tests.schema.json
+++ b/test/schemas/v0/tests.schema.json
@@ -290,9 +290,6 @@
                   "close"
                 ]
               },
-              "source": {
-                "type": "string"
-              },
               "name": {
                 "type": "string"
               },
@@ -308,8 +305,7 @@
             "description": "Message expression part.",
             "type": "object",
             "required": [
-              "type",
-              "source"
+              "type"
             ],
             "not": {
               "required": [
@@ -319,9 +315,6 @@
             },
             "properties": {
               "type": {
-                "type": "string"
-              },
-              "source": {
                 "type": "string"
               },
               "locale": {
@@ -334,11 +327,7 @@
                   "properties": {
                     "type": {
                       "type": "string"
-                    },
-                    "source": {
-                      "type": "string"
-                    },
-                    "value": {}
+                    }
                   },
                   "required": [
                     "type"
@@ -346,6 +335,23 @@
                 }
               },
               "value": {}
+            }
+          },
+          {
+            "description": "Fallback part.",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "type",
+              "source"
+            ],
+            "properties": {
+              "type": {
+                "const": "fallback"
+              },
+              "source": {
+                "type": "string"
+              }
             }
           }
         ]

--- a/test/schemas/v0/tests.schema.json
+++ b/test/schemas/v0/tests.schema.json
@@ -39,6 +39,7 @@
         {
           "properties": {
             "defaultTestProperties": {
+              "type": "object",
               "required": [
                 "locale"
               ]
@@ -50,6 +51,7 @@
             "tests": {
               "type": "array",
               "items": {
+                "type": "object",
                 "required": [
                   "locale"
                 ]
@@ -64,6 +66,7 @@
         {
           "properties": {
             "defaultTestProperties": {
+              "type": "object",
               "required": [
                 "src"
               ]
@@ -75,6 +78,7 @@
             "tests": {
               "type": "array",
               "items": {
+                "type": "object",
                 "required": [
                   "src"
                 ]
@@ -307,17 +311,19 @@
             "required": [
               "type"
             ],
-            "not": {
-              "required": [
-                "parts",
-                "value"
-              ]
-            },
             "properties": {
               "type": {
-                "type": "string"
+                "enum": [
+                  "datetime",
+                  "number",
+                  "string",
+                  "test"
+                ]
               },
               "locale": {
+                "type": "string"
+              },
+              "id": {
                 "type": "string"
               },
               "parts": {
@@ -391,6 +397,7 @@
       }
     },
     "anyExp": {
+      "type": "object",
       "anyOf": [
         {
           "required": [

--- a/test/tests/bidi.json
+++ b/test/tests/bidi.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../schemas/v0/tests.schema.json",
   "scenario": "Bidi support",
   "description": "Tests for correct parsing of messages with bidirectional marks and isolates",
   "defaultTestProperties": {

--- a/test/tests/data-model-errors.json
+++ b/test/tests/data-model-errors.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "$schema": "../schemas/v0/tests.schema.json",
   "scenario": "Data model errors",
   "defaultTestProperties": {
     "locale": "en-US"

--- a/test/tests/fallback.json
+++ b/test/tests/fallback.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "$schema": "../schemas/v0/tests.schema.json",
   "scenario": "Fallback",
   "description": "Test cases for fallback behaviour.",
   "defaultTestProperties": {

--- a/test/tests/fallback.json
+++ b/test/tests/fallback.json
@@ -11,7 +11,8 @@
     {
       "description": "function with unquoted literal operand",
       "src": "{42 :test:function fails=format}",
-      "exp": "{|42|}"
+      "exp": "{|42|}",
+      "expParts": [{ "type": "fallback", "source": "|42|" }]
     },
     {
       "description": "function with quoted literal operand",
@@ -26,7 +27,8 @@
     {
       "description": "annotated implicit input variable",
       "src": "{$var :number}",
-      "exp": "{$var}"
+      "exp": "{$var}",
+      "expParts": [{ "type": "fallback", "source": "$var" }]
     },
     {
       "description": "local variable with unknown function in declaration",
@@ -46,7 +48,8 @@
     {
       "description": "function with no operand",
       "src": "{:test:undefined}",
-      "exp": "{:test:undefined}"
+      "exp": "{:test:undefined}",
+      "expParts": [{ "type": "fallback", "source": ":test:undefined" }]
     }
   ]
 }

--- a/test/tests/functions/currency.json
+++ b/test/tests/functions/currency.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "$schema": "../../schemas/v0/tests.schema.json",
   "scenario": "Currency function",
   "description": "The built-in formatter and selector for currencies.",
   "defaultTestProperties": {

--- a/test/tests/functions/date.json
+++ b/test/tests/functions/date.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "$schema": "../../schemas/v0/tests.schema.json",
   "scenario": "Date function",
   "description": "The built-in formatter for dates.",
   "defaultTestProperties": {

--- a/test/tests/functions/datetime.json
+++ b/test/tests/functions/datetime.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "$schema": "../../schemas/v0/tests.schema.json",
   "scenario": "Datetime function",
   "description": "The built-in formatter for datetimes.",
   "defaultTestProperties": {

--- a/test/tests/functions/integer.json
+++ b/test/tests/functions/integer.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "$schema": "../../schemas/v0/tests.schema.json",
   "scenario": "Integer function",
   "description": "The built-in formatter for integers.",
   "defaultTestProperties": {

--- a/test/tests/functions/math.json
+++ b/test/tests/functions/math.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "$schema": "../../schemas/v0/tests.schema.json",
   "scenario": "Math function",
   "description": "The built-in formatter and selector for addition and subtraction.",
   "defaultTestProperties": {

--- a/test/tests/functions/number.json
+++ b/test/tests/functions/number.json
@@ -326,13 +326,7 @@
       "expParts": [
         {
           "type": "number",
-          "source": "|42|",
-          "parts": [
-            {
-              "type": "integer",
-              "value": "42"
-            }
-          ]
+          "parts": [{ "type": "integer", "value": "42" }]
         }
       ]
     }

--- a/test/tests/functions/number.json
+++ b/test/tests/functions/number.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "$schema": "../../schemas/v0/tests.schema.json",
   "scenario": "Number function",
   "description": "The built-in formatter for numbers.",
   "defaultTestProperties": {

--- a/test/tests/functions/string.json
+++ b/test/tests/functions/string.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "$schema": "../../schemas/v0/tests.schema.json",
   "scenario": "String function",
   "description": "The built-in formatter for strings.",
   "defaultTestProperties": {

--- a/test/tests/functions/time.json
+++ b/test/tests/functions/time.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "$schema": "../../schemas/v0/tests.schema.json",
   "scenario": "Time function",
   "description": "The built-in formatter for times.",
   "defaultTestProperties": {

--- a/test/tests/pattern-selection.json
+++ b/test/tests/pattern-selection.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "$schema": "../schemas/v0/tests.schema.json",
   "scenario": "Pattern selection",
   "description": "Tests for pattern selection",
   "defaultTestProperties": {

--- a/test/tests/syntax-errors.json
+++ b/test/tests/syntax-errors.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "$schema": "../schemas/v0/tests.schema.json",
   "scenario": "Syntax errors",
   "description": "Strings that produce syntax errors when parsed.",
   "defaultTestProperties": {

--- a/test/tests/syntax.json
+++ b/test/tests/syntax.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "$schema": "../schemas/v0/tests.schema.json",
   "scenario": "Syntax",
   "description": "Test cases that do not depend on any registry definitions.",
   "defaultTestProperties": {

--- a/test/tests/syntax.json
+++ b/test/tests/syntax.json
@@ -412,13 +412,7 @@
       "description": "... attribute -> \"@\" identifier s \"=\" s quoted-literal ...",
       "src": "{42 @foo=|bar|}",
       "exp": "42",
-      "expParts": [
-        {
-          "type": "string",
-          "source": "|42|",
-          "value": "42"
-        }
-      ]
+      "expParts": [{ "type": "string", "value": "42" }]
     },
     {
       "description": "... quoted-literal",
@@ -722,13 +716,7 @@
     {
       "src": "{42 @foo @bar=13}",
       "exp": "42",
-      "expParts": [
-        {
-          "type": "string",
-          "source": "|42|",
-          "value": "42"
-        }
-      ]
+      "expParts": [{ "type": "string", "value": "42" }]
     },
     {
       "src": "{{trailing whitespace}} \n",

--- a/test/tests/u-options.json
+++ b/test/tests/u-options.json
@@ -54,13 +54,7 @@
       "expParts": [
         { "type": "text", "value": "hello " },
         { "type": "bidiIsolation", "value": "\u2066" },
-        {
-          "type": "string",
-          "source": "|world|",
-          "dir": "ltr",
-          "id": "foo",
-          "value": "world"
-        },
+        { "type": "string", "dir": "ltr", "id": "foo", "value": "world" },
         { "type": "bidiIsolation", "value": "\u2069" }
 
       ]
@@ -71,13 +65,7 @@
       "expParts": [
         { "type": "text", "value": "hello " },
         { "type": "bidiIsolation", "value": "\u2067" },
-        {
-          "type": "string",
-          "source": "|world|",
-          "dir": "rtl",
-          "locale": "en-US",
-          "value": "world"
-        },
+        { "type": "string", "dir": "rtl", "locale": "en-US", "value": "world" },
         { "type": "bidiIsolation", "value": "\u2069" }
       ]
     },
@@ -89,7 +77,6 @@
         { "type": "bidiIsolation", "value": "\u2068" },
         {
           "type": "string",
-          "source": "|world|",
           "locale": "en-US",
           "value": "world"
         },
@@ -102,13 +89,7 @@
       "expParts": [
         { "type": "text", "value": "hello " },
         { "type": "bidiIsolation", "value": "\u2066" },
-        {
-          "type": "string",
-          "source": "|world|",
-          "dir": "ltr",
-          "id": "foo",
-          "value": "world"
-        },
+        { "type": "string", "dir": "ltr", "id": "foo", "value": "world" },
         { "type": "bidiIsolation", "value": "\u2069" }
       ]
     },

--- a/test/tests/u-options.json
+++ b/test/tests/u-options.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "$schema": "../schemas/v0/tests.schema.json",
   "scenario": "u: Options",
   "description": "Common options affecting the function context",
   "defaultTestProperties": {


### PR DESCRIPTION
While reviewing the messageformat.dev documentation, I started to re-think the `source` value that's currently included in formatted parts.

I think we should drop it, as it makes a part of what ought to be considered implementation details into a public API (such as the name of a message variable or function). If a user does have a need to identify a specific part in the output, that ought to be explicit, and it's what we have `u:id` for.

For markup in particular it adds no value, as the `source` value is constructable from the `name` and the `kind`.

CC @ryzokuken