### PR TITLE
Clarifications to 'Resolved Values' section

### DIFF
--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -156,7 +156,7 @@ and different implementations MAY choose to perform different levels of resoluti
 > interface MessageValue {
 >   formatToString(): string
 >   formatToX(): X // where X is an implementation-defined type
->   getResult(): unknown
+>   unwrap(): unknown
 >   resolvedOptions(): { [key: string]: MessageValue }
 >   selectKeys(keys: string[]): string[]
 >   directionality(): 'LTR' | 'RTL' | 'unknown'
@@ -172,21 +172,23 @@ and different implementations MAY choose to perform different levels of resoluti
 > - A _variable_ could be used as a _selector_ if
 >   calling the `selectKeys(keys)` method of its _resolved value_
 >   did not emit an error.
-> - Using a _variable_, the _resolved value_ of an _expression_
+> - The _resolved value_ of an _expression_
 >   could be used as an _operand_ or _option value_ if
->   calling the `getResult()` method of its _resolved value_ did not emit an error.
+>   calling the `unwrap()` method of its _resolved value_ did not emit an error.
+>   (This requires an intermediate _variable_ _declaration_.)
 >   In this use case, the `resolvedOptions()` method could also
 >   provide a set of option values that could be taken into account by the called function.
->   - In some cases (such as in a number formatting function), `getResult()` would
->     return the _operand_ of the function that returned the `MessageValue`. In other
->     cases (such as in a function that extracts a field from a data structure),
->     `getResult()` would return a different result than the _operand_.
+>   - The relationship between the _operand_ and the result of the `unwrap()` method
+>     is specific to each function. For example, with the built-in function `:number`,
+>     the `unwrap()` method would return the numeric value of the _operand_.
+>     In other cases, such as in a function that extracts a field from a data structure,
+>     `unwrap()` would return a different result than the _operand_.
 > - The `directionality()`, `isolate()`, and `isLiteralOptionValue()` methods
 >   fulfill requirements and recommendations mentioned elsewhere in this specification.
 >
 > Extensions of the base `MessageValue` interface could be provided for different data types,
 > such as numbers or strings,
-> for which the `unknown` return type of `getResult()` and
+> for which the `unknown` return type of `unwrap()` and
 > the generic `MessageValue` type used in `resolvedOptions()`
 > could be narrowed appropriately.
 > An implementation could also allow `MessageValue` values to be passed in as input variables,

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -180,7 +180,7 @@ and different implementations MAY choose to perform different levels of resoluti
 >   provide a set of option values that could be taken into account by the called function.
 >   - The `unwrap()` method returns the _function_-specific result
 >     of the _function_'s operation.
->     For example, the handlers for the following functions might
+>     For example, the handlers for the following _functions_ might
 >     behave as follows:
 >     - The handler for the _default function_ `:number` returns a value
 >       whose `unwrap()` method returns

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -182,7 +182,7 @@ and different implementations MAY choose to perform different levels of resoluti
 >     cases (such as in a function that extracts a field from a data structure),
 >     `getResult()` would return a different result than the _operand_.
 > - The `directionality()`, `isolate()`, and `isLiteralOptionValue()` methods
->   fulfill the requirements and recommendations mentioned earlier in this section.
+>   fulfill requirements and recommendations mentioned elsewhere in this specification.
 >
 > Extensions of the base `MessageValue` interface could be provided for different data types,
 > such as numbers or strings,

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -178,12 +178,21 @@ and different implementations MAY choose to perform different levels of resoluti
 >   (This requires an intermediate _variable_ _declaration_.)
 >   In this use case, the `resolvedOptions()` method could also
 >   provide a set of option values that could be taken into account by the called function.
->   - The relationship between the _operand_ and the result of the `unwrap()` method
->     is specific to each function. For example, with the built-in function `:number`,
->     the `unwrap()` method would return the numeric value of the _operand_.
->     In other cases, such as in a function that extracts a field from a data structure,
->     `unwrap()` would return the extracted value,
->     not the _operand_ it was extracted from.
+>   - The `unwrap()` method returns the _function_-specific result
+>     of the _function_'s operation.
+>     For example:
+>     - The _default function_ `:number` returns a value
+>       whose `unwrap()` method returns
+>       the implementation-defined numeric value of the _operand_.
+>     - A custom `:uppercase` function might return a value
+>       whose `unwrap()` method returns
+>       an uppercase string in place of the original _operand_ value.
+>     - A custom function that extracts a field from a data structure
+>       might return a value whose `unwrap()` method returns
+>       the extracted value.
+>     - Other functions might return a value
+>       whose `unwrap()` method returns
+>       the original _operand_ value.
 > - The `directionality()`, `isolate()`, and `isLiteralOptionValue()` methods
 >   fulfill requirements and recommendations mentioned elsewhere in this specification.
 >

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -182,7 +182,8 @@ and different implementations MAY choose to perform different levels of resoluti
 >     is specific to each function. For example, with the built-in function `:number`,
 >     the `unwrap()` method would return the numeric value of the _operand_.
 >     In other cases, such as in a function that extracts a field from a data structure,
->     `unwrap()` would return a different result than the _operand_.
+>     `unwrap()` would return the extracted value,
+>     not the _operand_ it was extracted from.
 > - The `directionality()`, `isolate()`, and `isLiteralOptionValue()` methods
 >   fulfill requirements and recommendations mentioned elsewhere in this specification.
 >

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -180,17 +180,18 @@ and different implementations MAY choose to perform different levels of resoluti
 >   provide a set of option values that could be taken into account by the called function.
 >   - The `unwrap()` method returns the _function_-specific result
 >     of the _function_'s operation.
->     For example:
->     - The _default function_ `:number` returns a value
+>     For example, the handlers for the following functions might
+>     behave as follows:
+>     - The handler for the _default function_ `:number` returns a value
 >       whose `unwrap()` method returns
 >       the implementation-defined numeric value of the _operand_.
->     - A custom `:uppercase` function might return a value
+>     - The handler for a custom `:uppercase` _function_ might return a value
 >       whose `unwrap()` method returns
 >       an uppercase string in place of the original _operand_ value.
->     - A custom function that extracts a field from a data structure
+>     - The handler for a custom _function_ that extracts a field from a data structure
 >       might return a value whose `unwrap()` method returns
 >       the extracted value.
->     - Other functions might return a value
+>     - Other _functions_' handlers might return a value
 >       whose `unwrap()` method returns
 >       the original _operand_ value.
 > - The `directionality()`, `isolate()`, and `isLiteralOptionValue()` methods

--- a/spec/formatting.md
+++ b/spec/formatting.md
@@ -136,10 +136,11 @@ of its formatted string representation,
 as well as a flag to indicate whether
 its formatted representation requires isolation
 from the surrounding text.
+(See ["Handling Bidirectional Text"](#handling-bidirectional-text).)
 
 For each _option value_, the _resolved value_ MUST indicate if the value
 was directly set with a _literal_, as opposed to being resolved from a _variable_.
-This is to allow _functions handlers_ to require specific _options_ to be set using _literals_.
+This is to allow _function handlers_ to require specific _options_ to be set using _literals_.
 
 > For example, the _default functions_ `:number` and `:integer` require that the _option_
 > `select` be set with a _literal_ _option value_ (`plural`, `ordinal`, or `exact`). 
@@ -155,7 +156,7 @@ and different implementations MAY choose to perform different levels of resoluti
 > interface MessageValue {
 >   formatToString(): string
 >   formatToX(): X // where X is an implementation-defined type
->   getValue(): unknown
+>   getResult(): unknown
 >   resolvedOptions(): { [key: string]: MessageValue }
 >   selectKeys(keys: string[]): string[]
 >   directionality(): 'LTR' | 'RTL' | 'unknown'
@@ -173,13 +174,19 @@ and different implementations MAY choose to perform different levels of resoluti
 >   did not emit an error.
 > - Using a _variable_, the _resolved value_ of an _expression_
 >   could be used as an _operand_ or _option value_ if
->   calling the `getValue()` method of its _resolved value_ did not emit an error.
+>   calling the `getResult()` method of its _resolved value_ did not emit an error.
 >   In this use case, the `resolvedOptions()` method could also
 >   provide a set of option values that could be taken into account by the called function.
+>   - In some cases (such as in a number formatting function), `getResult()` would
+>     return the _operand_ of the function that returned the `MessageValue`. In other
+>     cases (such as in a function that extracts a field from a data structure),
+>     `getResult()` would return a different result than the _operand_.
+> - The `directionality()`, `isolate()`, and `isLiteralOptionValue()` methods
+>   fulfill the requirements and recommendations mentioned earlier in this section.
 >
 > Extensions of the base `MessageValue` interface could be provided for different data types,
 > such as numbers or strings,
-> for which the `unknown` return type of `getValue()` and
+> for which the `unknown` return type of `getResult()` and
 > the generic `MessageValue` type used in `resolvedOptions()`
 > could be narrowed appropriately.
 > An implementation could also allow `MessageValue` values to be passed in as input variables,


### PR DESCRIPTION
I was re-reading the `MessageValue` example and noticed that it's easy to skip over what the last three methods are for, so I added a reference to the earlier text.

I also thought that the `getValue()` method could have another name, since it's confusing to think about the "value" that it returns, vs. the enclosing `MessageValue`. The name I thought of was `getResult()`, but I'm open to other suggestions. I also thought it needed a little more explanation.