### PR TITLE
Design document for percent formatting

### DIFF
--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -181,7 +181,7 @@ _Pros_
 
 _Cons_
 - `:unit` won't be REQUIRED, so percentage format will not be guaranteed across implementations.
-  Requiring `:unit type=percent` would be complicated at best.
+  Requiring `:unit unit=percent` would be complicated at best.
 - Implementation of `:unit` in its entirely requires significantly more data than implementation of
   percentage formatting.
 - More verbose placeholder
@@ -275,18 +275,23 @@ The value `0.5` formats as `50%`
 > Example.
 > ```
 > .local $pctSaved = {50}
-> {$pctSaved :percent}
+> {{{$pctSaved :percent}}}
 > ```
 > Prints as `5,000%`.
 
 #### Optional Scaling
-Implementation automatically does (or does not) scale.
-There is an option to switch to the other behavior.
+Function automatically does (or does not) scale,
+but there is an option to switch to the non-default behavior.
+Such an option might be:
+- An option with a name like `scaling` with boolean-like values `true` and `false`
+- An option with a name like `scale` with 
+  digit size option values
+  limited to a small set of supported values (possibly only `1` and `100`)
 
 > Example. Note that `scale=false` is only to demonstrate switching.
 >```
 > .local $pctSaved = {50}
-> {$pctSaved :percent} {$pctSaved :percent scale=false}
+> {{{$pctSaved :percent} {$pctSaved :percent scale=false}}}
 >```
 > Prints as `5,000% 50%` if `:percent` is autoscaling by default
 
@@ -300,7 +305,7 @@ Extension of `:math` to support other mathematical capabilities would allow for 
 >```
 > .local $pctSaved = {0.5}
 > .local $pctScaled = {$pctSaved :math exp=2}
-> {$pctSaved :percent} {$pctScaled :unit unit=percent}
+> {{{$pctSaved :percent} {$pctScaled :unit unit=percent}}}
 >```
 > Prints as `50% 50%` if `:percent` is autoscaling by default and `:unit` is not.
 

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -137,11 +137,11 @@ You saved {$savings :unit unit=percent} on your order today!
 
 #### Use `:number`/`:integer` with `type=percent`
 
-Use the existing functions for number formatting with a separate `type` option for `percent`.
+Use the existing functions for number formatting with a separate `style` option for `percent`.
 (This was previously the design)
 
 ```
-You saved {$savings :number type=percent} on your order today!
+You saved {$savings :number style=percent} on your order today!
 ```
 
 **Pros**

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -50,8 +50,9 @@ Developers need to know which behavior will occur so that they can adjust the va
 > - `Intl.NumberFormat(locale, { style: 'percent' })` scales
 > - `Intl.NumberFormat(locale, { style: 'unit', unit: 'percent' })` does not scale
 
-It is also possible for Unicode MessageFormat to provide support for scaling in the message itself,
-perhaps by extending the `:math` function.
+It is also possible for Unicode MessageFormat to provide support for scaling in the message itself.
+Since we've removed the `:math` function (at least for now), this would have to be through either
+the re-introduction of `:math` or through a specialized scaling function.
 
 An addition concern is whether to add a dedicated `:percent` function,
 use one of the existing number-formatting functions `:number` and `:integer` with an option `type=percent`,
@@ -295,13 +296,15 @@ Such an option might be:
 >```
 > Prints as `5,000% 50%` if `:percent` is autoscaling by default
 
-#### Provide scaling via additions to `:math`
+#### Provide scaling via a function
 Regardless of the scaling done by the percent formatting function, 
 there might need to be an in-message mechanism for scaling/descaling values.
-The (currently DRAFT) function `:math` was added to support offsets in number matching/formatting.
-Extension of `:math` to support other mathematical capabilities would allow for scaling.
+The function `:math` was originally proposed to support offsets in number matching/formatting,
+although the WG removed this proposal and replaced with with an `:offset` function in May 2025.
+Reintroducing `:math` to support scaling
+or the proposal of a new function dedicated to scaling might address the need for value adjustment.
 
-> Example. 
+> Example using `:math` as a placeholder function name
 >```
 > .local $pctSaved = {0.5}
 > .local $pctScaled = {$pctSaved :math exp=2}
@@ -322,9 +325,9 @@ _Cons_
   instability into the message regime as new options are introduced over time.
   Compare with `java.lang.Math`
 
-Two proposals exist for using `:math`:
+Two proposals exist for `:math`-like scaling:
 
