### PR TITLE
Implementations SHOULD provide mechanisms for users to use user-defined function handlers for default functions

### DIFF
--- a/spec/functions/README.md
+++ b/spec/functions/README.md
@@ -49,6 +49,8 @@ In addition, implementations SHOULD provide mechanisms for users to
 register and use user-defined _functions_ and their associated _function handlers_.
 Functions not defined by any version of this specification SHOULD use 
 an implementation-defined or user-defined _namespace_.
+Implementations SHOULD provide mechanisms for users to
+use user-defined _function handlers_ for _default functions_.
 
 Implementations MAY implement additional _options_ not defined
 by any version of this specification for _default functions_.


### PR DESCRIPTION
As reported by Matt O'Conor on Slack:

> Hello my fellow message-format friends!
>
> we're trying to decouple the formatting locale from the selection locale in our MF2 wrapper. We want en-US number formatting but locale-correct plural selection (Russian few/many, etc.). We tried setting the MessageFormatter locale to the message locale and registering custom en-US-pinned formatters for :number/:integer via `setFunctionRegistry()`. But `lookupFormatterFactory()` in ICU 78 checks the standard registry before the custom one, so built-in formatters always win and ours are never reached.
>
> Is there a recommended way to override a built-in formatter while keeping the built-in selector? Or a different pattern for "format in locale A, select in locale B"
>
> Let me know! Thanks

And my reply:

> Filing a bug in the ICU issue tracker does seem appropriate for this, as overriding the default :number and :integer functions should be possible. We don't have explicit spec language to ensure that, but I'll submit a spec PR shortly to that effect.

This PR adds a new normative SHOULD to help avoid this problem recurring, as it should be possible to override default function handlers.