### PR TITLE
Make the Default Bidi Strategy required and default

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -939,8 +939,8 @@ The **_<dfn>Default Bidi Strategy<dfn>_** is a _bidirectional isolation strategy
 isolating Unicode control characters around _placeholder_'s formatted values.
 It is primarily intended for use in plain-text strings, where markup or other mechanisms
 are not available.
-Implementations MUST implement the _Default Bidi Strategy_ as the default
-_bidirectional isolation strategy_.
+The _Default Bidi Strategy_ MUST be the default _bidirectional isolation strategy_
+when formatting a _message_ as a single string.
 
 Implementations MAY provide other _bidirectional isolation strategies_.
 

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -939,8 +939,8 @@ The **_<dfn>Default Bidi Strategy<dfn>_** is a _bidirectional isolation strategy
 isolating Unicode control characters around _placeholder_'s formatted values.
 It is primarily intended for use in plain-text strings, where markup or other mechanisms
 are not available.
-Implementations MUST provide the _Default Bidi Strategy_ as one of the 
-_bidirectional isolation strategies_.
+Implementations MUST implement the _Default Bidi Strategy_ as the default
+_bidirectional isolation strategy_.
 
 Implementations MAY provide other _bidirectional isolation strategies_.
 


### PR DESCRIPTION
Fix #997 

The working group resolved that in v48 we would make the Default Bidi Isolation Strategy not just required but also the default.