-##### Use `:math exp` to scale
+##### Use `:math exp` (`:exp`??) to scale
 Provide functionality to scale numbers with integer powers of 10 using the `:math` function.
 
 Examples using `:unit`, each of which would format as "Completion: 50%.":
@@ -344,7 +347,7 @@ _Cons_
 - Cannot use _digit size option_ as the `exp` option value type, since negative exponents are a Thing
 
 
-##### Use `:math multiply` to scale
+##### Use `:math multiply` (`:multiply`??) to scale
 Provide arbitrary integer multiplication functionality using the `:math` function.
 
 Examples using `:unit`, each of which would format as "Completion: 50%.":

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -197,7 +197,7 @@ You saved {$savings :scaled per=100} on your order today!
 #### No Scaling
 User has to scale the number. The value `0.5` formats as `0.5%`
 
-#### Scaling
+#### Always Scale
 Implementation always scales the number. The value `0.5` formats as `50%`
 
 #### Optional Scaling

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -58,6 +58,36 @@ use one of the existing number-formatting functions `:number` and `:integer` wit
 or use the proposed _optional_ function `:unit` with an option `unit=percent`.
 Combinations of these approached might also be used.
 
+### Unit Scaling
+
+There is a difference between _input_ scaling and _output_ scaling in `MeasureFormat`,
+which is the model for the `:unit` function in Unicode MessageFormat.
+
+For example, an input of <3.5, `meter`> with `meter` as the output unit doesn't scale.
+
+If one supplies <0.35 `percent`> as the input and the output unit were `percent`, 
+`MeasureFormat` would format as 0.35%. 
+Just like `meter` ==> `meter` doesn't scale.
+
+However, if one supplies a different input unit, then percent does scale 
+(just like `meter` ==> `foot`). 
+The base unit is for such dimensionless units is 'part'.
+In MF, a bare number literal, such as `.local $foo = {35}`
+or an implementation-specific number type (such as an `int` in Java)
+might be considered to use the input unit of `part`
+unless we specified that the `percent` unit value or `:percent` function overrode the `part` unit with `percent`.
+ 
+With <0.35 `part`> as the input and the output unit of `percent`, the format is "35%".
+
+| Amount | Input Unit | Formatted Value with... | Unit |
+|---|---|---|---|
+| 0.35 | part | 0.35 | part |
+| 0.35 | part | 35.0 | percent |
+| 0.35 | part | 350.0 | permille |
+| 0.35 | part | 3500.0 | permyriad |
+| 0.35 | part | 350000.0 | part-per-1e6 |
+| 0.35 | part | 3.5E8 | part-per-1e9 |
+
 ## Use-Cases
 
 _What use-cases do we see? Ideally, quote concrete examples._

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -71,7 +71,7 @@ Just like `meter` ==> `meter` doesn't scale.
 
 However, if one supplies a different input unit, then percent does scale 
 (just like `meter` ==> `foot`). 
-The base unit is for such dimensionless units is 'part'.
+The base unit for such dimensionless units is called 'part'.
 In MF, a bare number literal, such as `.local $foo = {35}`
 or an implementation-specific number type (such as an `int` in Java)
 might be considered to use the input unit of `part`

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -204,7 +204,28 @@ Implementation always scales the number. The value `0.5` formats as `50%`
 Implementation automatically does (or does not) scale.
 There is an option to switch to the other behavior.
 
-#### Use `:math exp` to scale
+#### Provide scaling via additions to `:math`
+Regardless of the scaling done by the percent formatting function, 
+there might need to be an in-message mechanism for scaling/descaling values.
+The (currently DRAFT) function `:math` was added to support offsets in number matching/formatting.
+Extension of `:math` to support other mathematical capabilities would allow for scaling.
+
+**Pros**
+- Users may find utility in performing math transforms in messages rather than in business logic.
+- Should be easy to implement, given that basic math functionality is common
+ 
+**Cons**
+- Implementation burden, especially when providing generic mathematical operations
+- Designs should be generic and extensible, not tied to short term needs of a given formatter.
+- Potential for abuse and misuse is higher.
+- "Real" math utilities or classes tend to have a long list of functions with many capabilities.
+  A complete implementation would require a lot of design work and effort or introduce
+  instability into the message regime as new options are introduced over time.
+  Compare with `java.lang.Math`
+
+Two proposals exist:
+
+##### Use `:math exp` to scale
 Provide functionality to scale numbers with integer powers of 10 using the `:math` function.
 
 Examples using `:unit`, each of which would format as "Completion: 50%.":
