### PR TITLE
Add test that :string can be used as a formatter

### DIFF
--- a/test/tests/functions/string.json
+++ b/test/tests/functions/string.json
@@ -47,6 +47,10 @@
       ]
     },
     {
+      "src": ".local $x = {foo} {{{$x :string} bar}}",
+      "exp": "foo bar"
+    },
+    {
       "description": "NFC: keys are normalized (unquoted)",
       "src": ".local $x = {\u1E0A\u0323 :string} .match $x \u1E0A\u0323 {{Not normalized}} \u1E0C\u0307 {{Normalized}} * {{Wrong}}",
       "expErrors": [{"type": "duplicate-variant"}]


### PR DESCRIPTION
All the previous tests only test :string as a selector.