### PR TITLE
Define time zone values and conversions

### DIFF
--- a/spec/functions/datetime.md
+++ b/spec/functions/datetime.md
@@ -283,12 +283,12 @@ the functions `:datetime`, `:date`, and `:time`.
   - `UTC`
 
 The value `input` corresponds to the time zone of the _operand_.
-If it is used and _operand_ value does not include a time zone,
+If it is used and the _resolved value_ of the _operand_ does not include a time zone,
 a _Bad Operand_ error is emitted and the default time zone is used to format the _expression_.
 
-If the _operand_ value does not include a time zone,
+If the _resolved value_ of the _operand_ does not include a time zone,
 it is presumed to use the default time zone provided by the _formatting context_.
-If the _operand_ value does include a time zone and the `timeZone` _option_ is set,
+If the _resolved value_ of the _operand_ does include a time zone and the `timeZone` _option_ is set,
 an implementation SHOULD convert the value to the time zone indicated by the _option_.
 If such conversion is not supported, an implementation MAY alternatively
 emit a _Bad Option_ error and use a _fallback value_ as the _resolved value_ of the _expression_.

--- a/spec/functions/datetime.md
+++ b/spec/functions/datetime.md
@@ -282,14 +282,16 @@ the functions `:datetime`, `:date`, and `:time`.
   - `input`
   - `UTC`
 
+The default value for `timeZone` is the default time zone provided by the _formatting context_.
+
 The value `input` corresponds to the time zone of the _operand_.
 If it is used and the _resolved value_ of the _operand_ does not include a time zone,
 a _Bad Operand_ error is emitted and the default time zone is used to format the _expression_.
 
-If the _resolved value_ of the _operand_ does not include a time zone,
-it is presumed to use the default time zone provided by the _formatting context_.
-If the _resolved value_ of the _operand_ does include a time zone and the `timeZone` _option_ is set,
-an implementation SHOULD convert the value to the time zone indicated by the _option_.
+If the _resolved value_ of the _operand_ includes a time zone,
+and the _resolved value_ of the `timeZone` _option_ is different from that,
+an implementation SHOULD convert the _resolved value_ of the _operand_
+to the time zone indicated by the _resolved value_ of the `timeZone` _option_.
 If such conversion is not supported, an implementation MAY alternatively
 emit a _Bad Option_ error and use a _fallback value_ as the _resolved value_ of the _expression_.
 

--- a/spec/functions/datetime.md
+++ b/spec/functions/datetime.md
@@ -285,10 +285,10 @@ the functions `:datetime`, `:date`, and `:time`.
 The default value for `timeZone` is the default time zone provided by the _formatting context_.
 
 The value `input` corresponds to the time zone of the _operand_.
-If it is used and the _resolved value_ of the _operand_ does not include a time zone,
+If it is used and the _resolved value_ of the _operand_ does not include a time zone or offset,
 a _Bad Operand_ error is emitted and the default time zone is used to format the _expression_.
 
-If the _resolved value_ of the _operand_ includes a time zone,
+If the _resolved value_ of the _operand_ includes a time zone or offset,
 and the _resolved value_ of the `timeZone` _option_ is different from that,
 an implementation SHOULD convert the _resolved value_ of the _operand_
 to the time zone indicated by the _resolved value_ of the `timeZone` _option_.

--- a/spec/functions/datetime.md
+++ b/spec/functions/datetime.md
@@ -282,11 +282,14 @@ the functions `:datetime`, `:date`, and `:time`.
   - `local`
   - `UTC`
 
-> [!NOTE]
-> The value `local` permits a _message_ to convert a date/time value
-> into a [floating](https://www.w3.org/TR/timezone/#floating) time value
-> (sometimes called a _plain_ or _local_ time value) by removing
-> the association with a specific time zone.
+The value `local` corresponds to the default time zone.
+
+If the _operand_ value does not include a time zone,
+it is presumed to use the default time zone.
+If the _operand_ value does include a time zone and the `timeZone` _option_ is set,
+an implementation SHOULD convert the value to the time zone indicated by the _option_.
+If such conversion is not supported, an implementation MAY alternatively
+emit a _Bad Option_ error and use a _fallback value_ as the _resolved value_ of the _expression_.
 
 The following _option_ is REQUIRED to be available on
 the functions `:datetime` and `:time`:

--- a/spec/functions/datetime.md
+++ b/spec/functions/datetime.md
@@ -279,13 +279,15 @@ the functions `:datetime`, `:date`, and `:time`.
     (see [TZDB](https://www.iana.org/time-zones)
     and [LDML](https://www.unicode.org/reports/tr35/tr35-dates.html#Time_Zone_Names)
     for information on identifiers)
-  - `local`
+  - `input`
   - `UTC`
 
-The value `local` corresponds to the default time zone.
+The value `input` corresponds to the time zone of the _operand_.
+If it is used and _operand_ value does not include a time zone,
+a _Bad Operand_ error is emitted and the default time zone is used to format the _expression_.
 
 If the _operand_ value does not include a time zone,
-it is presumed to use the default time zone.
+it is presumed to use the default time zone provided by the _formatting context_.
 If the _operand_ value does include a time zone and the `timeZone` _option_ is set,
 an implementation SHOULD convert the value to the time zone indicated by the _option_.
 If such conversion is not supported, an implementation MAY alternatively


### PR DESCRIPTION
This is proposed as a separate change from #1077, as it was not discussed on the call.

The intent with the text updated here is to clarify what happens when the `timeZone` option is set on a date/time function.

The SHOULD/MAY language that's proposed is intended to allow for an implementation that does not support time zone conversions, which I believe matches the case in JS Temporal.

Is there prior art of `local` being used as a time zone value as we're proposing, or are there alternatives that other date/time formatters use?