@@ -216,7 +237,7 @@ Examples using `:unit`, each of which would format as "Completion: 50%.":
 {{Completion: {$n :unit unit=percent}.}}
 ```
 
-#### Use `:math multiply` to scale
+##### Use `:math multiply` to scale
 Provide arbitrary integer multiplication functionality using the `:math` function.
 
 Examples using `:unit`, each of which would format as "Completion: 50%.":

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -264,7 +264,7 @@ The value `0.5` formats as `0.5%`
 > Example.
 > ```
 > .local $pctSaved = {50}
-> {$pctSaved :percent}
+> {{{$pctSaved :percent}}}
 > ```
 > Prints as `50%`.
 

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -7,6 +7,7 @@ Status: **Proposed**
 	<dl>
 		<dt>Contributors</dt>
 		<dd>@aphillips</dd>
+		<dd>@eemeli</dd>
 		<dt>First proposed</dt>
 		<dd>2025-04-07</dd>
 		<dt>Pull Requests</dt>
@@ -135,30 +136,7 @@ _What prior decisions and existing conditions limit the possible design?_
 
 _Describe the proposed solution. Consider syntax, formatting, errors, registry, tooling, interchange._
 
-Support the formatting of percent values as follows:
-
-- REQUIRE the `:unit` function for all implementations
-  - Only specific `unit` option values are required, initially the unit `percent`.
-  - The function `:unit unit=percent` does not scale the operand, e.g. `{5 :unit unit=percent}` formats as `5%`.
-- REQUIRE the `:number` and `:integer` functions to support `style=percent` as an option
-  - The functions `:number` and `:integer` scale the operand, e.g. `{5 :integer style=percent}` formats as `500%`.
-    Note that the selector selects on the scaled value
-    (selectors currently cannot select fractional parts)
-
-> Examples. These are equivalent **except** that `:unit` does NOT scale.
->```
-> {{You have {$pct :number style=percent} remaining.}}
-> {{You have {$pct :unit unit=percent} remaining.}}
-> {{You have {$pct :integer style=percent} remaining.}}
->```
-> Selector example:
->```
-> .local $pct = {0.05 :number style=percent}
-> .match $pct
-> 5   {{This pattern is selected}}
-> one {{You have {$pct} left.}}
-> *   {{You have {$pct} left.}}
->``` 
+TBD
 
 ## Alternatives Considered
 
@@ -387,3 +365,32 @@ _Pros_
 
 _Cons_
 - Brings in multiplication
+
+---
+
+### Why not both?
+
+Rather than choosing only one option, choose multiple parallel solutions:
+
+- REQUIRE the `:unit` function for all implementations
+  - Only specific `unit` option values are required, initially the unit `percent`.
+  - The function `:unit unit=percent` does not scale the operand, e.g. `{5 :unit unit=percent}` formats as `5%`.
+- REQUIRE the `:number` and `:integer` functions to support `style=percent` as an option
+  - The functions `:number` and `:integer` scale the operand, e.g. `{5 :integer style=percent}` formats as `500%`.
+    Note that the selector selects on the scaled value
+    (selectors currently cannot select fractional parts)
+
+> Examples. These are equivalent **except** that `:unit` does NOT scale.
+>```
+> {{You have {$pct :number style=percent} remaining.}}
+> {{You have {$pct :unit unit=percent} remaining.}}
+> {{You have {$pct :integer style=percent} remaining.}}
+>```
+> Selector example:
+>```
+> .local $pct = {0.05 :number style=percent}
+> .match $pct
+> 5   {{This pattern is selected}}
+> one {{You have {$pct} left.}}
+> *   {{You have {$pct} left.}}
+>``` 

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -94,7 +94,7 @@ _Describe the proposed solution. Consider syntax, formatting, errors, registry, 
 - Use a dedicated function `:percent` that scales by default.
 - Provide an option `scaling` with values `true` and `false` and defaulting to `true`.
 - Provide all options identical to `:number` _except_ that `select` does not provide `ordinal` value.
-- Allow `unit=percent` in `:unit` that is identical to `:percent` in formatting performance,
+- Allow `unit=percent` in `:unit` that is identical to `:percent` in formatting capabilities,
   for compatibility with CLDR units,
   but document that this usage is not preferred.
 

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -327,7 +327,7 @@ although the WG removed this proposal and replaced with with an `:offset` functi
 Reintroducing `:math` to support scaling
 or the proposal of a new function dedicated to scaling might address the need for value adjustment.
 
-> Example using `:math` as a placeholder function name
+> Example using `:math` as a hypothetical function name
 >```
 > .local $pctSaved = {0.5}
 > .local $pctScaled = {$pctSaved :math exp=2}

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -181,7 +181,7 @@ or scientific notation (1000000 => 1.0e6).
 _Pros_
 - Uses an existing set of functionality
 - Might provide a more consistent interface for formatting "number-like" values
