### PR TITLE
Allow clamping of digit size options

### DIFF
--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -631,8 +631,11 @@ digit-size-option = "0" / (("1"-"9") [DIGIT])
 
 If the value of a _digit size option_ does not evaluate as a non-negative integer,
 or if the value exceeds any implementation-defined and option-specific upper or lower limit,
-the implementation will emit a _Bad Option Error_ and
-either ignore the option or replace it with an implementation-defined value.
+the implementation will emit a _Bad Option Error_
+and ignore the _option_.
+An implementation MAY replace a _digit size option_
+that exceeds an implementation-defined or option-specific upper or lower limit
+with an implementation-defined value rather than ignoring the _option_.
 
 #### Number Selection
 

--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -633,7 +633,7 @@ If the value of a _digit size option_ does not evaluate as a non-negative intege
 or if the value exceeds any implementation-defined and option-specific upper or lower limit,
 a _Bad Option_ error is emitted.
 If the value exceeds an implementation-defined upper or lower limit, 
-the implementation MAY replace the offending value with an implementation-defined value.
+the implementation MAY replace it with an implementation-defined value.
 
 #### Number Selection
 

--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -632,6 +632,8 @@ digit-size-option = "0" / (("1"-"9") [DIGIT])
 If the value of a _digit size option_ does not evaluate as a non-negative integer,
 or if the value exceeds any implementation-defined and option-specific upper or lower limit,
 a _Bad Option_ error is emitted.
+If the value exceeds an implementation-defined upper or lower limit, 
+the implementation MAY replace the offending value with an implementation-defined value.
 
 #### Number Selection
 

--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -617,7 +617,7 @@ such as the number of fraction, integer, or significant digits.
 A **_<dfn>digit size option</dfn>_** is an _option_ 
 whose _option value_ is interpreted by the _function_
 as a small integer greater than or equal to zero.
-Implementations MAY define an upper limit on the _resolved value_
+Implementations MAY define upper and lower limits on the _resolved value_
 of a _digit size option_ consistent with that implementation's practical limits.
 
 In most cases, the value of a _digit size option_ will be a string that
@@ -631,9 +631,8 @@ digit-size-option = "0" / (("1"-"9") [DIGIT])
 
 If the value of a _digit size option_ does not evaluate as a non-negative integer,
 or if the value exceeds any implementation-defined and option-specific upper or lower limit,
-a _Bad Option_ error is emitted.
-If the value exceeds an implementation-defined upper or lower limit, 
-the implementation MAY replace it with an implementation-defined value.
+the implementation will emit a _Bad Option Error_ and
+either ignore the option or replace it with an implementation-defined value.
 
 #### Number Selection
 

--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -636,6 +636,17 @@ and ignore the _option_.
 An implementation MAY replace a _digit size option_
 that exceeds an implementation-defined or option-specific upper or lower limit
 with an implementation-defined value rather than ignoring the _option_.
+Any such replacement value becomes the _resolved value_ of that _option_.
+
+> For example, if an implementation imposed an upper limit of 20 on the _option_
+> `minimumIntegerDigits` for the function `:number`
+> then the _resolved value_ of the _option_ `minimumIntegerDigits`
+> for both `$x` and `$y` in the following _message_ would be 20:
+> ```
+> .input {$x :number minimumIntegerDigits=999}
+> .local $y = {$x}
+> {{{$y}}}
+> ```
 
 #### Number Selection
 


### PR DESCRIPTION
Fixes #960 

Per the discussion in the 2025-04-14 telecon, allow digit size options to be to clamped to an implementation-specific value.