### PR TITLE
Add first draft of default attribute definitions

### DIFF
--- a/spec/attributes/README.md
+++ b/spec/attributes/README.md
@@ -18,7 +18,7 @@ this SHOULD be provided for by a resource container for Unicode MessageFormat me
 
 As all _attributes_ with _reserved identifiers_ are reserved,
 definitions are provided here for common _attribute_ use cases.
-Custom _attributes_ SHOULD use a _custom identifier_,
+Use a _custom identifier_ for other (custom) _attributes_,
 preferably one with an appropriate _namespace_.
 
 ### Attribute Values

--- a/spec/attributes/README.md
+++ b/spec/attributes/README.md
@@ -6,9 +6,11 @@
 
 The Unicode MessageFormat syntax and data model allow for _attributes_
 to be defined on _expressions_ and _markup_.
-These are REQUIRED to have no impact on the formatting of a message,
-and are intended to be useful in informing translators and translator tooling
+These MUST NOT have any impact on the formatting of a message,
+and are intended to inform users, such as translators, and tools
 about the specific _expressions_ or _markup_ to which they are attached.
+_Attributes_ MAY be stripped from _expressions_ and _markup_
+with no effect on the message's formatting.
 
 While the specification does not define how an _attribute_ could be attached
 to the _message_ as a whole,
@@ -168,7 +170,6 @@ Should be accompanied by an explanatory `@comment`.
 
 _Value:_ A strictly positive integer, followed by a space, followed by one of the following:
 - `chars`
-- `bytes`
 - `lines`
 
 Limits the length of a _message_.
@@ -195,7 +196,7 @@ _Value_: **TBD**
 Documents a _variable_.
 
 > [!NOTE]
-> Having a well-defined structure for this tag is pretty important,
+> Having a well-defined structure for this attribute is pretty important,
 > at least to identify the variable its description is pertaining to.
 > In addition to describing the variable in words, it could include:
 > - The variable's type -- is it a string, a number, something else?

--- a/spec/attributes/README.md
+++ b/spec/attributes/README.md
@@ -1,25 +1,28 @@
 ## Expression, Markup, and Message Attributes
 
 > [!IMPORTANT]
-> This part of the specification is under active development,
-> and is non-normative.
+> This part of the specification is under incubation by the MessageFormat WG,
+> and may end up being finalized elsewhere.
+> It is non-normative.
 
-The Unicode MessageFormat syntax and data model allow for _attributes_
-to be defined on _expressions_ and _markup_.
-These MUST NOT have any impact on the formatting of a message,
-and are intended to inform users, such as translators, and tools
-about the specific _expressions_ or _markup_ to which they are attached.
-_Attributes_ MAY be stripped from _expressions_ and _markup_
-with no effect on the message's formatting.
+### Expression and Markup Attributes
 