-- Removes percentages from `:number` and `:integer`, making those functions more "pure"
+- Keeps percentage formatting out of `:number` and `:integer`, making those functions more "pure"
 
 _Cons_
 - `:unit` won't be REQUIRED, so percentage format will not be guaranteed across implementations.
@@ -277,7 +277,7 @@ The value `0.5` formats as `50%`
 > .local $pctSaved = {50}
 > {$pctSaved :percent}
 > ```
-> Prints as `5000%`.
+> Prints as `5,000%`.
 
 #### Optional Scaling
 Implementation automatically does (or does not) scale.
@@ -288,7 +288,7 @@ There is an option to switch to the other behavior.
 > .local $pctSaved = {50}
 > {$pctSaved :percent} {$pctSaved :percent scale=false}
 >```
-> Prints as `5000% 50%` if `:percent` is autoscaling by default
+> Prints as `5,000% 50%` if `:percent` is autoscaling by default
 
 #### Provide scaling via additions to `:math`
 Regardless of the scaling done by the percent formatting function, 
@@ -336,7 +336,7 @@ _Pros_
 - Useful for other scaling operations
 
 _Cons_
-- Might require changes to digit size options, since negative exponents are a Thing
+- Cannot use _digit size option_ as the `exp` option value type, since negative exponents are a Thing
 
 
 ##### Use `:math multiply` to scale

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -225,13 +225,12 @@ _Pros_
 - Clear what the placeholder does; self-documenting
 - Consistent with separating specialized formats from `:number`/`:integer`
   as was done with `:currency`
+- Makes it possible to apply a `scaling` option to only percent formatting.
 
 _Cons_
 - Adds to a (growing) list of functions
 - Not "special enough" to warrant its own formatter?
-- Unlike `:currency`, because currency formatting depends on currency codes,
-  which in turn impact default fraction digits, and other presentation details.
-  Nothing like that applies to percents. 
+- Adds yet another numeric function, with its own subset of numeric function options.
 
 ---
 
@@ -364,7 +363,7 @@ _Pros_
 - Can be used for other general purpose math
 
 _Cons_
-- Brings in multiplication
+- Increases implementation burden: multiplication must be handled on arbitrary numeric input types
 
 ---
 
@@ -375,16 +374,15 @@ Rather than choosing only one option, choose multiple parallel solutions:
 - REQUIRE the `:unit` function for all implementations
   - Only specific `unit` option values are required, initially the unit `percent`.
   - The function `:unit unit=percent` does not scale the operand, e.g. `{5 :unit unit=percent}` formats as `5%`.
-- REQUIRE the `:number` and `:integer` functions to support `style=percent` as an option
-  - The functions `:number` and `:integer` scale the operand, e.g. `{5 :integer style=percent}` formats as `500%`.
+- REQUIRE the `:number` function to support `style=percent` as an option
+  - The function `:number`scales the operand, e.g. `{5 :number style=percent}` formats as `500%`.
     Note that the selector selects on the scaled value
     (selectors currently cannot select fractional parts)
 
 > Examples. These are equivalent **except** that `:unit` does NOT scale.
 >```
 > {{You have {$pct :number style=percent} remaining.}}
-> {{You have {$pct :unit unit=percent} remaining.}}
-> {{You have {$pct :integer style=percent} remaining.}}
+> {{You have {$scaledPct :unit unit=percent} remaining.}}
 >```
 > Selector example:
 >```

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -10,7 +10,7 @@ Status: **Proposed**
 		<dt>First proposed</dt>
 		<dd>2025-04-07</dd>
 		<dt>Pull Requests</dt>
-		<dd>#000</dd>
+		<dd>#1068</dd>
 	</dl>
 </details>
 
@@ -99,6 +99,15 @@ _What other solutions are available?_
 _How do they compare against the requirements?_
 _What other properties they have?_
 
+### Combinations of Functions and Scaling
+
+Any proposed design needs to choose one or more functions
+each of which has a scaling approach
+or a combination of both.
+It is possible to have separate functions, one that is scaling and one that is non-scaling.
+However, the working group suspects that this would represent a hazard,
+since users would be forced to look up which one what which behavior.
+
 ### Function Alternatives
 
 #### Use `:unit`
@@ -144,6 +153,10 @@ Use a new function `:percent` dedicated to percentages.
 You saved {$savings :percent} on your order today!
 ```
 
