### PR TITLE
Finalize :percent

### DIFF
--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -415,10 +415,6 @@ together with the resolved options' values.
 
 #### The `:percent` function
 
-> [!IMPORTANT]
-> The _function_ `:percent` has a status of **Draft**.
-> It is proposed for inclusion in a future release of this specification and is not Stable.
-
 The function `:percent` is a selector and formatter for percent values.
 
 ##### `:percent` Operands


### PR DESCRIPTION
The PR (#1094) adding `:percent` landed on 2025-08-11, and I'm not aware of any extant concerns about it.

I recommend therefore that we call it final and stable.