-While the specification does not define how an _attribute_ could be attached
-to the _message_ as a whole,
-this SHOULD be provided for by a resource container for Unicode MessageFormat messages.
+- [@can-copy](expression-and-markup.md#can-copy)
+- [@can-delete](expression-and-markup.md#can-delete)
+- [@can-overlap](expression-and-markup.md#can-overlap) (Markup only)
+- [@can-reorder](expression-and-markup.md#can-reorder) (Markup only)
+- [@comment](expression-and-markup.md#comment)
+- [@example](expression-and-markup.md#example) (Expression only)
+- [@term](expression-and-markup.md#term)
+- [@translate](mexpression-and-markup.md#translate)
 
-As all _attributes_ with _reserved identifiers_ are reserved,
-definitions are provided here for common _attribute_ use cases.
-Use a _custom identifier_ for other (custom) _attributes_,
-preferably one with an appropriate _namespace_.
+### Message Attributes
+
+- [@allow-empty](message.md#allow-empty)
+- [@obsolete](message.md#obsolete)
+- [@param](message.md#param)
+- [@schema](message.md#schema)
+- [@translate](message.md#translate)
 
 ### Attribute Values
 
@@ -27,207 +30,3 @@ _Attributes_ are not required to have a value.
 For _attributes_ defined here that explicitly support `yes` as a value,
 an _attribute_ with no value is considered synonymous
 with the same _attribute_ with the value `yes`.
-
-### Expression Attributes
-
-#### @comment
-
-_Value_: A non-empty string.
-
-Associates a freeform comment with the _expression_.
-
-> For example:
->
-> ```
-> The {$device @comment=|Possible values: Printer or Stacker|} has been enabled.
-> ```
-
-#### @example
-
-_Value_: A non-empty string.
-
-An example of the value the _expression_ might take.
-
-> For example:
->
-> ```
-> Error: {$details @example=|Failed to fetch RSS feed.|}
-> ```
-
-#### @term
-
-_Value_: A non-empty string, or a URI.
-
-Identifies a well-defined term.
-The value may be a short definition of the term,
-or a URI pointing to such a definition.
-
-> For example:
->
-> ```
-> He saw his {|doppelgänger| @term=|https://en.wikipedia.org/wiki/Doppelg%C3%A4nger|}.
-> ```
-
-#### @translate
-
-_Value:_ `yes` or `no`.
-
-Indicates whether the _expression_ is translatable or not.
-
-> For example:
->
-> ```
-> He saw his {|doppelgänger| @translate=no}.
-> ```
-
-### Markup Attributes
-
-#### @can-copy
-
-_Value:_ `yes` or `no`.
-
-Indicates whether or not the _markup_ and its contents can be copied.
-
-> For example:
->
-> ```
-> Have a {#span @can-copy}great and wonderful{/span @can-copy} birthday!
-> ```
-
-#### @can-delete
-
-_Value:_ `yes` or `no`.
-
-Indicates whether or not the _markup_ and its contents can be deleted.
-
-#### @can-overlap
-
-_Value:_ `yes` or `no`.
-
-Indicates whether or not the _markup_ and its contents where this _attribute_ is used
-can enclose partial _markup_
-(i.e. a _markup-open_ without its corresponding _markup-end_,
-or a _markup-end_ without its corresponding _markup-start_).
-
-#### #can-reorder
-
-_Value:_ `yes` or `no`.
-
-Indicates whether or not the _markup_ and its contents can be re-ordered.
-
-#### @comment
-
-_Value_: A non-empty string.
-
-Associates a freeform comment with the _markup_.
-
-> For example:
->
-> ```
-> Click {#link @comment=|Rendered as a button|}here{/link} to continue.
-> ```
-
-#### @term
-
-_Value_: A non-empty string, or a URI.
-
-Identifies a well-defined term.
-The value may be a short definition of the term,
-or a URI pointing to such a definition.
-
-> For example:
->
-> ```
-> He saw his {#span @term=|https://en.wikipedia.org/wiki/Doppelg%C3%A4nger|}doppelgänger{/span}.
-> ```
-
-#### @translate
-
-_Value:_ `yes` or `no`.
-
-Indicates whether the _markup_ and its contents are translatable or not.
-
-> For example:
->
-> ```
-> He saw his {#span @translate=no}doppelgänger{/span}.
-> ```
-
-### Message Attributes
-
-#### @allow-empty
-
-_Value:_ `yes` or `no`.
-
-Explicitly mark a message with an empty _pattern_ as valid.
-
-Most empty messages are mistakes,
-so being able to mark ones that can be empty is useful.
-
-Empty _messages_ SHOULD be accompanied by an explanatory `@comment`.
-
-#### @max-length
-
-_Value:_ A strictly positive integer, followed by a space, followed by one of the following:
-- `chars`
-- `lines`
-
-Limits the length of a _message_.
-
-#### @obsolete
-
-_Value:_ `yes` or `no`.
-
-Explicitly mark a _message_ as obsolete.
-
-This might be used in workflows where messages are not immediately removed
-when they are no longer referenced by code,
-but kept in to support patch releases for previous versions.
-During translation, this can be used to de-prioritize such messages.
-
-> [!NOTE]
-> The value could include a way to note some version or timestamp when the removal happened,
-> or be paired with a second `@removed-in` or similar tag.
-
-#### @param
-
-_Value_: **TBD**
-
-Documents a _variable_.
-
-> [!NOTE]
-> Having a well-defined structure for this attribute is pretty important,
-> at least to identify the variable its description is pertaining to.
-> In addition to describing the variable in words, it could include:
-> - The variable's type -- is it a string, a number, something else?
-> - A default example value to use for the variable.
-
-#### @schema
-
-_Value:_ A valid URI.
-
-Identify the _functions_ and _markup_ supported by the _message_ formatter.
-
-#### @source
-
-_Value_: A string.
-
-Provides the _message_ in its source locale.
-
-#### @translate
-
-_Value:_ `yes` or `no`
-
-Indicates whether the _message_ is translatable or not.
-
-Some _messages_ may be required to have the same value in all locales.
-
-#### @version
-
-_Value_: A string.
-
-Explicitly versions a source string.
-
-This allows for differentiating typo fixes from actual changes in message contents.
-The (message id, version) tuple can be used by tooling instead of just the message id
-to uniquely identify a message and its translations.

--- a/spec/attributes/README.md
+++ b/spec/attributes/README.md
@@ -164,7 +164,7 @@ Explicitly mark a message with an empty _pattern_ as valid.
 Most empty messages are mistakes,
 so being able to mark ones that can be empty is useful.
 
-Should be accompanied by an explanatory `@comment`.
+Empty _messages_ SHOULD be accompanied by an explanatory `@comment`.
 
 #### @max-length
 

--- a/spec/attributes/README.md
+++ b/spec/attributes/README.md
@@ -1,0 +1,232 @@
+## Expression, Markup, and Message Attributes
+
+> [!IMPORTANT]
+> This part of the specification is under active development,
+> and is non-normative.
+
+The Unicode MessageFormat syntax and data model allow for _attributes_
+to be defined on _expressions_ and _markup_.
+These are REQUIRED to have no impact on the formatting of a message,
+and are intended to be useful in informing translators and translator tooling
+about the specific _expressions_ or _markup_ to which they are attached.
+
+While the specification does not define how an _attribute_ could be attached
+to the _message_ as a whole,
+this SHOULD be provided for by a resource container for Unicode MessageFormat messages.
+
+As all _attributes_ with _reserved identifiers_ are reserved,
+definitions are provided here for common _attribute_ use cases.
+Custom _attributes_ SHOULD use a _custom identifier_,
+preferably one with an appropriate _namespace_.
+
+### Attribute Values
+
+_Attributes_ are not required to have a value.
+For _attributes_ defined here that explicitly support `yes` as a value,
+an _attribute_ with no value is considered synonymous
+with the same _attribute_ with the value `yes`.
+
+### Expression Attributes
+
+#### @comment
+
+_Value_: A non-empty string.
+
+Associates a freeform comment with the _expression_.
+
+> For example:
+>
+> ```
+> The {$device @comment=|Possible values: Printer or Stacker|} has been enabled.
+> ```
+
+#### @example
+
+_Value_: A non-empty string.
+
+An example of the value the _expression_ might take.
+
+> For example:
+>
+> ```
+> Error: {$details @example=|Failed to fetch RSS feed.|}
+> ```
+
+#### @term
+
+_Value_: A non-empty string, or a URI.
+
+Identifies a well-defined term.
+The value may be a short definition of the term,
+or a URI pointing to such a definition.
+
+> For example:
+>
+> ```
+> He saw his {|doppelgänger| @term=|https://en.wikipedia.org/wiki/Doppelg%C3%A4nger|}.
+> ```
+
+#### @translate
+
+_Value:_ `yes` or `no`.
+
+Indicates whether the _expression_ is translatable or not.
+
+> For example:
+>
+> ```
+> He saw his {|doppelgänger| @translate=no}.
+> ```
+
+### Markup Attributes
+
+#### @can-copy
+
+_Value:_ `yes` or `no`.
+
+Indicates whether or not the _markup_ and its contents can be copied.
+
+> For example:
+>
+> ```
+> Have a {#span @can-copy}great and wonderful{/span @can-copy} birthday!
+> ```
+
+#### @can-delete
+
+_Value:_ `yes` or `no`.
+
+Indicates whether or not the _markup_ and its contents can be deleted.
+
+#### @can-overlap
+
+_Value:_ `yes` or `no`.
+
+Indicates whether or not the _markup_ and its contents where this _attribute_ is used
+can enclose partial _markup_
+(i.e. a _markup-open_ without its corresponding _markup-end_,
+or a _markup-end_ without its corresponding _markup-start_).
+
+#### #can-reorder
+
+_Value:_ `yes` or `no`.
+
+Indicates whether or not the _markup_ and its contents can be re-ordered.
+
+#### @comment
+
+_Value_: A non-empty string.
+
+Associates a freeform comment with the _markup_.
+
+> For example:
+>
+> ```
+> Click {#link @comment=|Rendered as a button|}here{/link} to continue.
+> ```
+
+#### @term
+
+_Value_: A non-empty string, or a URI.
+
+Identifies a well-defined term.
+The value may be a short definition of the term,
+or a URI pointing to such a definition.
+
+> For example:
+>
+> ```
+> He saw his {#span @term=|https://en.wikipedia.org/wiki/Doppelg%C3%A4nger|}doppelgänger{/span}.
+> ```
+
+#### @translate
+
+_Value:_ `yes` or `no`.
+
+Indicates whether the _markup_ and its contents are translatable or not.
+
+> For example:
+>
+> ```
+> He saw his {#span @translate=no}doppelgänger{/span}.
+> ```
+
+### Message Attributes
+
+#### @allow-empty
+
+_Value:_ `yes` or `no`.
+
+Explicitly mark a message with an empty _pattern_ as valid.
+
+Most empty messages are mistakes,
+so being able to mark ones that can be empty is useful.
+
+Should be accompanied by an explanatory `@comment`.
+
+#### @max-length
+
+_Value:_ A strictly positive integer, followed by a space, followed by one of the following:
+- `chars`
+- `bytes`
+- `lines`
+
+Limits the length of a _message_.
+
+#### @obsolete
+
+_Value:_ `yes` or `no`.
+
+Explicitly mark a _message_ as obsolete.
+
+This might be used in workflows where messages are not immediately removed
+when they are no longer referenced by code,
+but kept in to support patch releases for previous versions.
+During translation, this can be used to de-prioritize such messages.
+
+> [!NOTE]
+> The value could include a way to note some version or timestamp when the removal happened,
+> or be paired with a second `@removed-in` or similar tag.
+
+#### @param
+
+_Value_: **TBD**
+
+Documents a _variable_.
+
+> [!NOTE]
+> Having a well-defined structure for this tag is pretty important,
+> at least to identify the variable its description is pertaining to.
+> In addition to describing the variable in words, it could include:
+> - The variable's type -- is it a string, a number, something else?
+> - A default example value to use for the variable.
+
+#### @schema
+
+_Value:_ A valid URI.
+
+Identify the _functions_ and _markup_ supported by the _message_ formatter.
+
+#### @source
+
+_Value_: A string.
+
+Provides the _message_ in its source locale.
+
+#### @translate
+
+_Value:_ `yes` or `no`
+
+Indicates whether the _message_ is translatable or not.
+
+Some _messages_ may be required to have the same value in all locales.
+
+#### @version
+
+_Value_: A string.
+
+Explicitly versions a source string.
+
+This allows for differentiating typo fixes from actual changes in message contents.
+The (message id, version) tuple can be used by tooling instead of just the message id
+to uniquely identify a message and its translations.

--- a/spec/attributes/expression-and-markup.md
+++ b/spec/attributes/expression-and-markup.md
@@ -7,11 +7,11 @@
 
 The Unicode MessageFormat syntax and data model allow for _attributes_
 to be defined on _expressions_ and _markup_.
-These MUST NOT have any impact on the formatting of a message,
+These MUST NOT have any impact on the _formatting_ of a message,
 and are intended to inform users, such as translators, and tools
 about the specific _expressions_ or _markup_ to which they are attached.
 _Attributes_ MAY be stripped from _expressions_ and _markup_
-with no effect on the message's formatting.
+with no effect on the message's _formatting_.
 
 As all _attributes_ with _reserved identifiers_ are reserved,
 definitions are provided here for common _attribute_ use cases.

--- a/spec/attributes/expression-and-markup.md
+++ b/spec/attributes/expression-and-markup.md
@@ -24,6 +24,9 @@ _Value:_ `yes` or `no`.
 
 Indicates whether or not the _expression_ or the _markup_ and its contents can be copied.
 
+This corresponds to
+the [XLIFF 2 `canCopy` attribute](https://docs.oasis-open.org/xliff/xliff-core/v2.2/xliff-core-v2.2-part1.html#cancopy).
+
 > For example:
 >
 > ```
@@ -36,6 +39,9 @@ _Value:_ `yes` or `no`.
 
 Indicates whether or not the _expression_ or the _markup_ and its contents can be deleted.
 
+This corresponds to
+the [XLIFF 2 `canDelete` attribute](https://docs.oasis-open.org/xliff/xliff-core/v2.2/xliff-core-v2.2-part1.html#candelete).
+
 ### @can-overlap (Markup only)
 
 _Value:_ `yes` or `no`.
@@ -45,17 +51,27 @@ can enclose partial _markup_
 (i.e. a _markup-open_ without its corresponding _markup-end_,
 or a _markup-end_ without its corresponding _markup-start_).
 
+This corresponds to
+the [XLIFF 2 `canOverlap` attribute](https://docs.oasis-open.org/xliff/xliff-core/v2.2/xliff-core-v2.2-part1.html#canoverlap).
+
 ### @can-reorder (Markup only)
 
 _Value:_ `yes` or `no`.
 
 Indicates whether or not the _markup_ and its contents can be re-ordered.
 
+This corresponds to
+the [XLIFF 2 `canReorder` attribute](https://docs.oasis-open.org/xliff/xliff-core/v2.2/xliff-core-v2.2-part1.html#canreorder).
+
 ### @comment
 
 _Value_: A non-empty string.
 
 Associates a freeform comment with an _expression_ or _markup_.
+
+This corresponds to
+the [ITS 2 Localization Note data category](https://www.w3.org/TR/its20/#locNote-datacat), and
+the [XLIFF 2 comment annotation](https://docs.oasis-open.org/xliff/xliff-core/v2.2/xliff-core-v2.2-part1.html#commentAnnotation).
 
 > For example:
 >
@@ -87,6 +103,10 @@ Identifies a well-defined term.
 The value may be a short definition of the term,
 or a URI pointing to such a definition.
 
+This corresponds to
+the [ITS 2 Terminology data category](https://www.w3.org/TR/its20/#terminology), and
+the [XLIFF 2 term annotation](https://docs.oasis-open.org/xliff/xliff-core/v2.2/xliff-core-v2.2-part1.html#termAnnotation).
+
 > For example:
 >
 > ```
@@ -102,6 +122,11 @@ or a URI pointing to such a definition.
 _Value:_ `yes` or `no`.
 
 Indicates whether the _expression_ or the _markup_ and its contents are translatable or not.
+
+This corresponds to
+the [HTML `translate` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate),
+the [ITS 2 Translate data category](https://www.w3.org/TR/its20/#trans-datacat), and
+the [XLIFF 2 translate annotation](https://docs.oasis-open.org/xliff/xliff-core/v2.2/xliff-core-v2.2-part1.html#translateAnnotation).
 
 > For example:
 >

--- a/spec/attributes/expression-and-markup.md
+++ b/spec/attributes/expression-and-markup.md
@@ -1,0 +1,114 @@
+## Expression and Markup Attributes
+
+> [!IMPORTANT]
+> This part of the specification is under incubation by the MessageFormat WG,
+> and may end up being finalized elsewhere.
+> It is non-normative.
+
+The Unicode MessageFormat syntax and data model allow for _attributes_
+to be defined on _expressions_ and _markup_.
+These MUST NOT have any impact on the formatting of a message,
+and are intended to inform users, such as translators, and tools
+about the specific _expressions_ or _markup_ to which they are attached.
+_Attributes_ MAY be stripped from _expressions_ and _markup_
+with no effect on the message's formatting.
+
+As all _attributes_ with _reserved identifiers_ are reserved,
+definitions are provided here for common _attribute_ use cases.
+Use a _custom identifier_ for other (custom) _attributes_,
+preferably one with an appropriate _namespace_.
+
+### @can-copy
+
+_Value:_ `yes` or `no`.
+
+Indicates whether or not the _expression_ or the _markup_ and its contents can be copied.
+
+> For example:
+>
+> ```
+> Have a {#span @can-copy}great and wonderful{/span @can-copy} birthday!
+> ```
+
+### @can-delete
+
+_Value:_ `yes` or `no`.
+
+Indicates whether or not the _expression_ or the _markup_ and its contents can be deleted.
+
+### @can-overlap (Markup only)
+
+_Value:_ `yes` or `no`.
+
+Indicates whether or not the _markup_ and its contents where this _attribute_ is used
+can enclose partial _markup_
+(i.e. a _markup-open_ without its corresponding _markup-end_,
+or a _markup-end_ without its corresponding _markup-start_).
+
+### @can-reorder (Markup only)
+
+_Value:_ `yes` or `no`.
+
+Indicates whether or not the _markup_ and its contents can be re-ordered.
+
+### @comment
+
+_Value_: A non-empty string.
+
+Associates a freeform comment with an _expression_ or _markup_.
+
+> For example:
+>
+> ```
+> The {$device @comment=|Possible values: Printer or Stacker|} has been enabled.
+> ```
+>
+> ```
+> Click {#link @comment=|Rendered as a button|}here{/link} to continue.
+> ```
+
+### @example (Expression only)
+
+_Value_: A non-empty string.
+
+An example of the value the _expression_ might take.
+
+> For example:
+>
+> ```
+> Error: {$details @example=|Failed to fetch RSS feed.|}
+> ```
+
+### @term
+
+_Value_: A non-empty string, or a URI.
+
+Identifies a well-defined term.
+The value may be a short definition of the term,
+or a URI pointing to such a definition.
+
+> For example:
+>
+> ```
+> He saw his {|doppelgänger| @term=|https://en.wikipedia.org/wiki/Doppelg%C3%A4nger|}.
+> ```
+>
+> ```
+> He saw his {#span @term=|https://en.wikipedia.org/wiki/Doppelg%C3%A4nger|}doppelgänger{/span}.
+> ```
+
+### @translate
+
+_Value:_ `yes` or `no`.
+
+Indicates whether the _expression_ or the _markup_ and its contents are translatable or not.
+
+> For example:
+>
+> ```
+> He saw his {|doppelgänger| @translate=no}.
+> ```
+>
+> ```
+> He saw his {#span @translate=no}doppelgänger{/span}.
+> ```

--- a/spec/attributes/message.md
+++ b/spec/attributes/message.md
@@ -1,0 +1,67 @@
+## Message Attributes
+
+> [!IMPORTANT]
+> This part of the specification is under incubation by the MessageFormat WG,
+> and may end up being finalized elsewhere.
+> It is non-normative.
+
+This specification does not define a means of attaching an _attribute_
+to the _message_ as a whole.
+In general, resource formats and containers of
+Unicode MessageFormat _messages_ provide their own such mechanisms.
+
+At least for now, the syntax of message attributes is
+outside the scope of this specification.
+
+### @allow-empty
+
+_Value:_ `yes` or `no`.
+
+Explicitly mark a message with an empty _pattern_ as valid.
+
+Most empty messages are mistakes,
+so being able to mark ones that can be empty is useful.
+
+Empty _messages_ SHOULD be accompanied by an explanatory `@comment`.
+
+### @obsolete
+
+_Value:_ `yes` or `no`.
+
+Explicitly mark a _message_ as obsolete.
+
+This might be used in workflows where messages are not immediately removed
+when they are no longer referenced by code,
+but kept in to support patch releases for previous versions.
+During translation, this can be used to de-prioritize such messages.
+
+> [!NOTE]
+> The value could include a way to note some version or timestamp when the removal happened,
+> or be paired with a second `@removed-in` or similar tag.
+
+### @param
+
+_Value_: **TBD**
+
+Documents a _variable_.
+
+> [!NOTE]
+> Having a well-defined structure for this attribute is pretty important,
+> at least to identify the variable its description is pertaining to.
+> In addition to describing the variable in words, it could include:
+> - The variable's type -- is it a string, a number, something else?
+> - A default example value to use for the variable.
+
+### @schema
+
+_Value:_ A valid URI.
+
+Identify the _functions_ and _markup_ supported by the _message_ formatter.
+
+### @translate
+
+_Value:_ `yes` or `no`
+
+Indicates whether the _message_ is translatable or not.
+
+Some _messages_ may be required to have the same value in all locales.


### PR DESCRIPTION
Adds an initial set of expression, markup, and message attribute definitions.

The proposed attributes are drawn from:
- [XLIFF 2.2](https://docs.oasis-open.org/xliff/xliff-core/v2.2/xliff-core-v2.2-part1.html)
- The messages.json web extension definition for [placeholders.example](https://developer.chrome.com/docs/extensions/how-to/ui/localization-message-formats#placeholders)
- https://github.com/eemeli/message-resource-wg/issues/19

As noted in the text, this is not intended as a final list, but as a starting point. The text is not being currently proposed to be normative, but we could change that later.