+> [!NOTE]
+> @sffc suggested that we should consider other names for `:percent`.
+> The name shown here could be considered a placeholder pending other suggestions.
+
 **Pros**
 - Least verbose placeholder
 - Clear what the placeholder does; self-documenting?
@@ -151,6 +164,28 @@ You saved {$savings :percent} on your order today!
 **Cons**
 - Adds to a (growing) list of functions
 - Not "special enough" to warrant its own formatter?
+
+#### Use a generic scaling function
+
+Use a new function with a more generic name so that it can be used to format other scaled values.
+For example, it might use an option `unit` to select `percent`/`permille`/etc.
+
+```
+You saved {$savings :dimensionless unit=percent} on your order today!
+You saved {$savings :scaled per=100} on your order today!
+```
+
+**Pros**
+- Could be used to support non-percent/non-permille scales that might exist in other cultures
+- Somewhat generic
+- Unlike currency or unit values, "per" units do not have to be stored with the value to prevent loss of fidelity,
+  since the scaling is done to a plain old number.
+  This would not apply if the values are not scaled.
+
+**Cons**
+- Only percent and permille are backed with CLDR data and symbols.
+  Other scales would impose an implementation burden.
+- More verbose. Might be harder for users to understand and use.
 
 ### Scaling Alternatives
 

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -42,8 +42,13 @@ That is, does the value `0.5` format as `50%` or `0.5%`?
 Developers need to know which behavior will occur so that they can adjust the value passed appropriately.
 
 > [!NOTE]
-> MessageFormat (MF1) in ICU4J scales.
-> MeasureFormat in ICU4J does not scale.
+> In ICU4J:
+> - MessageFormat (MF1) scales.
+> - MeasureFormat does not scale.
+>
+> In JavaScript:
+> - `Intl.NumberFormat(locale, { style: 'percent' })` scales
+> - `Intl.NumberFormat(locale, { style: 'unit', unit: 'percent' })` does not scale
 
 It is also possible for Unicode MessageFormat to provide support for scaling in the message itself,
 perhaps by extending the `:math` function.

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -60,8 +60,9 @@ Combinations of these approached might also be used.
 
 ### Unit Scaling
 
-There is a difference between _input_ scaling and _output_ scaling in `MeasureFormat`,
-which is the model for the `:unit` function in Unicode MessageFormat.
+This section describes the scaling behavior of ICU's `NumberFormatter` class and its `unit()` method,
+which is one model for how Unicode MessageFormat might implement percents and units.
+There is a difference between _input_ scaling and _output_ scaling in ICU's `NumberFormatter`.
 
 For example, an input of <3.5, `meter`> with `meter` as the output unit doesn't scale.
 
@@ -225,11 +226,15 @@ You saved {$savings :percent} on your order today!
 _Pros_
 - Least verbose placeholder
 - Clear what the placeholder does; self-documenting
-- Consistent with separating `:currency`
+- Consistent with separating specialized formats from `:number`/`:integer`
+  as was done with `:currency`
 
 _Cons_
 - Adds to a (growing) list of functions
 - Not "special enough" to warrant its own formatter?
+- Unlike `:currency`, because currency formatting depends on currency codes,
+  which in turn impact default fraction digits, and other presentation details.
+  Nothing like that applies to percents. 
 
 ---
 

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -134,12 +134,7 @@ _What prior decisions and existing conditions limit the possible design?_
 
 _Describe the proposed solution. Consider syntax, formatting, errors, registry, tooling, interchange._
 
-- Use a dedicated function `:percent` that scales by default.
-- Provide an option `scaling` with values `true` and `false` and defaulting to `true`.
-- Provide all options identical to `:number` _except_ that `select` does not provide `ordinal` value.
-- Allow `unit=percent` in `:unit` that is identical to `:percent` in formatting capabilities,
-  for compatibility with CLDR units,
-  but document that this usage is not preferred.
+(Awaiting WG consensus)
 
 ## Alternatives Considered
 

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -135,7 +135,30 @@ _What prior decisions and existing conditions limit the possible design?_
 
 _Describe the proposed solution. Consider syntax, formatting, errors, registry, tooling, interchange._
 
