### PR TITLE
Semantic skeletons design

### DIFF
--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -129,22 +129,32 @@ I should trust that the placeholder will produce appropriate results for my lang
 
 _What properties does the solution have to manifest to enable the use-cases above?_
 
-1. It should be possible to format operands consisting of common incremental time types
-   (e.g. milliseconds since epoch times such as `java.util.Date`, `time_t`, JS `Date`, etc.)
-2. It should be possible to format operands consisting of field-based time types
-   (e.g. those that contain seperate values per field type in a date/time, such as a year-month)
-3. It should be possible to format [floating time](https://www.w3.org/TR/timezone/#dfn-floating-time) values
-   (e.g. those that are not tied to a specific time zone, variously called local/plain/civil times)
-4. Date/time formatters should not permit users to format fields that don't exist in the value
+1. It should be possible to format operands consisting of locally-relevant date/time types, including:
+   - Temporal values such as `java.time` or JS `Temporal` values,
+   - incremental time types ("timestamps")
+     (e.g. milliseconds since epoch times such as `java.util.Date`, `time_t`, JS `Date`, etc.),
+   - field-based time types
+     (e.g. those that contain seperate values per field type in a date/time, such as a year-month),
+   - [floating time](https://www.w3.org/TR/timezone/#dfn-floating-time) values
+     (e.g. those that are not tied to a specific time zone, variously called local/plain/civil times),
+   -  or other local exotica (Java `Calendar`, C `tm` struct, etc.)
+1. Date/time formatters should not permit users to format fields that don't exist in the value
    (e.g. the "month" of a time, the "hour" of a date)
-5. Date/time formatters should not permit users to format bad combinations of fields
+1. Date/time formatters should not permit users to format bad combinations of fields
    (e.g. `MMMMmm` (month-minute), `yyyyjm` (year-hour-minute), etc.)
-6. Date/time formatters should permit users to control or influence the width of indvidual fields
-   in a manner similar to classical skeletons
-   (e.g. `yMMd` vs. `yMMMd` vs. `yMMMMd` => 04/06/2025 vs. Apr 6, 2025 vs. April 6, 2025)
-7. Developers, translators, and UI designers should only have to learn a single "microsyntax" or set of options for date formatting.
-   Such a syntax or option set should be easy to understand only from the placeholder.
-   Such a syntax or option set should not require translators to alter the values in most or all locales.
+1. Date/time formatters should permit users to specify the desired width of indvidual fields
+   in a manner similar to classical skeletons,
+   while relying on locale data to prevent undesirable results.
+   For example:
+   | Classical Skeleton | `en-US` Output | 
+   |---|---|
+   | `yMd` | 04/06/2025 |
+   | `yMMMd` | Apr 6, 2025 |
+   | `yMMMMd` | April 6, 2025 |
+1. Developers, translators, and UI designers should not have to learn
+   multiple new microsyntaxes or multiple different sets of options for date/time value formatting.
+1. Any microsyntax or option set specified should be easy to understand only from the placeholder.
+1. Any microsyntax or option set specified should not _require_ translators to alter the values in most or all locales.
 
 ## Constraints
 

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -139,9 +139,10 @@ such as `java.text.SimpleDateFormat`.
 This section considers some potential arguments against the design
 or captures frequently asked questions about it.
 
-**What if semantic skeletons doesn't support the format I want?
-Unlike picture strings or classical skeletons, semantic skeletons do not allow unrestricted
-composition of date/time formats.**
+**What if semantic skeletons don't support the format I want?**
+
+Unlike picture strings or classical skeletons,
+semantic skeletons do not allow unrestricted composition of date/time formats.
 
 If there were an overlooked format, it could be added in a future release.
 However, the designers of semantic skeletons have considered the breadth of use cases.

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -30,11 +30,10 @@ Previously, ICU MessageFormat provided support for "classical skeletons",
 using a microsyntax derived from familiar 'picture strings' (see below)
 combined with code in ICU (`DateTimePatternGenerator`) to produce the desired date/time value format.
 
-`Intl.DateTimeFormat` provided options to provide a similar capability.
-These weren't "skeletons" from the point of view that they didn't use a dedicated microsyntax
-similar to 'picture strings',
-but the effect was the same:
-users specified which fields they wanted with which display options (such as width).
+`Intl.DateTimeFormat` provides options that provide a similar capability.
+These aren't "skeletons" from the point of view that they don't use a dedicated microsyntax similar to 'picture strings',
+but the effect is the same:
+users specify which fields they want with which display options (such as width).
 For example:
 ```javascript
 options = {

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -11,7 +11,7 @@ Status: **Proposed**
 		<dt>First proposed</dt>
 		<dd>2024-04-06</dd>
 		<dt>Pull Requests</dt>
-		<dd>#000</dd>
+		<dd><a href="https://github.com/unicode-org/message-format-wg/pull/1067">#1067</a></dd>
 	</dl>
 </details>
 

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -68,7 +68,7 @@ Many date/time formatting regimes provide for "picture strings".
 A "picture string" is a pattern using a microsyntax in which the user (developer, translator, UX designer)
 exactly specifies the desired format of the date/time value.
 In a picture string, separators, spaces, and other formatting are explicitly specified.
-This provides a lot of power to the devleoper or user experience designer, in terms of specifying formatting.
+This provides a lot of power to the developer or user experience designer, in terms of specifying formatting.
 For example: `MMM dd, yyyy` or `yyyy-dd-MM'T'HH:mm:ss`
   
 Picture strings require translators to interact with and "translate" the picture string

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -280,6 +280,21 @@ what is the format?
 - `Jan 1, 1970, 12:00:00 AM UTC` (value wins; user cannot adjust)
 - `Jan 1, 1970, 2:00:00 AM EET` (option wins; inconsistent with some Temporal behaviors on Java and JS)
 
+### Inflection
+
+```
+new Intl.DateTimeFormat('fi', { month: 'long' }).format()
+// 'toukokuu'
+
+new Intl.DateTimeFormat('fi', { day: 'numeric', month: 'long' }).format()
+// '2. toukokuuta'
+```
+
+As a developer, I need the formatted values to inflect fields and formats correctly,
+depending on the combination chosen for display.
+For example, as shown above, 
+I want the month name to be inflected for standalone when used by itself,
+but properly inflected when used in a month-day combination.
 
 ## Requirements
 
@@ -407,7 +422,8 @@ Such a list might look like:
 
 - Standalone fields
   - `:day`, `:weekday`, `:month`, `:year`, `:hour`, `:minute`, `:second`, `:zone`, `:era`
-  - plus the common combo `:time` and `:date`
+- Common combinations
+  - `:time` and `:date`
 - Date Field Sets
   - `:day-weekday`, `:month-day`, `:month-day-weekday`, `:year-month-day`, `:year-month-day-weekday`
 - Composite field sets

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -34,7 +34,7 @@ combined with code in ICU (`DateTimePatternGenerator`) to produce the desired da
 These weren't "skeletons" from the point of view that they didn't use a dedicated microsyntax
 similar to 'picture strings',
 but the effect was the same:
-user's specified which fields they wanted with which display options (such as width).
+users specified which fields they wanted with which display options (such as width).
 For example:
 ```javascript
 options = {

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -169,11 +169,12 @@ such as "11 PM April" (`jjMMMM` or `HHaMMMM`) or "2 2025" (`dyyyy`).
 
 **What about specialized formats, such as ISO8601?**
 
-These should be provided via other means that requiring a specialized pattern 
-and the (optional) `@locale` attribute. Do you really want to support this,
+These should be provided via other means than requiring a specialized pattern 
+and the (optional) `u:locale` option.
+Do you really want to support this,
 given that it can then be used for other things:
 ```
-{$now :datetime pattern=|yyyy-MM-dd'T'HH:mm:ss.sssz| @locale=und timezone=UTC}
+{$now :datetime pattern=|yyyy-MM-dd'T'HH:mm:ss.sssz| u:locale=und timezone=UTC}
 ```
 
 **What do we call a [floating time value](https://www.w3.org/TR/timezone/#dfn-floating-time)?**

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -380,7 +380,7 @@ _Pros_
 _Cons_
 - Not fully type-safe.
 
-#### Use separate semantic functions
+#### Use separate typed functions
 
 `:date`, `:time`, `:datetime`, `:zoneddatetime`, *maybe* `:zoneddate`, `:zonedtime`, `:timezone`
 
@@ -395,7 +395,45 @@ _Pros_
 - Better at documenting the message author's intention
 
 _Cons_
-- _Lots_ of functions
+- More functions
+
+
+#### Use separate skeleton functions
+
+Define functions according to the available "field sets" or fields in the semantic skeletons spec.
+Use options to handle field widths.
+Such a list might look like:
+
+- Standalone fields
+  - `:day`, `:weekday`, `:month`, `:year`, `:hour`, `:minute`, `:second`, `:zone`, `:era`
+  - plus the common combo `:time` and `:date`
+- Date Field Sets
+  - `:day-weekday`, `:month-day`, `:month-day-weekday`, `:year-month-day`, `:year-month-day-weekday`
+- Composite field sets
+  - `:date-zone`, `:date-time-zone`, `:time-zone` (note: `time-zone` is two fields, not "timezone")
+
+Examples:
+```
+Your package arrived on {$d :date} at {$d :time}.
+    Your package arrived on Apr 27, 2025 at 10:50 AM.
+Your package arrived on {$d :month-day-weekday} at {$d :time-zone}.
+    Your package arrived on Sunday, April 27th at 10:50 AM PDT.
+Your package arrived on {$d :month-day-weekday month=medium weekday=full} at {$d :time-zone display=full zone=short}.
+    Your package arrive on Sunday, Apr 27th at 10:50 PDT.
+```
+
+
+_Pros_
+- Options focused on field widths
+- Self-documenting: obvious what fields are shown
+- Reserves options for field width
+
+_Cons_
+- _Nineteen_ (or so) functions
+- Names appear generative, but aren't actually
+- Options might be baroque. Some option values might not be compatible with one another.
+  - Expression-wide options (short/medium/long/full) and field-level options might both be needed together
+
 
 ---
 

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -31,7 +31,35 @@ Advantages of semantic skeletons over classical skeletons:
 
 Advantages of semantic skeletons over other mechanisms:
 
-- Unlike "picture strings" (`MMM dd, yyyy`), does not require translation
+- Unlike "picture strings" (`MMM dd, yyyy`), skeletons do not require translation.
+  Many date/time formatting regimes provide for "picture strings", which are patterns that
+  exactly match the expected format of the output.
+  In a picture string, separators, spaces, and other formatting are explicitly specified.
+  This provides a lot of power to the devleoper or user experience designer, in terms of specifying formatting.
+  However, this means that the translator has to modify the string to get localized output.
+  For example, here are some picture strings with their output vs. the skeleton `MMMddyyyy`:
+```
+en-US
+MMM dd, yyyy=Apr 21, 2025
+dd MMM, yyyy=21 Apr, 2025
+MM/dd/yyyy=04/21/2025
+dd-MM-yyyy=21-04-2025
+Apr 21, 2025
+---
+fr-FR
+MMM dd, yyyy=avr. 21, 2025
+dd MMM, yyyy=21 avr., 2025
+MM/dd/yyyy=04/21/2025
+dd-MM-yyyy=21-04-2025
+21 avr. 2025
+---
+ja-JP
+MMM dd, yyyy=4月 21, 2025
+dd MMM, yyyy=21 4月, 2025
+MM/dd/yyyy=04/21/2025
+dd-MM-yyyy=21-04-2025
+2025年4月21日
+```
 
 
 ## Background

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -296,8 +296,8 @@ They should not have to coerce or convert normal date/time types in order to do 
    - [floating time](https://www.w3.org/TR/timezone/#dfn-floating-time) values
      (e.g. those that are not tied to a specific time zone, variously called local/plain/civil times),
    -  or other local exotica (Java `Calendar`, C `tm` struct, etc.)
-1. Date/time formatters should not permit users to format fields that don't exist in the value
-   (e.g. the "month" of a time, the "hour" of a date)
+1. Date/time formatter options should be able to impose restrictions on acceptable values,
+   such as formatting a month requiring a date, and formatting an hour requiring a time.
 1. Date/time formatters should not permit users to format bad combinations of fields
    (e.g. `MMMMmm` (month-minute), `yyyyjm` (year-hour-minute), etc.)
 1. Date/time formatters should permit users to specify the desired width of indvidual fields

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -62,14 +62,15 @@ Advantages of semantic skeletons over classical skeletons:
 
 #### Avoid 'picture strings'
 
-The MFWG early on considered including support for "picture strings" in the formatting of date/time values.
-There is a Working Group consensus **_not_** to support picture strings in Unicode MessageFormat, if possible.
 Many date/time formatting regimes provide for "picture strings".
 A "picture string" is a pattern using a microsyntax in which the user (developer, translator, UX designer)
 exactly specifies the desired format of the date/time value.
 In a picture string, separators, spaces, and other formatting are explicitly specified.
 This provides a lot of power to the developer or user experience designer, in terms of specifying formatting.
 For example: `MMM dd, yyyy` or `yyyy-dd-MM'T'HH:mm:ss`
+
+The MFWG early on considered including support for "picture strings" in the formatting of date/time values.
+There is a Working Group consensus **_not_** to support picture strings in Unicode MessageFormat, if possible.
   
 Picture strings require translators to interact with and "translate" the picture string
 which is embedded into the _placeholder_ in order to get appropriately localized output.

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -321,6 +321,72 @@ use calendar and time zone information to compute the displayed field.
 Users of these kinds of date/time values sometime can need access to calendar, time zone, and possibly offset controls
 in order to achieve effects similar to what temporal types provide.
 
+### Dealing with Field Widths
+
+The current design of date/time functions includes "option bags" derived from `Intl.DateTimeFormat`.
+These option bags serve as both classical skeletons _and_ as a source for field width.
+The current options are specified as:
+
+- `weekday`
+  - `long`
+  - `short`
+  - `narrow`
+- `era`
+  - `long`
+  - `short`
+  - `narrow`
+- `year`
+  - `numeric`
+  - `2-digit`
+- `month`
+  - `numeric`
+  - `2-digit`
+  - `long`
+  - `short`
+  - `narrow`
+- `day`
+  - `numeric`
+  - `2-digit`
+- `hour`
+  - `numeric`
+  - `2-digit`
+- `minute`
+  - `numeric`
+  - `2-digit`
+- `second`
+  - `numeric`
+  - `2-digit`
+- `fractionalSecondDigits`
+  - `1`
+  - `2`
+  - `3`
+- `timeZoneName`
+  - `long`
+  - `short`
+  - `shortOffset`
+  - `longOffset`
+  - `shortGeneric`
+  - `longGeneric`
+
+Notice that each of these options is specifically about field width or presentation.
+The "skeleton" functionality in `Intl` is based on the idea that only the fields mentioned are formatted.
+If a separate option specifies which fields to use,
+then the above options could be used independently to control field presentation.
+
+> Examples.
+> ```
+> {{{$d :datetime fields=YMDE month=short} prints Wednesday, Jun 4, 2025}}
+> {{{$d :datetime fields=YMDE month=short weekday=short} prints Wed, Jun 4, 2025}}
+> {{{$d :datetime fields=T timePrecision=minutes} prints 9:53 AM}}
+> {{{$d :datetime fields=T timePrecision=seconds hour=2-digit} prints 09:53:00 AM}}
+> {{{$d :datetime fields=T timePrecision=fractionalSeconds hour=2-digit fractionalSecondDigits=2} prints 09:53:00.17 AM}}
+> ```
+
+In the above design, it would be an error to specify a field width for a field that is not in the skeleton:
+```
+{{{$d :datetime fields=T month=short} is an error.}}
+```
+
 ## Requirements
 
 _What properties does the solution have to manifest to enable the use-cases above?_
@@ -432,6 +498,15 @@ For example:
 {$date :datetime time=second}           ⇒  11:39:00 AM
 ```
 
+Pros:
+- Reduces the number of skeleton strings and associated alphabet soup
+  for message authors (developers, translators) to memorize
+
+Cons:
+- Different mechanism from that used for the date portion.
+  Greater learning curve/cognitive burden for users?
+
+
 ### Design: Use Separate Functions
 
 Some choices:
@@ -505,7 +580,7 @@ _Pros_
 - Reserves options for field width
 
 _Cons_
-- _Nineteen_ (or so) functions
+- _Eighteen_ (or so) functions
 - Names appear generative, but aren't actually
 - Options might be baroque. Some option values might not be compatible with one another.
   - Expression-wide options (short/medium/long/full) and field-level options might both be needed together
@@ -520,6 +595,5 @@ _Cons_
   >```
 
 ---
-
 
 

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -29,11 +29,20 @@ Advantages of semantic skeletons over classical skeletons:
 - Allows for a more clear, ergonomic API
 - More future-proof since CLDR recently added them (??)
 
+Advantages of semantic skeletons over other mechanisms:
+
+- Unlike "picture strings" (`MMM dd, yyyy`), does not require translation
 
 
 ## Background
 
 _What context is helpful to understand this proposal?_
+
+Links:
+- [Semantic Skeletons Specification](https://unicode.org/reports/tr35/tr35-dates.html#Semantic_Skeletons)
+- [ICU4X Field Set Enum \(strongly typed\)](https://unicode-org.github.io/icu4x/rustdoc/icu/datetime/fieldsets/enums/enum.CompositeFieldSet.html)
+- [ICU4X Field Set Builder \(more JS-like\)](https://unicode-org.github.io/icu4x/rustdoc/icu/datetime/fieldsets/builder/struct.FieldSetBuilder.html)
+
 
 Semantic skeletons are not the first attempt to provide this functionality.
 Previous skeleton mechanisms used 

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -506,6 +506,27 @@ Cons:
 - Different mechanism from that used for the date portion.
   Greater learning curve/cognitive burden for users?
 
+#### Mixing the Above Solutions
+
+Use `dateFields`, `timePrecisions` and `zoneStyle` to separately control the date, time, and zone
+portions of a placeholder.
+
+> A date formatter
+>```
+> {$d :datetime dateFields=YMD}
+>```
+> A time formatter
+>```
+> {$d :datetime timePrecision=minute}
+>```
+> A datetime formatter
+>```
+> {$d :datetime dateFields=YMD timePrecision=minute}
+>```
+> A zoned datetime formatter
+>```
+> {$d :datetime dateFields=YMD timePrecision=minute zoneStyle=generic}
+>```
 
 ### Design: Use Separate Functions
 

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -37,31 +37,23 @@ Advantages of semantic skeletons over other mechanisms:
   In a picture string, separators, spaces, and other formatting are explicitly specified.
   This provides a lot of power to the devleoper or user experience designer, in terms of specifying formatting.
   However, this means that the translator has to modify the string to get localized output.
-  For example, here are some picture strings with their output vs. the skeleton `MMMddyyyy`:
-```
-en-US
-MMM dd, yyyy=Apr 21, 2025
-dd MMM, yyyy=21 Apr, 2025
-MM/dd/yyyy=04/21/2025
-dd-MM-yyyy=21-04-2025
-Apr 21, 2025
----
-fr-FR
-MMM dd, yyyy=avr. 21, 2025
-dd MMM, yyyy=21 avr., 2025
-MM/dd/yyyy=04/21/2025
-dd-MM-yyyy=21-04-2025
-21 avr. 2025
----
-ja-JP
-MMM dd, yyyy=4月 21, 2025
-dd MMM, yyyy=21 4月, 2025
-MM/dd/yyyy=04/21/2025
-dd-MM-yyyy=21-04-2025
-2025年4月21日
-```
+  For example, here are some picture strings with their output vs. common skeletons:
 
-
+| Picture String | Locale | Output | Skeleton yMMMd | Skeleton yMMd |
+|---|---|---|---|---|
+|MMM dd, yyyy| en-US | Apr 22, 2025| Apr 22, 2025| 04/22/2025|
+| | fr-FR | avr. 22, 2025| 22 avr. 2025| 22/04/2025|
+| | ja-JP | 4月 22, 2025| 2025年4月22日| 2025/04/22|
+|dd MMM, yyyy| en-US | 22 Apr, 2025| Apr 22, 2025| 04/22/2025|
+| | fr-FR | 22 avr., 2025| 22 avr. 2025| 22/04/2025|
+| | ja-JP | 22 4月, 2025| 2025年4月22日| 2025/04/22|
+|MM/dd/yyyy| en-US | 04/22/2025| Apr 22, 2025| 04/22/2025|
+| | fr-FR | 04/22/2025| 22 avr. 2025| 22/04/2025|
+| | ja-JP | 04/22/2025| 2025年4月22日| 2025/04/22|
+|dd-MM-yyyy| en-US | 22-04-2025| Apr 22, 2025| 04/22/2025|
+| | fr-FR | 22-04-2025| 22 avr. 2025| 22/04/2025|
+| | ja-JP | 22-04-2025| 2025年4月22日| 2025/04/22|
+  
 ## Background
 
 _What context is helpful to understand this proposal?_

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -31,6 +31,10 @@ using a microsyntax derived from familiar 'picture strings' (see below)
 combined with code in ICU (`DateTimePatternGenerator`) to produce the desired date/time value format.
 
 `Intl.DateTimeFormat` provided options to provide a similar capability.
+These weren't "skeletons" from the point of view that they didn't use a dedicated microsyntax
+similar to 'picture strings',
+but the effect was the same:
+user's specified which fields they wanted with which display options (such as width).
 For example:
 ```javascript
 options = {
@@ -129,6 +133,47 @@ arranging the specified fields in the correct order,
 selecting locale-appropriate separators,
 and producing a "picture string" that can be consumed by date/time formatters
 such as `java.text.SimpleDateFormat`.
+
+### FAQ
+
+This section considers some potential arguments against the design
+or captures frequently asked questions about it.
+
+**What if semantic skeletons doesn't support the format I want?
+Unlike picture strings or classical skeletons, semantic skeletons do not allow unrestricted
+composition of date/time formats.**
+
+If there were an overlooked format, it could be added in a future release.
+However, the designers of semantic skeletons have considered the breadth of use cases.
+If a skeleton is not available, there is probably a good reason for avoiding it.
+
+**My UX designer wants to specify different separators/presentational details.
+I could do that with picture strings, but not with any kind of skeleton. Help!**
+
+Specialized formats might be constructed using individual fields or by using formatToParts.
+In general, such specialized designs rapidly become examples of poor internationalization,
+since examples of such adjustments do not consider the breadth of date/time representation.
+
+**Semantic skeletons are too new. 
+Implementation experience is limited.
+Shouldn't we wait to adopt them?**
+
+Unicode MessageFormat has a one-time opportunity to avoid "deprecated at birth" date/time formatting
+and to provide a robust, internally-consistent mechanism that guides users away from
+common date/time formatting pitfalls.
+
+This is already ample experience with classical skeletons.
+The difference with semantic skeletons is that it filters out "mistakes"
+such as "11 PM April" (`jjMMMM` or `HHaMMMM`) or "2 2025" (`dyyyy`).
+
+**What about specialized formats, such as ISO8601?**
+
+These should be provided via other means that requiring a specialized pattern 
+and the (optional) `@locale` attribute. Do you really want to support this,
+given that it can then be used for other things:
+```
+{$now :datetime pattern=|yyyy-MM-dd'T'HH:mm:ss.sssz| @locale=und timezone=UTC}
+```
 
 ## Use-Cases
 

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -314,7 +314,7 @@ They should not have to coerce or convert normal date/time types in order to do 
    multiple new microsyntaxes or multiple different sets of options for date/time value formatting.
 1. Any microsyntax or option set specified should be easy to understand only from the expression.
 1. Any microsyntax or option set specified should not _require_ translators to alter the values in most or all locales.
-1. User's should be able to specify the time zone or local time offset used in formatting
+1. Users should be able to specify the time zone or local time offset used in formatting
    an incremental or timestamp value
    because many date/time formatting processes are
    running in a different environment/offset/zone from where the value will be seen

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -81,7 +81,9 @@ Unlike "picture strings", skeletons (classical or semantic) do not require the t
 developer to alter them for each locale or to know about the specifics, 
 such as spaces or separators in each locale.
   
-Here are some picture strings with their output vs. common skeletons:
+Here are some picture strings with their output vs. common skeletons,
+showing how picture strings produce poorly localized output
+while skeletons produce localized output:
 
 | Picture String | Locale | Output | Skeleton yMMMd | Skeleton yMMd |
 |---|---|---|---|---|

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -19,8 +19,22 @@ Status: **Proposed**
 
 _What is this proposal trying to achieve?_
 
+### Provide support for formatting date/time values using semantic skeletons
+
 "Semantic skeletons" are a method introduced in CLDR 46 for programmatically selecting a datetime pattern for formatting. 
 There is a fixed set of acceptable semantic skeletons.
+
+Previously, ICU MessageFormat provided support for "classical skeletons",
+using a microsyntax derived from familiar picture strings (see below)
+combined with code in ICU (`DateTimePatternGenerator`) to produce the desired date/time value format.
+`Intl.DateTimeFormat` uses "option bags" to provide a similar capability.
+A classical skeleton allowed users to express the desired fields and field widths in a formatted date/time value.
+The runtime uses locale data to determine minutiae such as 
+field-order, 
+separators, 
+spacing, 
+field-length, 
+etc. to produce the desired output.
 
 Advantages of semantic skeletons over classical skeletons:
 
@@ -29,15 +43,29 @@ Advantages of semantic skeletons over classical skeletons:
 - Allows for a more clear, ergonomic API
 - More future-proof since CLDR recently added them (??)
 
-Advantages of semantic skeletons over other mechanisms:
 
-- Unlike "picture strings" (`MMM dd, yyyy`), skeletons do not require translation.
-  Many date/time formatting regimes provide for "picture strings", which are patterns that
-  exactly match the expected format of the output.
-  In a picture string, separators, spaces, and other formatting are explicitly specified.
-  This provides a lot of power to the devleoper or user experience designer, in terms of specifying formatting.
-  However, this means that the translator has to modify the string to get localized output.
-  For example, here are some picture strings with their output vs. common skeletons:
+### Avoid 'picture strings'
+
+The MFWG early on considered including support for "picture strings" in the formatting of date/time values.
+There is a Working Group consensus **_not_** to support picture strings in Unicode MessageFormat, if possible.
+Many date/time formatting regimes provide for "picture strings".
+A "picture string" is a pattern using a microsyntax in which the user (developer, translator, UX designer)
+exactly specifies the desired format of the date/time value.
+In a picture string, separators, spaces, and other formatting are explicitly specified.
+This provides a lot of power to the devleoper or user experience designer, in terms of specifying formatting.
+For example: `MMM dd, yyyy` or `yyyy-dd-MM'T'HH:mm:ss`
+  
+Picture strings require translators to interact with and "translate" the picture string
+which is embedded into the _placeholder_ in order to get appropriately localized output.
+For example, in MF1 you might see: `Today is {myDate,date,MMM dd, yyyy}`
+
+Translating picture strings can result in non-functional messages.
+The exotic microsyntax can be unfamiliar to translators, as it is designed for developers.
+Unlike "picture strings", skeletons (classical or semantic) do not require the translator or
+developer to alter them for each locale or to know about the specifics, 
+such as spaces or separators in each locale.
+  
+Here are some picture strings with their output vs. common skeletons:
 
 | Picture String | Locale | Output | Skeleton yMMMd | Skeleton yMMd |
 |---|---|---|---|---|
@@ -65,7 +93,7 @@ Links:
 
 
 Semantic skeletons are not the first attempt to provide this functionality.
-Previous skeleton mechanisms used 
+Previous skeleton mechanisms ("classical skeletons") used 
 collections of field options (as in `Intl.DateTimeFormat`)
 or a microsyntax (as in ICU4J).
 

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -329,11 +329,11 @@ They should not have to coerce or convert normal date/time types in order to do 
    multiple new microsyntaxes or multiple different sets of options for date/time value formatting.
 1. Any microsyntax or option set specified should be easy to understand only from the expression.
 1. Any microsyntax or option set specified should not _require_ translators to alter the values in most or all locales.
-1. Users should be able to specify the time zone or local time offset used in formatting
-   an incremental or timestamp value
-   because many date/time formatting processes are
-   running in a different environment/offset/zone from where the value will be seen
-   or are formatting a value for a specific offset or zone.
+1. Message authors and developers should be able to manage 
+   the formatting of date/time values such that
+   processes running in an environment with a different time zone or local time offset
+   from that needed to express or format the value
+   can get the necessary results.
 
 ## Constraints
 

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -154,7 +154,7 @@ They should not have to coerce or convert normal date/time types in order to do 
    - incremental time types ("timestamps")
      (e.g. milliseconds since epoch times such as `java.util.Date`, `time_t`, JS `Date`, etc.),
    - field-based time types
-     (e.g. those that contain seperate values per field type in a date/time, such as a year-month),
+     (e.g. those that contain separate values per field type in a date/time, such as a year-month),
    - [floating time](https://www.w3.org/TR/timezone/#dfn-floating-time) values
      (e.g. those that are not tied to a specific time zone, variously called local/plain/civil times),
    -  or other local exotica (Java `Calendar`, C `tm` struct, etc.)

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -205,6 +205,7 @@ Options:
 {$date :datetime fields=YMD}
 ```
 
+The names `dateFields`, `date`, and `fields` are candidate names for the option that specifies the semantic skeleton string to be used for formatting the date/time value.
 #### TimePrecision
 
 Options:

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -221,7 +221,7 @@ They should not have to coerce or convert normal date/time types in order to do 
    | `yMMMMd` | April 6, 2025 |
 1. Developers, translators, and UI designers should not have to learn
    multiple new microsyntaxes or multiple different sets of options for date/time value formatting.
-1. Any microsyntax or option set specified should be easy to understand only from the placeholder.
+1. Any microsyntax or option set specified should be easy to understand only from the expression.
 1. Any microsyntax or option set specified should not _require_ translators to alter the values in most or all locales.
 
 ## Constraints

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -38,11 +38,10 @@ etc. to produce the desired output.
 
 Advantages of semantic skeletons over classical skeletons:
 
-- A smaller set of acceptable options focused on producing outputs that are sensical
-- Allows for a more efficient implementation
-- Allows for a more clear, ergonomic API
-- More future-proof since CLDR recently added them (??)
-
+- Provides all and only those combinations that make sense
+   - Allows for more efficient implementation, since there is no need to support "crazy" combinations like "month-hour"
+- Allows for a more clear, ergonomic placeholder syntax, since the number of options can be limited
+- Easier for user experience designers to specify, developers to implement, and translators to interpret
 
 ### Avoid 'picture strings'
 
@@ -102,7 +101,7 @@ such as `{ year: "numeric", month: "short", day: "numeric" }`
 in which the user specifies the field and its width.
 Only fields appearing in the options appear in the formatted date/time value.
 
-The ICU microsyntax uses strings supplied by the developers.
+The ICU MessageFormat "classical skeleton" microsyntax uses strings supplied by the developers.
 These strings specify the fields and field lengths that should appear in the formatted value.
 See [here](https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table)
 The system then uses the string to perform date/time pattern generation,
@@ -130,12 +129,12 @@ I should trust that the placeholder will produce appropriate results for my lang
 
 _What properties does the solution have to manifest to enable the use-cases above?_
 
-1. It should be possible to format common incremental time types
-   (e.g. milliseconds since epoch times)
-2. It should be possible to format field-based time types
+1. It should be possible to format operands consisting of common incremental time types
+   (e.g. milliseconds since epoch times such as `java.util.Date`, `time_t`, JS `Date`, etc.)
+2. It should be possible to format operands consisting of field-based time types
    (e.g. those that contain seperate values per field type in a date/time, such as a year-month)
 3. It should be possible to format [floating time](https://www.w3.org/TR/timezone/#dfn-floating-time) values
-   (e.g. those that are not tied to a specific time zone)
+   (e.g. those that are not tied to a specific time zone, variously called local/plain/civil times)
 4. Date/time formatters should not permit users to format fields that don't exist in the value
    (e.g. the "month" of a time, the "hour" of a date)
 5. Date/time formatters should not permit users to format bad combinations of fields

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -1,0 +1,143 @@
+# Semantic Skeletons Design
+
+Status: **Proposed**
+
+<details>
+	<summary>Metadata</summary>
+	<dl>
+		<dt>Contributors</dt>
+		<dd>@sffc</dd>
+    <dd>@aphillips</dd>
+		<dt>First proposed</dt>
+		<dd>2024-04-06</dd>
+		<dt>Pull Requests</dt>
+		<dd>#000</dd>
+	</dl>
+</details>
+
+## Objective
+
+_What is this proposal trying to achieve?_
+
+"Semantic skeletons" are a method introduced in CLDR 46 for programmatically selecting a datetime pattern for formatting. 
+There is a fixed set of acceptable semantic skeletons.
+
+Advantages of semantic skeletons over classical skeletons:
+
+- A smaller set of acceptable options focused on producing outputs that are sensical
+- Allows for a more efficient implementation
+- Allows for a more clear, ergonomic API
+- More future-proof since CLDR recently added them (??)
+
+
+
+## Background
+
+_What context is helpful to understand this proposal?_
+
+Semantic skeletons are not the first attempt to provide this functionality.
+Previous skeleton mechanisms used 
+collections of field options (as in `Intl.DateTimeFormat`)
+or a microsyntax (as in ICU4J).
+
+The `Intl.DateTimeFormat` skeletons consist of "option bags"
+such as `{ year: "numeric", month: "short", day: "numeric" }`
+in which the user specifies the field and its width.
+Only fields appearing in the options appear in the formatted date/time value.
+
+The ICU microsyntax uses strings supplied by the developers.
+These strings specify the fields and field lengths that should appear in the formatted value.
+See [here](https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table)
+The system then uses the string to perform date/time pattern generation,
+arranging the specified fields in the correct order,
+selecting locale-appropriate separators,
+and producing a "picture string" that can be consumed by date/time formatters
+such as `java.text.SimpleDateFormat`.
+
+## Use-Cases
+
+_What use-cases do we see? Ideally, quote concrete examples._
+
+As a developer, I want to format date, time, or date/time values to show specific fields
+with specific appearance without having to learn a complex microsyntax
+or modify my code or formatting directions for each locale.
+
+As a translator, I want to understand what output a given date/time placeholder will produce 
+in my language.
+
+As a translator, I don't want to have to "translate" or modify a date/time placeholder to suit
+my language's needs.
+I should trust that the placeholder will produce appropriate results for my language.
+
+## Requirements
+
+_What properties does the solution have to manifest to enable the use-cases above?_
+
+1. It should be possible to format common incremental time types
+   (e.g. milliseconds since epoch times)
+2. It should be possible to format field-based time types
+   (e.g. those that contain seperate values per field type in a date/time, such as a year-month)
+3. It should be possible to format [floating time](https://www.w3.org/TR/timezone/#dfn-floating-time) values
+   (e.g. those that are not tied to a specific time zone)
+4. Date/time formatters should not permit users to format fields that don't exist in the value
+   (e.g. the "month" of a time, the "hour" of a date)
+5. Date/time formatters should not permit users to format bad combinations of fields
+   (e.g. `MMMMmm` (month-minute), `yyyyjm` (year-hour-minute), etc.)
+6. Date/time formatters should permit users to control or influence the width of indvidual fields
+   in a manner similar to classical skeletons
+   (e.g. `yMMd` vs. `yMMMd` vs. `yMMMMd` => 04/06/2025 vs. Apr 6, 2025 vs. April 6, 2025)
+7. Developers, translators, and UI designers should only have to learn a single "microsyntax" or set of options for date formatting.
+   Such a syntax or option set should be easy to understand only from the placeholder.
+   Such a syntax or option set should not require translators to alter the values in most or all locales.
+
+## Constraints
+
+_What prior decisions and existing conditions limit the possible design?_
+
+## Proposed Design
+
+_Describe the proposed solution. Consider syntax, formatting, errors, registry, tooling, interchange._
+
+## Alternatives Considered
+
+_What other solutions are available?_
+_How do they compare against the requirements?_
+_What other properties they have?_
+
+
+### Design: Use Option Naming
+
+In this section, we use a scheme similar to `FieldSetBuilder` linked earlier.
+
+#### DateTime fields
+
+Options:
+
+```
+{$date :datetime dateFields="YMD"}  
+{$date :datetime date="YMD"}  
+{$date :datetime fields="YMD"}
+```
+
+#### TimePrecision
+
+Options:
+```
+{$date :datetime timePrecision="minute"}  
+{$date :datetime time="minute"}
+```
+(TODO: Add others)
+
+### Design: Use Separate Functions
+
+Some choices:
+
+1. A single :datetime function  
+   1. Pro: All in one place  
+   2. Con: More combinations of options that form invalid skeletons  
+2. :date, :time, and :datetime  
+   1. Pro: More tailored and type-safe  
+   2. Con: Not fully type-safe  
+3. :date, :time, :datetime, :zoneddatetime, *maybe* :zoneddate, :zonedtime, :timezone  
+   1. Pro: Most type-safe  
+   2. Con: Lots of functions

--- a/exploration/semantic-skeletons.md
+++ b/exploration/semantic-skeletons.md
@@ -450,7 +450,15 @@ _Cons_
 - Names appear generative, but aren't actually
 - Options might be baroque. Some option values might not be compatible with one another.
   - Expression-wide options (short/medium/long/full) and field-level options might both be needed together
-
+- Providing easy-to-use standalone field functions 
+  could lead to localization failures similar to picture strings,
+  as naive users might use combinations of standalone functions to concatenate date/time values
+  that are inappropriate in various other locales and require translator intervention.
+  > For example, this message hard codes separators, field order, and
+  > uses standalone representation of the fields:
+  > ```
+  > Today is {$d :month} {$d :day}, {$d :year} and it is {$d :hour}:{$d :minute} o'clock.
+  >```
 
 ---
 


### PR DESCRIPTION
This design document contains the proposed design for including semantic skeletons into Unicode MessageFormat's functions.

This PR is based on @sffc's [doc](https://docs.google.com/document/d/1s7GeN5V0cnw9B1erfMHTWwmnxz0EJkq2v78ZjzRq2t8/edit)