### PR TITLE
Specify well-formed values for timezones, calendars & units

### DIFF
--- a/spec/functions/datetime.md
+++ b/spec/functions/datetime.md
@@ -256,12 +256,11 @@ The following _option_ is REQUIRED to be available on
 the functions `:datetime`, `:date`, and `:time`.
 
 - `timeZone`
-  - A valid time zone identifier
-    (see [TZDB](https://www.iana.org/time-zones)
-    and [LDML](https://www.unicode.org/reports/tr35/tr35-dates.html#Time_Zone_Names)
-    for information on identifiers)
   - `input`
-  - `UTC`
+  - A well-formed time zone identifier matching the `time-zone-name` rule of
+    [RFC 9557](https://www.rfc-editor.org/rfc/rfc9557#name-abnf).
+  - A well-formed UTC offset matching the `time-numoffset` rule of
+    [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6).
 
 The default value for `timeZone` is the default time zone provided by the _formatting context_.
 
@@ -269,12 +268,18 @@ The value `input` corresponds to the time zone of the _operand_.
 If it is used and the _resolved value_ of the _operand_ does not include a time zone or offset,
 a _Bad Operand_ error is emitted and the default time zone is used to format the _expression_.
 
+If the _resolved value_ of the _operand_ does not include a time zone or offset,
+the _resolved value_ of the `timeZone` _option_ is used as its time zone.
+
 If the _resolved value_ of the _operand_ includes a time zone or offset,
 and the _resolved value_ of the `timeZone` _option_ is different from that,
 an implementation SHOULD convert the _resolved value_ of the _operand_
 to the time zone indicated by the _resolved value_ of the `timeZone` _option_.
 If such conversion is not supported, an implementation MAY alternatively
 emit a _Bad Option_ error and use a _fallback value_ as the _resolved value_ of the _expression_.
+
+> [!NOTE]
+> A date/time type encapsulating a Unix time is considered to include UTC as its time zone.
 
 The following _option_ is REQUIRED to be available on
 the functions `:datetime` and `:time`:
@@ -287,4 +292,5 @@ The following _option_ is RECOMMENDED to be available on
 the functions `:datetime`, `:date`, and `:time`.
 
 - `calendar`
-  - valid [Unicode Calendar Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeCalendarIdentifier)
+  - A well-formed [Unicode Calendar Identifier](https://unicode.org/reports/tr35/tr35.html#UnicodeCalendarIdentifier),
+    i.e. a [uvalue](https://unicode.org/reports/tr35/tr35.html#uvalue).

--- a/spec/functions/datetime.md
+++ b/spec/functions/datetime.md
@@ -257,6 +257,7 @@ the functions `:datetime`, `:date`, and `:time`.
 
 - `timeZone`
   - `input`
+  - `UTC`
   - A well-formed time zone identifier matching the `time-zone-name` rule of
     [RFC 9557](https://www.rfc-editor.org/rfc/rfc9557#name-abnf).
   - An offset from UTC matching the `time-numoffset` rule of
@@ -279,7 +280,7 @@ If such conversion is not supported, an implementation MAY alternatively
 emit a _Bad Option_ error and use a _fallback value_ as the _resolved value_ of the _expression_.
 
 > [!NOTE]
-> A date/time type encapsulating a Unix time is considered to include UTC as its time zone.
+> A date/time type that represents a numeric offset from some epoch (such as a "Unix timestamp") is considered to include UTC as its time zone.
 
 The following _option_ is REQUIRED to be available on
 the functions `:datetime` and `:time`:

--- a/spec/functions/datetime.md
+++ b/spec/functions/datetime.md
@@ -259,7 +259,7 @@ the functions `:datetime`, `:date`, and `:time`.
   - `input`
   - A well-formed time zone identifier matching the `time-zone-name` rule of
     [RFC 9557](https://www.rfc-editor.org/rfc/rfc9557#name-abnf).
-  - A well-formed UTC offset matching the `time-numoffset` rule of
+  - An offset from UTC matching the `time-numoffset` rule of
     [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6).
 
 The default value for `timeZone` is the default time zone provided by the _formatting context_.

--- a/spec/functions/number.md
+++ b/spec/functions/number.md
@@ -542,7 +542,7 @@ or it can be a _numeric operand_, as long as the _option_
 `unit` is provided.
 
 Valid values of the _operand_'s `unit` are either a string containing a
-valid [Unit Identifier](https://www.unicode.org/reports/tr35/tr35-general.html#unit-identifiers)
+well-formed [Unicode Unit Identifier](https://unicode.org/reports/tr35/tr35-general.html#unit-syntax)
 or an implementation-defined unit type.
 
 A _numeric operand_ without a `unit` _option_ results in a _Bad Operand_ error.
@@ -579,10 +579,10 @@ The following _options_ are REQUIRED to be available on the function `:unit`,
 unless otherwise indicated:
 
 - `unit`
-  - valid [Unit Identifier](https://www.unicode.org/reports/tr35/tr35-general.html#unit-identifiers)
+  - A well-formed [Unicode Unit Identifier](https://unicode.org/reports/tr35/tr35-general.html#unit-syntax)
     (no default)
 - `usage` \[RECOMMENDED\]
-  - valid [Unicode Unit Preference](https://www.unicode.org/reports/tr35/tr35-info.html#unit-preferences)
+  - A well-formed [Unicode Unit Usage](https://www.unicode.org/reports/tr35/tr35-info.html#unit-preferences)
     (no default, see [Unit Conversion](#unit-conversion) below)
 - `unitDisplay`
   - `short` (default)
@@ -656,8 +656,8 @@ Implementing this _option_ is optional.
 Not all `usage` _option values_ are compatible with a given unit.
 Implementations SHOULD emit an _Unsupported Operation_ error if the requested conversion is not supported.
 
-> For example, trying to convert a `length` unit (such as "meters")
-> to a `volume` usage (which might be a unit akin to "liters" or "gallons", depending on the locale)
+> For example, trying to convert a `length` unit (such as "meter")
+> to a `volume` usage (which might be a unit akin to "liter" or "gallon", depending on the locale)
 > could produce an _Unsupported Operation_ error.
 
 Implementations MUST NOT substitute the unit without performing the associated conversion.


### PR DESCRIPTION
Closes #935
Closes #936
See also https://github.com/unicode-org/message-format-wg/issues/961#issuecomment-3109611039
Closes #962

As resolved on this week's call, the options for which we accept values defined elsewhere should all be spec'd as "well-formed" rather than "valid". As we do not mandate that all well-formed values are accepted without error, or that the errors emitted for "not well-formed" and "not valid" are different from each other, this allows for a linter/validator to detect not-well-formed values early, while not requiring a formatting implementation to differentiate well-formed-but-not-valid from not-well-formed values.

While the spec text does not make mention of Unicode short time zone identifiers, it should be noted that all such values are technically well-formed time zone identifiers according to RFC 9557. This means that an implementation _could_ support such values, but they would probably not work in all implementations. If we'd like to discourage this, I think including a non-normative note to that effect might be appropriate (suggestions for exact text are most welcome).

This PR also addresses https://github.com/unicode-org/message-format-wg/issues/961#issuecomment-3109611039 by defining the behaviour when formatting date/time values that do not include a time zone.