-(Awaiting WG consensus)
+Support the formatting of percent values as follows:
+
+- REQUIRE the `:unit` function for all implementations
+  - Only specific `unit` option values are required, initially the unit `percent`.
+  - The function `:unit unit=percent` does not scale the operand, e.g. `{5 :unit unit=percent}` formats as `5%`.
+- REQUIRE the `:number` and `:integer` functions to support `style=percent` as an option
+  - The functions `:number` and `:integer` scale the operand, e.g. `{5 :integer style=percent}` formats as `500%`.
+    Note that the selector selects on the scaled value
+    (selectors currently cannot select fractional parts)
+
+> Examples. These are equivalent **except** that `:unit` does NOT scale.
+>```
+> {{You have {$pct :number style=percent} remaining.}}
+> {{You have {$pct :unit unit=percent} remaining.}}
+> {{You have {$pct :integer style=percent} remaining.}}
+>```
+> Selector example:
+>```
+> .local $pct = {0.05 :number style=percent}
+> .match $pct
+> 5   {{This pattern is selected}}
+> one {{You have {$pct} left.}}
+> *   {{You have {$pct} left.}}
+>``` 
 
 ## Alternatives Considered
 

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -201,7 +201,7 @@ or scientific notation (1000000 => 1.0e6).
 _Pros_
 - Uses an existing set of functionality
 - Might provide a more consistent interface for formatting "number-like" values
-- Keeps percentage formatting out of `:number` and `:integer`, making those functions more "pure"
+- Keeps percentage formatting out of `:number` and `:integer`, limiting the scope of those functions
 
 _Cons_
 - `:unit` won't be REQUIRED, so percentage format will not be guaranteed across implementations.

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -81,7 +81,10 @@ Users need control over most formatting details, identical to general number for
 
 _What properties does the solution have to manifest to enable the use-cases above?_
 
-
+- **Be consistent** Any solution for scaling percentages should be a model for other, similar scaling operations,
+  such as _per-mille_ or _per-myriad_,
+  as well as other, non-percent or even non-unit scaling.
+  This does not mean that a scaling mechanism or any particular scaling mechanism itself is a requirement.
 
 ## Constraints
 

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -204,6 +204,26 @@ Implementation always scales the number. The value `0.5` formats as `50%`
 Implementation automatically does (or does not) scale.
 There is an option to switch to the other behavior.
 
-#### Use `:math` to scale
-Provide functionality to scale numbers arbitrarily using the `:math` function.
-This alternative can be used with scaling/no scaling to fix the passed value appropriately without altering userland code.
+#### Use `:math exp` to scale
+Provide functionality to scale numbers with integer powers of 10 using the `:math` function.
+
+Examples using `:unit`, each of which would format as "Completion: 50%.":
+```
+.local $n = {50}
+{{Completion: {$n :unit unit=percent}.}}
+
+.local $n = {0.5 :math exp=2}
+{{Completion: {$n :unit unit=percent}.}}
+```
+
+#### Use `:math multiply` to scale
+Provide arbitrary integer multiplication functionality using the `:math` function.
+
+Examples using `:unit`, each of which would format as "Completion: 50%.":
+```
+.local $n = {50}
+{{Completion: {$n :unit unit=percent}.}}
+
+.local $n = {0.5 :math multiply=100}
+{{Completion: {$n :unit unit=percent}.}}
+```

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -188,7 +188,7 @@ _Cons_
 
 ---
 
-#### Use `:number`/`:integer` with `type=percent`
+#### Use `:number`/`:integer` with `style=percent`
 
 Use the existing functions for number formatting with a separate `style` option for `percent`.
 (This was previously the design)

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -64,9 +64,11 @@ _What use-cases do we see? Ideally, quote concrete examples._
 
 Developers wish to write messages that format a numeric value as a percentage in a locale-sensitive manner.
 
-The numeric value is not scaled because it is the result of a computation, e.g. `var savings = discount / price`.
+The numeric value of the operand is not pre-scaled because it is the result of a computation, 
+e.g. `var savings = discount / price`.
 
-The numeric value is scaled, e.g. `var savingsPercent = 50`
+The numeric value of the operant is pre-scaled, 
+e.g. `var savingsPercent = 50`
 
 Users need control over most formatting details, identical to general number formatting:
 - negative number sign display
@@ -81,10 +83,17 @@ Users need control over most formatting details, identical to general number for
 
 _What properties does the solution have to manifest to enable the use-cases above?_
 
