### PR TITLE
Mark dataflow-composability design doc as obsolete

### DIFF
--- a/exploration/README.md
+++ b/exploration/README.md
@@ -3,7 +3,7 @@
 
 This folder contains design documents used by the MessageFormat Working Group
 as part of the development process for MFv2.
-Designs can be "accepted", "proposed", or "rejected". 
+Designs can be "accepted", "proposed", "rejected", or "obsolete".
 These documents are not a normative part of the specification.
 They might be helpful to users seeking to understand specific design decisions
 taken by the working group,

--- a/exploration/dataflow-composability.md
+++ b/exploration/dataflow-composability.md
@@ -1,6 +1,6 @@
 # Data Flow for Composable Functions
 
-Status: **Proposed**
+Status: **Obsolete**
 
 <details>
 	<summary>Metadata</summary>


### PR DESCRIPTION
Per #1090, mark the doc as obsolete and add "obsolete" to the README as a possible status.