-- **Be consistent** Any solution for scaling percentages should be a model for other, similar scaling operations,
-  such as _per-mille_ or _per-myriad_,
-  as well as other, non-percent or even non-unit scaling.
-  This does not mean that a scaling mechanism or any particular scaling mechanism itself is a requirement.
+- **Be consistent**
+  - Any solution for scaling percentages should be a model for other, similar scaling operations,
+     such as _per-mille_ or _per-myriad_,
+     as well as other, non-percent or even non-unit scaling.
+     This does not mean that a scaling mechanism or any particular scaling mechanism itself is a requirement.
+  - Any solution for formatting percentages should be a model for solving related problems with:
+    - per-mille
+    - per-myriad
+    - compact notation
+    - scientific notation
+    - (others??)
 
 ## Constraints
 
@@ -113,8 +122,13 @@ Any proposed design needs to choose one or more functions
 each of which has a scaling approach
 or a combination of both.
 It is possible to have separate functions, one that is scaling and one that is non-scaling.
-However, the working group suspects that this would represent a hazard,
-since users would be forced to look up which one what which behavior.
+
+Some working group members suspect that having a function that scales and one that does not
+would represent a hazard,
+since users would be forced to look up which one has which behavior.
+
+Other working group members have expressed that the use cases for pre-scaled vs. non-pre-scaled are separate
+and that having separate functions for these is logically sensible.
 
 ### Function Alternatives
 
@@ -136,7 +150,7 @@ You saved {$savings :unit unit=percent} on your order today!
 - `:unit` won't be REQUIRED, so percentage format will not be guaranteed across implementations.
   Requiring `:unit type=percent` would be complicated at best.
 - More verbose placeholder
-- Could require a scaling mechanism
+- Could require a separate scaling mechanism
 
 #### Use `:number`/`:integer` with `type=percent`
 
@@ -198,14 +212,23 @@ You saved {$savings :scaled per=100} on your order today!
 ### Scaling Alternatives
 
 #### No Scaling
-User has to scale the number. The value `0.5` formats as `0.5%`
+User has to scale the number. 
+The value `0.5` formats as `0.5%`
 
 #### Always Scale
-Implementation always scales the number. The value `0.5` formats as `50%`
+Implementation always scales the number. 
+The value `0.5` formats as `50%`
 
 #### Optional Scaling
 Implementation automatically does (or does not) scale.
 There is an option to switch to the other behavior.
+
+> Example.
+>```
+> .local $pctSaved = {50}
+> {$pctSaved :percent} {$pctSaved :percent scale=false}
+>```
+> Prints as `5000% 50%` if `:percent` is autoscaling by default
 
 #### Provide scaling via additions to `:math`
 Regardless of the scaling done by the percent formatting function, 
@@ -226,7 +249,7 @@ Extension of `:math` to support other mathematical capabilities would allow for 
   instability into the message regime as new options are introduced over time.
   Compare with `java.lang.Math`
 
-Two proposals exist:
+Two proposals exist for using `:math`:
 
 ##### Use `:math exp` to scale
 Provide functionality to scale numbers with integer powers of 10 using the `:math` function.

--- a/exploration/percent-format.md
+++ b/exploration/percent-format.md
@@ -1,0 +1,169 @@
+# Formatting Percent Values
+
+Status: **Proposed**
+
+<details>
+	<summary>Metadata</summary>
+	<dl>
+		<dt>Contributors</dt>
+		<dd>@aphillips</dd>
+		<dt>First proposed</dt>
+		<dd>2025-04-07</dd>
+		<dt>Pull Requests</dt>
+		<dd>#000</dd>
+	</dl>
+</details>
+
+## Objective
+
+_What is this proposal trying to achieve?_
+
+One the capabilities present in ICU MessageFormat is the ability to format a number as a percentage.
+This design enumerates the approaches considered for adding this ability as a _default function_
+in Unicode MessageFormat.
+
+## Background
+
+_What context is helpful to understand this proposal?_
+
+> [!NOTE]
+> This design is an outgrowth of discussions in #956 and various teleconferences.
+
+Developers and translators often need to insert a numeric value into a formatted message as a percentage.
+The format of a percentage can vary by locale including
+the symbol used,
+the presence or absence of spaces,
+the shaping of digits,
+the position of the symbol,
+and other variations.
+
+One of the key problems is whether the value should be "scaled".
+That is, does the value `0.5` format as `50%` or `0.5%`?
+Developers need to know which behavior will occur so that they can adjust the value passed appropriately.
+
+> [!NOTE]
+> MessageFormat (MF1) in ICU4J scales.
+> MeasureFormat in ICU4J does not scale.
+
+It is also possible for Unicode MessageFormat to provide support for scaling in the message itself,
+perhaps by extending the `:math` function.
+
+An addition concern is whether to add a dedicated `:percent` function,
+use one of the existing number-formatting functions `:number` and `:integer` with an option `type=percent`,
+or use the proposed _optional_ function `:unit` with an option `unit=percent`.
+Combinations of these approached might also be used.
+
+## Use-Cases
+
+_What use-cases do we see? Ideally, quote concrete examples._
+
+Developers wish to write messages that format a numeric value as a percentage in a locale-sensitive manner.
+
+The numeric value is not scaled because it is the result of a computation, e.g. `var savings = discount / price`.
+
+The numeric value is scaled, e.g. `var savingsPercent = 50`
+
+Users need control over most formatting details, identical to general number formatting:
+- negative number sign display
+- digit shaping
+- minimum number of fractional digits
+- maximum number of fractional digits
+- minimum number of decimal digits
+- group used (for very large percentages, i.e. > 999%)
+- etc.
+
+## Requirements
+
+_What properties does the solution have to manifest to enable the use-cases above?_
+
+
+
+## Constraints
+
+_What prior decisions and existing conditions limit the possible design?_
+
+## Proposed Design
+
+_Describe the proposed solution. Consider syntax, formatting, errors, registry, tooling, interchange._
+
+- Use a dedicated function `:percent` that scales by default.
+- Provide an option `scaling` with values `true` and `false` and defaulting to `true`.
+- Provide all options identical to `:number` _except_ that `select` does not provide `ordinal` value.
+- Allow `unit=percent` in `:unit` that is identical to `:percent` in formatting performance,
+  for compatibility with CLDR units,
+  but document that this usage is not preferred.
+
+## Alternatives Considered
+
+_What other solutions are available?_
+_How do they compare against the requirements?_
+_What other properties they have?_
+
+### Function Alternatives
+
+#### Use `:unit`
+
+Leverage the `:unit` function by using the existing unit option value `percent`.
+The ICU implementation of `MeasureFormat` does **_not_** scale the percentage,
+although this does not have to be the default behavior of UMF's percent unit format.
+
+```
+You saved {$savings :unit unit=percent} on your order today!
+```
+
+**Pros**
+- Uses an existing set of functionality
+- Removes percentages from `:number` and `:integer`, making those functions more "pure"
+
+**Cons**
+- `:unit` won't be REQUIRED, so percentage format will not be guaranteed across implementations.
+  Requiring `:unit type=percent` would be complicated at best.
+- More verbose placeholder
+- Could require a scaling mechanism
+
+#### Use `:number`/`:integer` with `type=percent`
+
+Use the existing functions for number formatting with a separate `type` option for `percent`.
+(This was previously the design)
+
+```
+You saved {$savings :number type=percent} on your order today!
+```
+
+**Pros**
+- Consistent with ICU MessageFormat
+
+**Cons**
+- It's the only special case remaining in these functions. Why?
+
+#### Use a dedicated `:percent` function
+
+Use a new function `:percent` dedicated to percentages.
+
+```
+You saved {$savings :percent} on your order today!
+```
+
+**Pros**
+- Least verbose placeholder
+- Clear what the placeholder does; self-documenting?
+
+**Cons**
+- Adds to a (growing) list of functions
+- Not "special enough" to warrant its own formatter?
+
+### Scaling Alternatives
+
+#### No Scaling
+User has to scale the number. The value `0.5` formats as `0.5%`
+
+#### Scaling
+Implementation always scales the number. The value `0.5` formats as `50%`
+
+#### Optional Scaling
+Implementation automatically does (or does not) scale.
+There is an option to switch to the other behavior.
+
+#### Use `:math` to scale
+Provide functionality to scale numbers arbitrarily using the `:math` function.
+This alternative can be used with scaling/no scaling to fix the passed value appropriately without altering userland code.


### PR DESCRIPTION
This document now includes the proposed design discussed in the (poorly documented, sparsely attended) 2025-05-19 call. The emerging consensus appears to be:

- `:number`/`:integer` with option `style=percent` (this is the current design) with scaling
- `:unit` with unit `percent` is REQUIRED but other units are not required, this function has NO scaling

The most recent commit posits that `:number`/`:integer` select _after_ scaling because we don't support fraction selection currently.

> [!NOTE]
> All previous conversations were marked resolved on purpose and not because their content was in any way deficient, off topic, or necessarily addressed. Please comment on the proposed design.